### PR TITLE
REL-2659: Complete ITC support for summing GMOS IFU elements

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -581,11 +581,11 @@
 				<input name="ifuMaxOffset" size="5" value="3.0" type="text" /> arcsec </td>
 
 			</tr>
-			<!--tr>
+			<tr>
 				<td><input value="sumIFU" name="analysisMethod" type="radio" /></td>
 				<td>Sum all IFU elements within <input name="ifuNum" size="5" value="2" type="text" /> arcsec of the center
 				</td>
-			</tr-->
+			</tr>
 			<tr>
 				<td colspan="3" height="50" valign="bottom"><b>Output:</b> </td>
 			</tr>

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -494,7 +494,8 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
         String title = "Intermediate Single Exp and Final S/N in aperture" + (ifuUsed ? "\nIFU element offset: " + String.format("%.2f", ifuOffset) + " arcsec" : "");
         if (mainInstrument.isIfuUsed() &&  mainInstrument.getIfuMethod().get() instanceof IfuSum) {
             final IfuSum ifu = (IfuSum) mainInstrument.getIfuMethod().get();
-            title = "Intermediate Single Exp and Final S/N in aperture\nIFU elements summed in a radius of " + String.format("%.2f", ifu.num()) + " arcsec";
+            final int ifuElements = mainInstrument.getIFU().getApertureOffsetList().size();
+            title = "Intermediate Single Exp and Final S/N in aperture\n" + String.format("%d", ifuElements) + " IFU elements summed in a radius of " + String.format("%.2f", ifu.num()) + " arcsec";
         }
         final ChartAxis xAxis = ChartAxis.apply("Wavelength (nm)");
         final ChartAxis yAxis = ChartAxis.apply("Signal / Noise per spectral pixel");

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/IFUComponent.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/IFUComponent.java
@@ -69,9 +69,9 @@ public final class IFUComponent extends TransmissionElement {
 
         int Nelements = 0;
         for (int i = 0; i < numX; i++) {
-            double x = (i - (numX/2.)) * (0.75*IFU_DIAMETER + IFU_SPACING);
+            double x = (i - (numX/2.)) * ((Math.sqrt(3)/2.)*IFU_DIAMETER + IFU_SPACING);
             for (int j = 0; j < numY; j++) {
-                double y = (2*j - (numY - Math.abs(i)%2 + 1)) * ((Math.sqrt(3)/4.)*IFU_DIAMETER + IFU_SPACING);
+                double y = (2*j - (numY - Math.abs(i)%2 + 1)) * (IFU_DIAMETER/2. + IFU_SPACING);
                 double r = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
                 if (r < radius) {
                     IFUApertures.addAperture(new HexagonalAperture(x, y, IFU_DIAMETER));

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/IFUComponent.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/IFUComponent.java
@@ -68,10 +68,12 @@ public final class IFUComponent extends TransmissionElement {
         if (isIfu2) numX = 40;    // number of elements in the IFU-2 in the x-direction
 
         int Nelements = 0;
+        double distX = (Math.sqrt(3)/2.0)*IFU_DIAMETER + IFU_SPACING;
+        double distY = (IFU_DIAMETER + IFU_SPACING)/2.0;
         for (int i = 0; i < numX; i++) {
-            double x = (i - (numX/2.)) * ((Math.sqrt(3)/2.)*IFU_DIAMETER + IFU_SPACING);
+            double x = (i - (numX/2.0)) * distX;
             for (int j = 0; j < numY; j++) {
-                double y = (2*j - (numY - Math.abs(i)%2 + 1)) * (IFU_DIAMETER/2. + IFU_SPACING);
+                double y = (2*j - (numY - Math.abs(i)%2 + 1)) * distY;
                 double r = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
                 if (r < radius) {
                     IFUApertures.addAperture(new HexagonalAperture(x, y, IFU_DIAMETER));

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/IFUComponent.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/IFUComponent.java
@@ -65,20 +65,17 @@ public final class IFUComponent extends TransmissionElement {
 
         int numY = 25;            // number of elements in the IFU in the y-direction
         int numX = 20;            // number of elements in the IFU-1 in the x-direction
-        if (isIfu2) {
-            numX = 40;            // number of elements in the IFU-2 in the x-direction
-        }
+        if (isIfu2) numX = 40;    // number of elements in the IFU-2 in the x-direction
 
         int Nelements = 0;
-        for (int i = 0; i < numY; i++) {
-            double y = (i - (numY-1)/2.) * IFU_DIAMETER;
-            for (int j = 0; j < numX; j++) {
-                double x = (j - (numX-1)/2.) * IFU_DIAMETER;
+        for (int i = 0; i < numX; i++) {
+            double x = (i - (numX/2.)) * (0.75*IFU_DIAMETER + IFU_SPACING);
+            for (int j = 0; j < numY; j++) {
+                double y = (2*j - (numY - Math.abs(i)%2 + 1)) * ((Math.sqrt(3)/4.)*IFU_DIAMETER + IFU_SPACING);
                 double r = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
                 if (r < radius) {
                     IFUApertures.addAperture(new HexagonalAperture(x, y, IFU_DIAMETER));
-                    IFUOffsets.add(x);
-                    IFUOffsets.add(y);
+                    IFUOffsets.add(r);
                     Nelements++;
                 }
             }


### PR DESCRIPTION
This is the continuation of the upgrade to the GMOS ITC to support a new IFU analysis method to sum all apertures with a specified radius of the center, e.g.:
Sum all IFU elements within ____ arcsec of the center

This resolves the issues of:
Center and pack fibers using correct geometry
Display the number of summed elements in the generated plot title
Display the analysis method in the GMOS ITC page