### PR TITLE
REL-3351: Changed okinas to apostrophes to avoid unicode issues, take 2.

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
@@ -217,7 +217,7 @@
         <xsl:param name="inst"/>
         <xsl:param name="site"/>
         <xsl:choose>
-            <xsl:when test="$inst = 'alopeke'">ʻAlopeke</xsl:when>
+            <xsl:when test="$inst = 'alopeke'">'Alopeke</xsl:when>
             <xsl:when test="$inst = 'flamingos2'">Flamingos2</xsl:when>
             <xsl:when test="$inst = 'gmosN'">GMOS North</xsl:when>
             <xsl:when test="$inst = 'gmosS'">GMOS South</xsl:when>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_alopeke.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_alopeke.xml
@@ -49,7 +49,7 @@
     <blueprints>
         <alopeke>
             <Alopeke id="blueprint-0">
-                <name>ʻAlopeke Speckle (0.0096"/pix, 6.7" FoV)</name>
+                <name>'Alopeke Speckle (0.0096"/pix, 6.7" FoV)</name>
                 <visitor>false</visitor>
                 <mode>Speckle (0.0096"/pix, 6.7" FoV)</mode>
             </Alopeke>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
@@ -138,9 +138,9 @@ class P1TemplatesSpec extends Specification with XmlMatchers {
       // Check that we use the proper public name of DSSI
       XML.loadString(result) must (\\("table-cell") \ "block" \> "DSSI - Gemini North")
     }
-    "present the correct name when using ʻAlopeke, REL-3351" in {
+    "present the correct name when using 'Alopeke, REL-3351" in {
       val result = transformProposal("proposal_with_alopeke.xml")
-      XML.loadString(result) must (\\("table-cell") \ "block" \> "ʻAlopeke")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "'Alopeke")
     }
     "present the correct name when using Visitor GN, REL-1090" in {
       val result = transformProposal("proposal_with_visitor_gn.xml")

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/AlopekeBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/AlopekeBlueprint.scala
@@ -7,7 +7,7 @@ object AlopekeBlueprint {
 }
 
 case class AlopekeBlueprint(mode: AlopekeMode) extends GeminiBlueprintBase {
-  def name: String = s"ʻAlopeke ${mode.value}"
+  def name: String = s"'Alopeke ${mode.value}"
   override val visitor = true
 
   def this(m: M.AlopekeBlueprint) = this(

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
@@ -15,7 +15,7 @@ object Instrument {
   case object Niri       extends Instrument(GN, "NIRI")
   case object Dssi       extends Instrument(GN, "DSSI")
   case object Texes      extends Instrument(GN, "Texes", "Texes", "TEXES")
-  case object Alopeke    extends Instrument(GN, "Alopeke", "ʻAlopeke", "Alopeke")
+  case object Alopeke    extends Instrument(GN, "Alopeke", "'Alopeke", "Alopeke")
 
   case object Flamingos2 extends Instrument(GS, "Flamingos2", "Flamingos2", "FLAMINGOS")
   case object GmosSouth  extends Instrument(GS, "GMOSSouth", "GMOS South", "GMOS-S")

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Alopeke.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Alopeke.xsd
@@ -1,10 +1,10 @@
 <!--
-  Schema definition for ʻAlopeke blueprints.
+  Schema definition for 'Alopeke blueprints.
 -->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <xsd:include schemaLocation="Instrument.xsd"/>
     
-    <!-- Options for ʻAlopeke Blueprint. -->
+    <!-- Options for 'Alopeke Blueprint. -->
     <xsd:complexType name="AlopekeBlueprintChoice">
         <xsd:sequence>
             <xsd:choice>
@@ -14,11 +14,11 @@
         </xsd:sequence>
     </xsd:complexType>
     
-    <!-- ʻAlopeke null. Empty blueprint, not available in PIT. -->
+    <!-- 'Alopeke null. Empty blueprint, not available in PIT. -->
     <xsd:complexType name="AlopekeBlueprintNull"/>
 
     <!--
-      ʻAlopeke Blueprint base type.
+      'Alopeke Blueprint base type.
     -->
     <xsd:complexType name="AlopekeBlueprint">
         <xsd:complexContent>

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -4,7 +4,7 @@ Gemini Phase I Schema Changes
 ##########################
 
 * Added OVI and OVIC filters for GMOS-N and GMOS-S. (REL-3273)
-* Added new instrument, ʻAlopeke, with two modes, namely Speckle (0.0096"/pix, 6.7" FoV) and Wide Field (0.0725"/pix, 60" FoV). (REL-3351)
+* Added new instrument, 'Alopeke, with two modes, namely Speckle (0.0096"/pix, 6.7" FoV) and Wide Field (0.0725"/pix, 60" FoV). (REL-3351)
 
 # Version 2018.1.1 - 2018A
 ##########################

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_alopeke.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_alopeke.xml
@@ -49,7 +49,7 @@
     <blueprints>
         <alopeke>
             <Alopeke id="blueprint-0">
-                <name>ʻAlopeke Speckle (0.0096"/pix, 6.7" FoV)</name>
+              <name>'Alopeke Speckle (0.0096"/pix, 6.7" FoV)</name>
                 <visitor>false</visitor>
                 <mode>Speckle (0.0096"/pix, 6.7" FoV)</mode>
             </Alopeke>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/AlopekeSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/AlopekeSpec.scala
@@ -3,8 +3,8 @@ package edu.gemini.model.p1.dtree.inst
 import org.specs2.mutable.Specification
 
 class AlopekeSpec extends Specification {
-  "The ʻAlopeke decision tree" should {
-    "include ʻAlopeke modes" in {
+  "The 'Alopeke decision tree" should {
+    "include 'Alopeke modes" in {
       val alopeke = Alopeke()
       alopeke.title must beEqualTo("Mode")
       alopeke.choices must have size 2

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/AlopekeBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/AlopekeBlueprintSpec.scala
@@ -13,7 +13,7 @@ class AlopekeBlueprintSpec extends Specification with SemesterProperties with Xm
   // A proposal for Alopeke with speckle mode and visitor set to false.
   private val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_alopeke.xml")))
 
-  "The ʻAlopeke Blueprint" should {
+  "The 'Alopeke Blueprint" should {
     "not use Ao" in {
       ((_: AlopekeBlueprint).ao must beEqualTo(AoNone)).forall(blueprints)
     }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -465,7 +465,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           result must \\("Dssi") \\ "name" \> "DSSI Gemini South"
       }
     }
-    "proposal with dssi blueprints at Gemini North must migrate to ʻAlopeke, REL-3349" in {
+    "proposal with dssi blueprints at Gemini North must migrate to 'Alopeke, REL-3349" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi_gn.xml")))
 
       val converted = UpConverter.convert(xml)


### PR DESCRIPTION
Reports with the Hawaiian okina "apostrophe-like" character were making this display as `#Alopeke`. I changed to the apostrophe to fix this.