### PR TITLE
REL-3288: Change AGS client to use GMOS-N OI for GRACES.

### DIFF
--- a/bundle/edu.gemini.ags.client.impl/src/main/scala/edu/gemini/ags/client/impl/QueryArgs.scala
+++ b/bundle/edu.gemini.ags.client.impl/src/main/scala/edu/gemini/ags/client/impl/QueryArgs.scala
@@ -51,10 +51,11 @@ object QueryArgs {
   }).toList
 
   def instId(b: BlueprintBase): Either[String, String] = b match {
-    case g: AlopekeBlueprint    => Right(Instrument.Nifs.id) // REL-3351: treat Alopeke like NIFS until Visitor PWFS is changeable.
-    case g: TexesBlueprint      => Right(Instrument.Nifs.id) // REL-1062
-    case g: DssiBlueprint       => Right(Instrument.Nifs.id) // REL-1061
-    case g: VisitorBlueprint    => Right(Instrument.Niri.id) // REL-1090
+    case g: AlopekeBlueprint    => Right(Instrument.Nifs.id)      // REL-3351: treat Alopeke like NIFS until Visitor PWFS is changeable.
+    case g: DssiBlueprint       => Right(Instrument.Nifs.id)      // REL-1061
+    case g: GracesBlueprint     => Right(Instrument.GmosNorth.id) // REL-3288: GRACES uses GMOS-N OI.
+    case g: TexesBlueprint      => Right(Instrument.Nifs.id)      // REL-1062
+    case g: VisitorBlueprint    => Right(Instrument.Niri.id)      // REL-1090
     case g: GeminiBlueprintBase => Right(g.instrument.id)
     case _ => Left("Not a Gemini Instrument")
   }


### PR DESCRIPTION
GRACES uses GMOS-N OIWFS for guiding. Right now, AGS queries pass "inst=GRACES", which causes failure. Instead, GRACES should translate to GMOS-N for AGS lookups.

I also sorted the cases alphabetically for ease.

Here is a screenshot showing GRACES working as GMOS-N.
![screen shot 2018-02-01 at 5 07 34 pm](https://user-images.githubusercontent.com/8795653/35700960-414b7436-0773-11e8-846c-49cceea7c881.png)
