### PR TITLE
REL-3351: Made Alopeke a visitor instrument.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/AlopekeBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/AlopekeBlueprint.scala
@@ -8,6 +8,7 @@ object AlopekeBlueprint {
 
 case class AlopekeBlueprint(mode: AlopekeMode) extends GeminiBlueprintBase {
   def name: String = s"ʻAlopeke ${mode.value}"
+  override val visitor = true
 
   def this(m: M.AlopekeBlueprint) = this(
     m.getMode
@@ -19,6 +20,7 @@ case class AlopekeBlueprint(mode: AlopekeMode) extends GeminiBlueprintBase {
     val m = Factory.createAlopekeBlueprint
     m.setId(n.nameOf(this))
     m.setName(name)
+    m.setVisitor(visitor)
     m.setMode(mode)
     m
   }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/BlueprintBase.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/BlueprintBase.scala
@@ -4,6 +4,8 @@ import edu.gemini.model.p1.{mutable => M}
 
 object BlueprintBase {
   def apply(a: M.BlueprintBase): BlueprintBase = a match {
+    // Alopeke
+    case b: M.AlopekeBlueprint              => AlopekeBlueprint(b)
 
     // Flamingos2
     case b: M.Flamingos2BlueprintImaging    => Flamingos2BlueprintImaging(b)

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_alopeke.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_alopeke.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2018.2.1">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2018" half="B"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets>
+       <sidereal epoch="J2000" id="target-0">
+          <name>vega</name>
+            <degDeg>
+                <ra>279.23473479</ra>
+                <dec>38.78368896</dec>
+            </degDeg>
+            <properMotion deltaDec="286.23" deltaRA="200.94"/>
+            <magnitudes>
+                <magnitude system="Vega" band="B">0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="V">0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="R">0.10000000149011612</magnitude>
+                <magnitude system="Vega" band="J">-0.18000000715255737</magnitude>
+                <magnitude system="Vega" band="H">-0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="K">0.12999999523162842</magnitude>
+            </magnitudes>
+        </sidereal>
+    </targets>
+    <conditions>
+        <condition id="condition-0">
+            <name>CC Any, IQ Any, SB Any/Bright, WV Any</name>
+            <cc>Any</cc>
+            <iq>Any</iq>
+            <sb>Any/Bright</sb>
+            <wv>Any</wv>
+        </condition>
+    </conditions>
+    <blueprints>
+        <alopeke>
+            <Alopeke id="blueprint-0">
+                <name>ʻAlopeke Speckle (0.0096"/pix, 6.7" FoV)</name>
+                <visitor>false</visitor>
+                <mode>Speckle (0.0096"/pix, 6.7" FoV)</mode>
+            </Alopeke>
+        </alopeke>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" target="target-0" condition="condition-0" blueprint="blueprint-0">
+            <progTime units="hr">1.0</progTime>
+            <partTime units="hr">0.0</partTime>
+            <time units="hr">1.0</time>
+            <meta ck="">
+                <visibility>Good</visibility>
+                <gsa>0</gsa>
+            </meta>
+        </observation>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/AlopekeBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/AlopekeBlueprintSpec.scala
@@ -1,0 +1,53 @@
+package edu.gemini.model.p1.immutable
+
+import java.io.InputStreamReader
+
+import org.specs2.matcher.XmlMatchers
+import org.specs2.mutable.Specification
+
+import scala.xml.XML
+
+class AlopekeBlueprintSpec extends Specification with SemesterProperties with XmlMatchers {
+  private val blueprints = AlopekeMode.values.map(m => AlopekeBlueprint(m))
+
+  // A proposal for Alopeke with speckle mode and visitor set to false.
+  private val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_alopeke.xml")))
+
+  "The ʻAlopeke Blueprint" should {
+    "not use Ao" in {
+      ((_: AlopekeBlueprint).ao must beEqualTo(AoNone)).forall(blueprints)
+    }
+    "be a visitor instrument" in {
+      ((_: AlopekeBlueprint).visitor must beTrue).forall(blueprints)
+    }
+    "have a mode" in {
+      AlopekeBlueprint(AlopekeMode.SPECKLE).mode must beEqualTo(AlopekeMode.SPECKLE)
+      AlopekeBlueprint(AlopekeMode.WIDE_FIELD).mode must beEqualTo(AlopekeMode.WIDE_FIELD)
+      true must beTrue
+    }
+    "export Alopeke to XML" in {
+      { (b: AlopekeBlueprint) =>
+        val observation = Observation(Some(b), None, None, Band.BAND_1_2, None)
+        val proposal    = Proposal.empty.copy(observations = observation :: Nil)
+        val xml         = XML.loadString(ProposalIo.writeToString(proposal))
+
+        // Verify that this has the tags we expect.
+        xml must \\("alopeke")
+        xml must \\("alopeke") \\ "Alopeke"
+        xml must \\("Alopeke") \\ "name" \> b.name
+        xml must \\("Alopeke") \\ "mode" \> b.mode.value
+        xml must \\("Alopeke") \ "visitor" \> "true"
+      }.forall(blueprints)
+    }
+    "be possible to deserialize" in {
+      // This is configured with speckle mode.
+      proposal.blueprints.head must beEqualTo(AlopekeBlueprint(AlopekeMode.SPECKLE))
+    }
+    "overwrite visitor as true" in {
+      // Even though it is false in the XML, it should become true in the model.
+      proposal.blueprints.head.visitor must beTrue
+      val xml = XML.loadString(ProposalIo.writeToString(proposal))
+      xml must \\("Alopeke") \ "visitor" \> "true"
+    }
+  }
+}


### PR DESCRIPTION
I noticed during testing that both DSSI and TEXES proposals had a tag in the instrument node with `<visitor>true</visitor>` and that Alopeke had `<visitor>false</visitor>`, which is wrong and something I missed in the initial implementation.

This fixes that.