### PR TITLE
REL-3363: GMOS-N does not support Altair in 2018B

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/GmosNorth.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/GmosNorth.scala
@@ -10,8 +10,10 @@ object GmosNorth {
 
   import InstrumentMode._
 
+  // REL-3363: No GMOS-N + Altair offered for 2018B. Skip over the AdaptiveOpticsNode and just use AltairNone.
   // Constructor for initial node
-  def apply() = new AdaptiveOpticsNode
+  // def apply() = new AdaptiveOpticsNode
+  def apply() = new SelectMode(AltairNone)
 
   class AdaptiveOpticsNode extends SingleSelectNode[Unit, Altair, Altair](()) with AltairNode {
     override val allGuideStarTypes = true

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintIfu.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintIfu.scala
@@ -18,8 +18,9 @@ case class GmosNBlueprintIfu(
   filter: GmosNFilter,
   fpu: GmosNFpuIfu) extends GmosNBlueprintSpectrosopyBase {
 
-  def name =
-    s"GMOS-N IFU $altair ${disperser.value} ${filter.value} ${fpu.value}"
+  // REL-3363: No GMOS-N + Altair offered for 2018B. Remove from name.
+  // def name = s"GMOS-N IFU $altair ${disperser.value} ${filter.value} ${fpu.value}"
+  def name = s"GMOS-N IFU ${disperser.value} ${filter.value} ${fpu.value}"
 
   def mutable(n:Namer) = {
     val m = Factory.createGmosNBlueprintIfu

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintImaging.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintImaging.scala
@@ -9,7 +9,9 @@ object GmosNBlueprintImaging {
 
 case class GmosNBlueprintImaging(altair: Altair, filters: List[GmosNFilter]) extends GmosNBlueprintBase {
 
-  lazy val name = s"GMOS-N Imaging $altair ${filters.map(_.value).mkString("+")}"
+  // REL-3363: No GMOS-N + Altair offered for 2018B. Remove from name.
+  // lazy val name = s"GMOS-N Imaging $altair ${filters.map(_.value).mkString("+")}"
+  lazy val name = s"GMOS-N Imaging ${filters.map(_.value).mkString("+")}"
 
   def toChoice(n:Namer) = {
     val c = Factory.createGmosNBlueprintChoice

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintLongslit.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintLongslit.scala
@@ -33,6 +33,7 @@ case class GmosNBlueprintLongslit(altair: Altair, disperser: GmosNDisperser, fil
     m
   }
 
-  def name = s"GMOS-N LongSlit $altair ${disperser.value} ${filter.value} ${fpu.value}"
-
+  // REL-3363: No GMOS-N + Altair offered for 2018B. Remove from name.
+  // def name = s"GMOS-N LongSlit $altair ${disperser.value} ${filter.value} ${fpu.value}"
+  def name = s"GMOS-N LongSlit ${disperser.value} ${filter.value} ${fpu.value}"
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintLongslitNs.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintLongslitNs.scala
@@ -33,6 +33,8 @@ case class GmosNBlueprintLongslitNs(altair: Altair, disperser: GmosNDisperser, f
     m
   }
 
-  def name = s"GMOS-N LongSlit N+S $altair ${disperser.value} ${filter.value} ${fpu.value}"
+  // REL-3363: No GMOS-N + Altair offered for 2018B. Remove from name.
+  // def name = s"GMOS-N LongSlit N+S $altair ${disperser.value} ${filter.value} ${fpu.value}"
+  def name = s"GMOS-N LongSlit N+S ${disperser.value} ${filter.value} ${fpu.value}"
 
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintMos.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/GmosNBlueprintMos.scala
@@ -45,7 +45,9 @@ case class GmosNBlueprintMos(
   def name = {
     val ns = if (nodAndShuffle) "MOS N+S" else "MOS"
     val pi = if (preImaging) "+Pre" else ""
-    s"GMOS-N $ns $altair ${fpu.value} ${disperser.value} ${filter.value} $pi"
+    // REL-3363: No GMOS-N + Altair offered for 2018B. Remove from name.
+    // s"GMOS-N $ns $altair ${fpu.value} ${disperser.value} ${filter.value} $pi"
+    s"GMOS-N $ns ${fpu.value} ${disperser.value} ${filter.value} $pi"
   }
 
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -144,12 +144,15 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
 case object SemesterConverter2018ATo2018B extends SemesterConverter {
   // REL-3363: No GMOS-N + Altair offered for 2018B. Remove Altair from component.
   // The name of the instrument is auto-generated from its properties, so we don't worry about the <name>...</name> tag.
+  private lazy val gmosnAltairLGSRE  = " Altair Laser Guidestar( w/ (PWFS1|OIWFS))?"
+  private lazy val gmosnAltairNGSRE  = " Altair Natural Guidestar( w/ Field Lens)?"
   lazy val gmosnAltairRemoverMessage = "GMOS-N does not offer Altair in 2018B. Altair component removed."
   val gmosnAltairRemover: TransformFunction = {
     case p @ <gmosN>{ns @ _*}</gmosN> if (p \\ "altair" \ "lgs").nonEmpty || (p \\ "altair" \\ "ngs").nonEmpty =>
       object GmosNAltairRemover extends BasicTransformer {
         override def transform(n: xml.Node): xml.NodeSeq = n match {
           case <altair>{_ @ _*}</altair> => <altair><none/></altair>
+          case <name>{name}</name>       => <name>{name.text.replaceFirst(gmosnAltairLGSRE, "").replaceFirst(gmosnAltairNGSRE, "")}</name>
           case elem: xml.Elem            => elem.copy(child = elem.child.flatMap(transform))
           case _                         => n
         }

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_gmosn_altair_lgs.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_gmosn_altair_lgs.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2017.1.1">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2017" half="A"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints>
+        <gmosN>
+            <regime>optical</regime>
+            <imaging id="blueprint-0">
+                <name>GMOS-N Imaging Altair Laser Guidestar w/ OIWFS z (925 nm)</name>
+                <visitor>false</visitor>
+                <altair>
+                    <lgs pwfs1="false" aowfs="false" oiwfs="true"/>
+                </altair>
+                <filter>z (925 nm)</filter>
+            </imaging>
+        </gmosN>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" blueprint="blueprint-0"/>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -566,7 +566,8 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
           changes must contain(SemesterConverter2018ATo2018B.gmosnAltairRemoverMessage)
-          result \\ "altair" must \\("none")
+          (result \\ "gmosN" \\ "altair") must \\("none")
+          (result \\ "gmosN") must \\("name") \> "GMOS-N Imaging z (925 nm)"
       }
 
     }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -243,7 +243,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 7
+          changes must have length 8
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -268,7 +268,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 7
+          changes must have length 8
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -294,7 +294,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 8
+          changes must have length 9
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -558,6 +558,17 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           (result \\ "gmosN") must \\("fpu") \> "1.0 arcsec slit"
           (result \\ "gmosN") must \\("name") \>~ ".*1.0 arcsec slit.*"
       }
+    }
+    "proposal with GmosN with Altair mode must have it set to AltairNone for 2018B, REL-3363" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gmosn_altair_lgs.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must contain(SemesterConverter2018ATo2018B.gmosnAltairRemoverMessage)
+          result \\ "altair" must \\("none")
+      }
+
     }
     "proposal with Gnirs that doesn't have a central wavelength, REL-1254" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gnirs_no_centralwavelength.xml")))

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -693,6 +693,14 @@ case class Semester2018BProblems(p: Proposal, s: ShellAdvisor) {
     if p.semester == semester2018B
   } yield new Problem(Severity.Error, "Texes is not offered for 2018B.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
 
+  private val gmosnAltairNotOfferedCheck = for {
+    o <- p.observations
+    b <- o.blueprint
+    if b.isInstanceOf[GmosNBlueprintBase]
+    if p.semester == semester2018B
+    if b.asInstanceOf[GmosNBlueprintBase].altair != AltairNone
+  } yield new Problem(Severity.Error, "GMOS-N does not offer Altair in 2018B.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
+
   private val dssiOnlyGS = for {
     o <- p.observations
     b <- o.blueprint
@@ -708,7 +716,7 @@ case class Semester2018BProblems(p: Proposal, s: ShellAdvisor) {
     if b.site == Site.GN
   } yield new Problem(Severity.Error, "Phoenix is only available at Gemini South for 2018B.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
 
-  def all: List[Problem] = List(texesNotOfferedCheck, dssiOnlyGS, phoenixOnlyGS).flatten
+  def all: List[Problem] = List(texesNotOfferedCheck, gmosnAltairNotOfferedCheck, dssiOnlyGS, phoenixOnlyGS).flatten
 }
 
 case class TimeProblems(p: Proposal, s: ShellAdvisor) {


### PR DESCRIPTION
Andy pointed out that GMOS-N does not support Altair for 2018B. Thus, I:
1. Removed the Altair node from the GMOS-N instrument tree, instead forcing `AltairNone` to be used.
2. Removed any Altair mode other than `AltairNone` during upconversion, issuing a warning.
3. Removed references to Altair modes in GMOS-N names (as they will always be `None`, which would be confusing).
4. Added a case to the `ProblemRobot` (which should never happen) that reports an error if one tries to use GMOS-N with an Altair mode.
5. Added a test case to `UpConverterSpec` to make sure the Altair mode was set to `AltairNone`.