### PR TITLE
REL-503: removed WFS selection in multiple instrument webforms

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -338,11 +338,11 @@
 				<input value="SIDE_LOOKING" name="IssPort" checked="checked" type="radio" />
 				side-looking (3 reflections) </td>
 			</tr>
-			<tr>
+			<!--tr>
 				<td colspan="4">Wavefront sensor for tip-tilt compensation: 
 				<input value="PWFS" name="Type" type="radio" /> PWFS
 				<input value="OIWFS" name="Type" checked="checked"  type="radio" /> OIWFS
-			</tr>
+			</tr-->
 			<!-- Make these as hidden parameters -->
 			<input value="OUT" name="fieldLens" checked="checked" type="hidden" />
 			<input name="guideSep" size="5" value="0.0" type="hidden" />

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -446,7 +446,7 @@
 				side-looking (3 reflections) </td>
 			</tr>
 			<tr>
-				<td colspan="4">Wavefront sensor for tip-tilt compensation: <input value="PWFS" name="Type" type="radio" /> PWFS  <input value="OIWFS" name="Type" checked="checked" type="radio" /> OIWFS </td>
+				<!--td colspan="4">Wavefront sensor for tip-tilt compensation: <input value="PWFS" name="Type" type="radio" /> PWFS  <input value="OIWFS" name="Type" checked="checked" type="radio" /> OIWFS </td-->
 			</tr>
 			<tr>
 				<td colspan="4">

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -455,15 +455,13 @@
 				<td colspan="2" height="21">Instrument port: <input value="SIDE_LOOKING" name="IssPort" checked="checked" type="radio" />
 				side-looking (3 reflections) </td>
 			</tr>
-			<tr>
-
+			<!--tr>
 				<td colspan="2" height="21">Wavefront sensor for tip-tilt compensation:
                     <input value="PWFS" name="Type" checked="checked" type="radio" /> PWFS
                     <input value="OIWFS" name="Type" type="radio" /> OIWFS
 					<input value="AOWFS" name="Type" type="radio" />Altair
                 </td>
-			</tr>
-
+			</tr-->
 			<tr>
 				<td colspan="4" height="50" valign="bottom"><b>Altair properties:</b><i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10269','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
 			</tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -307,10 +307,10 @@
 				<td colspan="4">Instrument port: <input value="UP_LOOKING" name="IssPort" checked="checked" type="radio" /> up-looking (2 reflections)  <input value="SIDE_LOOKING" name="IssPort" type="radio" />
 				side-looking (3 reflections) </td>
 			</tr>
-			<tr>
+			<!--tr>
 				<td colspan="4">Wavefront sensor for tip-tilt compensation: <input value="PWFS" name="Type" checked="checked" type="radio" /> PWFS   (no OIWFS) </td>
 
-			</tr>
+			</tr-->
 			<tr>
 				<td colspan="4">
 				<p align="right">

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
@@ -383,16 +383,10 @@
 				<input value="UP_LOOKING" name="IssPort" checked="checked" type="radio" />
 				up-looking port</td>
 			</tr>
-			<tr>
-				<td height="40"> </td>
-			</tr>
-			<tr>
-
-			</tr>
-			<tr>
-				<td colspan="4"><b>Wavefront sensor: </b><input value="PWFS" name="Type" type="radio" /> PWFS
-				<input value="AOWFS" name="Type" checked="checked" type="radio" />Altair</td>
-			</tr>
+			<!--tr>
+				<!--td colspan="4"><b>Wavefront sensor: </b><input value="PWFS" name="Type" type="radio" /> PWFS
+				<input value="AOWFS" name="Type" checked="checked" type="radio" />Altair</td-->
+			<!--/tr-->
 			<tr>
 				<td colspan="4" height="50" valign="bottom"><b>Altair properties:</b><i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10269','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
@@ -325,9 +325,9 @@
 
 				side-looking (3 reflections) </td>
 			</tr>
-			<tr>
+			<!--tr>
 				<td colspan="4">Wavefront sensor for tip-tilt compensation: <input value="PWFS" name="Type" checked="checked" type="radio" /> PWFS   (no OIWFS) </td>
-			</tr>
+			</tr-->
 			<tr>
 				<td colspan="4">
 


### PR DESCRIPTION
If I need to remove the Altair properties selections from NIFS and GNIRS webforms, let me know.