### PR TITLE
REL-3349: PIT visitor instrument changes.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -8,7 +8,7 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
   var title = "Select Instrument"
   var description = s"The following instruments are available for semester ${sem.year}${sem.half}. See the Gemini website for information on instrument capabilities and configuration options."
 
-  def choices = List(Alopeke, Dssi, Flamingos2, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Texes, Visitor)
+  def choices = List(Alopeke, Dssi, Flamingos2, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Phoenix, Visitor)
 
   def apply(i:Instrument) = i match {
     case Alopeke    => Left(inst.Alopeke())

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Dssi.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Dssi.scala
@@ -10,7 +10,7 @@ object Dssi {
   class SiteNode extends SingleSelectNode[Unit, VisitorSite, DssiBlueprint](()) {
     val title       = "Site"
     val description = "Select the site."
-    def choices     = GNVisitorSite :: GSVisitorSite :: Nil
+    def choices     = GSVisitorSite :: Nil
 
     def apply(fs: VisitorSite) = Right(DssiBlueprint(fs))
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
@@ -13,7 +13,7 @@ object Instrument {
   case object Michelle   extends Instrument(GN, "Michelle", "Michelle", "michelle")
   case object Nifs       extends Instrument(GN, "NIFS")
   case object Niri       extends Instrument(GN, "NIRI")
-  case object Dssi       extends Instrument(GN, "DSSI", "DSSI", "DSSI")
+  case object Dssi       extends Instrument(GN, "DSSI")
   case object Texes      extends Instrument(GN, "Texes", "Texes", "TEXES")
   case object Alopeke    extends Instrument(GN, "Alopeke", "ʻAlopeke", "Alopeke")
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -526,7 +526,10 @@ package object immutable {
   object WavelengthRegime extends EnumObject[M.WavelengthRegime]
 
   type AlopekeMode = M.AlopekeMode
-  object AlopekeMode extends EnumObject[M.AlopekeMode]
+  object AlopekeMode extends EnumObject[M.AlopekeMode] {
+    val SPECKLE    = M.AlopekeMode.SPECKLE_0_0096_PIX_6_7_FO_V
+    val WIDE_FIELD = M.AlopekeMode.WIDE_FIELD_0_0725_PIX_60_FO_V
+  }
 
 }
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -265,7 +265,7 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
     }
 
   val dssiSite: TransformFunction = {
-    case <dssi>{ns @ _*}</dssi> if (ns \ "site").isEmpty =>
+    case p @ <dssi>{ns @ _*}</dssi> if (p \\ "Dssi" \\ "site").isEmpty =>
       object DssiSiteTransformer extends BasicTransformer {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
           case p @ <Dssi>{q @ _*}</Dssi> => <Dssi id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GS.name}</site>}</Dssi>

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -138,7 +138,38 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
  * This converter will upgrade to 2018B.
  */
 case object SemesterConverter2018ATo2018B extends SemesterConverter {
-  override val transformers = Nil
+  val dssiSite: TransformFunction = {
+    case <dssi>{ns @ _*}</dssi> =>
+      object DssiSiteTransformer extends BasicTransformer {
+        override def transform(n: xml.Node): xml.NodeSeq = n match {
+          case p @ <Dssi>{q @ _*}</Dssi> => <Dssi id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GS.name}</site>}</Dssi>
+          case <name>{name}</name>       => <name>DSSI {Site.GS.name}</name>
+          case elem: xml.Elem            => elem.copy(child = elem.child.flatMap(transform))
+          case _                         => n
+        }
+      }
+      StepResult("DSSI proposal has been assigned to Gemini South. Use ʻAlopeke instead for Gemini North.", <dssi>{DssiSiteTransformer.transform(ns)}</dssi>).successNel
+  }
+
+  val phoenixNameRegex = "(Phoenix) (.*)".r
+  def transformPhoenixName(name: String) = name match {
+    case phoenixNameRegex(a, b) => s"$a ${Site.GS.name} $b"
+    case _                      => name
+  }
+  val phoenixSite: TransformFunction = {
+    case <phoenix>{ns @ _*}</phoenix> =>
+      object PhoenixSiteTransformer extends BasicTransformer {
+        override def transform(n: xml.Node): xml.NodeSeq = n match {
+          case p @ <Phoenix>{q @ _*}</Phoenix> => <Phoenix id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GS.name}</site>}</Phoenix>
+          case <name>{name}</name>             => <name>{transformPhoenixName(name.text)}</name>
+          case elem: xml.Elem                  => elem.copy(child = elem.child.flatMap(transform))
+          case _                               => n
+        }
+      }
+      StepResult("Phoenix proposal has been assigned to Gemini South.", <phoenix>{PhoenixSiteTransformer.transform(ns)}</phoenix>).successNel
+  }
+
+  override val transformers = List(dssiSite, phoenixSite)
 }
 
 /**
@@ -233,37 +264,6 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
         StepResult("The Flamingos2 filter K-long (2.00 um) has been converted to K-long (2.20 um).", <flamingos2>{KLongFilterTransformer.transform(ns)}</flamingos2>).successNel
     }
 
-  val dssSite: TransformFunction = {
-    case <dssi>{ns @ _*}</dssi> =>
-      object DssiSiteTransformer extends BasicTransformer {
-        override def transform(n: xml.Node): xml.NodeSeq = n match {
-            case p @ <Dssi>{q @ _*}</Dssi> => <Dssi id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GN.name}</site>}</Dssi>
-            case <name>{name}</name>       => <name>DSSI {Site.GN.name}</name>
-            case elem: xml.Elem            => elem.copy(child = elem.child.flatMap(transform))
-            case _                         => n
-          }
-      }
-      StepResult("Dssi proposal has been assigned to Gemini North.", <dssi>{DssiSiteTransformer.transform(ns)}</dssi>).successNel
-  }
-
-  val phoenixNameRegex = "(Phoenix) (.*)".r
-  def transformPhoenixName(name: String) = name match {
-    case phoenixNameRegex(a, b) => s"$a ${Site.GS.name} $b"
-    case _                      => name
-  }
-  val phoenixSite: TransformFunction = {
-    case <phoenix>{ns @ _*}</phoenix> =>
-      object PhoenixSiteTransformer extends BasicTransformer {
-        override def transform(n: xml.Node): xml.NodeSeq = n match {
-            case p @ <Phoenix>{q @ _*}</Phoenix> => <Phoenix id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GS.name}</site>}</Phoenix>
-            case <name>{name}</name>             => <name>{transformPhoenixName(name.text)}</name>
-            case elem: xml.Elem                  => elem.copy(child = elem.child.flatMap(transform))
-            case _                               => n
-          }
-      }
-      StepResult("Phoenix proposal has been assigned to Gemini South.", <phoenix>{PhoenixSiteTransformer.transform(ns)}</phoenix>).successNel
-  }
-
   val texesNameRegex = "(Texes) (.*)".r
   def transformTexesName(name: String) = name match {
     case texesNameRegex(a, b) => s"$a ${Site.GN.name} $b"
@@ -274,11 +274,11 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
     case <texes>{ns @ _*}</texes> =>
       object TexesSiteTransformer extends BasicTransformer {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
-            case p @ <Texes>{q @ _*}</Texes> => <Texes id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GN.name}</site>}</Texes>
-            case <name>{name}</name>         => <name>{transformTexesName(name.text)}</name>
-            case elem: xml.Elem              => elem.copy(child = elem.child.flatMap(transform))
-            case _                           => n
-          }
+          case p @ <Texes>{q @ _*}</Texes> => <Texes id={p.attribute("id")}>{q.map(transform) +: <site>{Site.GN.name}</site>}</Texes>
+          case <name>{name}</name>         => <name>{transformTexesName(name.text)}</name>
+          case elem: xml.Elem              => elem.copy(child = elem.child.flatMap(transform))
+          case _                           => n
+        }
       }
       StepResult("Texes proposal has been assigned to Gemini North.", <texes>{TexesSiteTransformer.transform(ns)}</texes>).successNel
   }
@@ -297,7 +297,7 @@ case object SemesterConverter2016ATo2016B extends SemesterConverter {
       }
       StepResult(s"GPI proposal with observing mode ${(p \\ "observingMode").text} has been assigned to the ${GpiObservingMode.HDirect.value} mode.", <gpi>{GpiObsModeTransformer.transform(ns)}</gpi>).successNel
   }
-  override val transformers = List(replaceKLongFilter, dssSite, phoenixSite, texesSite, gpiModes)
+  override val transformers = List(replaceKLongFilter, texesSite, gpiModes)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_dssi_gn.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_dssi_gn.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2013.2.1">
+    <meta band3optionChosen="false"/>
+    <semester year="2013" half="B"/>
+    <title/>
+    <abstract/>
+    <scheduling/>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email/>
+            <address>
+                <institution/>
+                <address/>
+                <country/>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints>
+        <dssi>
+            <Dssi id="blueprint-0">
+                <name>Dssi Gemini North</name>
+                <visitor>true</visitor>
+                <site>Gemini North</site>
+            </Dssi>
+        </dssi>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" blueprint="blueprint-0"/>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
@@ -11,9 +11,9 @@ class RootSpec extends Specification {
       val root = new Root(Semester(2016, A))
       root.choices must contain(Instrument.Gsaoi)
     }
-    "Texes has been removed in 2017B" in {
-      val root = new Root(Semester(2018, A))
-      root.choices must contain (Instrument.Texes)
+    "Texes has been removed in 2018B" in {
+      val root = new Root(Semester(2018, B))
+      root.choices must not contain Instrument.Texes
     }
     "include Speckles" in {
       val root = new Root(Semester(2016, A))
@@ -32,8 +32,8 @@ class RootSpec extends Specification {
       root.choices must contain(Instrument.Graces)
     }
     "includes Phoenix" in {
-      val root = new Root(Semester(2018, A))
-      root.choices must not contain(Instrument.Phoenix)
+      val root = new Root(Semester(2018, B))
+      root.choices must contain(Instrument.Phoenix)
     }
     "Michelle has been removed in 2016A" in {
       val root = new Root(Semester(2016, A))

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -456,21 +456,23 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
           changes must have length 5
-          changes must contain("Dssi proposal has been assigned to Gemini North.")
+          changes must contain("DSSI proposal has been assigned to Gemini South. Use ʻAlopeke instead for Gemini North.")
           // The dssi blueprint must remain and include a site
           result must \\("Dssi", "id")
-          result must \\("Dssi") \\ "site" \> "Gemini North"
-          result must \\("Dssi") \\ "name" \> "DSSI Gemini North"
+          result must \\("Dssi") \\ "site" \> "Gemini South"
+          result must \\("Dssi") \\ "name" \> "DSSI Gemini South"
       }
     }
     "proposal with phoenix blueprints must have them removed, REL-3233" in {
-      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_phoenix_no_site.xml")))
+      skipped {
+        val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_phoenix_no_site.xml")))
 
-      val converted = UpConverter.convert(xml)
-      converted must beSuccessful.like {
-        case StepResult(changes, result) =>
-          changes must have length 5
-          changes must contain("The original proposal contained Phoenix observations. The instrument is not available and those resources have been removed.")
+        val converted = UpConverter.convert(xml)
+        converted must beSuccessful.like {
+          case StepResult(changes, result) =>
+            changes must have length 5
+            changes must contain("The original proposal contained Phoenix observations. The instrument is not available and those resources have been removed.")
+        }
       }
     }
     "proposal with texes blueprints must have a site, REL-2463" in {

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -456,11 +456,24 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
           changes must have length 5
-          changes must contain("DSSI proposal has been assigned to Gemini South. Use ʻAlopeke instead for Gemini North.")
+          changes must contain("DSSI proposal has been assigned to Gemini South.")
           // The dssi blueprint must remain and include a site
           result must \\("Dssi", "id")
           result must \\("Dssi") \\ "site" \> "Gemini South"
           result must \\("Dssi") \\ "name" \> "DSSI Gemini South"
+      }
+    }
+    "proposal with dssi blueprints at Gemini North must migrate to ʻAlopeke, REL-3349" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi_gn.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must have length 5
+          changes must contain("DSSI Gemini North proposal has been migrated to ʻAlopeke instead.")
+          result must \\("Alopeke", "id")
+          result must \\("Alopeke") \\ "mode" \> AlopekeMode.SPECKLE.value
+          result must \\("Alopeke") \\ "name" \> AlopekeBlueprint(AlopekeMode.SPECKLE).name
       }
     }
     "proposal with phoenix blueprints must have them removed, REL-3233" in {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -87,6 +87,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           TimeProblems(p, s).all ++
           TimeProblems.partnerZeroTimeRequest(p, s) ++
           TacProblems(p, s).all ++
+          Semester2018BProblems(p, s).all ++
           List(incompleteInvestigator, missingObsElementCheck, cfCheck, emptyTargetCheck,
             emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck,
             badGuiding, cwfsCorrectionsIssue, badVisibility, iffyVisibility, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsIQ70Check, lgsGemsIQ85Check,
@@ -679,6 +680,35 @@ object TimeProblems {
       probs.right.getOrElse(Nil)
     case _                            => Nil
   }
+}
+
+case class Semester2018BProblems(p: Proposal, s: ShellAdvisor) {
+  // *** 2018B specific issues ***
+  private val semester2018B = Semester(2018, SemesterOption.B)
+
+  private val texesNotOfferedCheck = for {
+    o <- p.observations
+    b <- o.blueprint
+    if b.isInstanceOf[TexesBlueprint]
+    if p.semester == semester2018B
+  } yield new Problem(Severity.Error, "TEXES is not offered for 2018B.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
+
+  private val dssiOnlyGS = for {
+    o <- p.observations
+    b <- o.blueprint
+    if b.isInstanceOf[DssiBlueprint]
+    if b.site == Site.GN
+    if p.semester == semester2018B
+  } yield new Problem(Severity.Error, "DSSI is not offered at Gemini North for 2018B.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
+
+  private val phoenixOnlyGS = for {
+    o <- p.observations
+    b <- o.blueprint
+    if b.isInstanceOf[PhoenixBlueprint]
+    if b.site == Site.GN
+  } yield new Problem(Severity.Error, "Phoenis is only available at Gemini South for 2018B.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
+
+  def all: List[Problem] = List(texesNotOfferedCheck, dssiOnlyGS, phoenixOnlyGS).flatten
 }
 
 case class TimeProblems(p: Proposal, s: ShellAdvisor) {


### PR DESCRIPTION
The following have been listed as requirements for the 2018B PIT:

1. Remove TEXES from the list of instruments.
2. Add Phoenix to the list of instruments (GS only).
3. Make DSSI GS only, as Alopeke will be used for GN instead.

In this PR, I adjust the instrument list accordingly, i.e. removing TEXES and adding Phoenix back, and change DSSI to be GS only. Here is the instrument list now:
![screen shot 2018-02-01 at 2 55 59 pm](https://user-images.githubusercontent.com/8795653/35694868-765d3572-0761-11e8-9ff6-8d22039eb173.png)



Here is what you now see when you select DSSI. (This is how Phoenix works, despite the strangeness of a one option selection box, so I followed suit to indicate that it is only at GS, especially important now since this has not always been the case.)
![screen shot 2018-02-01 at 2 56 20 pm](https://user-images.githubusercontent.com/8795653/35694851-6425fccc-0761-11e8-8271-9688ff024a85.png)

The UpConverter now takes DSSI observations at GN and issues a warning, and changes them to GS with the information that Alopeke should be used for GN observations instead.
![screen shot 2018-02-01 at 2 57 33 pm](https://user-images.githubusercontent.com/8795653/35694720-e6d5849a-0760-11e8-851e-089aa1d547ef.png)

Additionally, the UpConverter also assigns Phoenix proposals to GS. This was done in an earlier upconversion, so I simply grabbed the code out of there and moved it to the 2018B conversion.

Finally, the list of problems now generates issues if the configuration includes TEXES, or Phoenix at GN, or DSSI at GN. This should never happen based on the upconversion, but I thought it prudent to include it anyway.