### PR TITLE
REL-3384: Added warning to PIT build.sbt file.

### DIFF
--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -44,7 +44,7 @@ def common(pv: Version) = AppConfig(
     // line out for PIT production releases.
     // (I think it seems to work if you quit sbt, change it, restart sbt,
     // clean, compile, and then build the PIT.)
-    "edu.gemini.pit.test"                     -> "true",
+    //"edu.gemini.pit.test"                     -> "true",
     
     "edu.gemini.ags.host"                     -> "gnauxodb.gemini.edu",
     "edu.gemini.ags.port"                     -> "8443"

--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -38,7 +38,14 @@ def common(pv: Version) = AppConfig(
     "org.osgi.framework.storage.clean"        -> "onFirstInit",
     "org.osgi.framework.startlevel.beginning" -> "100",
     "org.osgi.framework.bootdelegation"       -> "*",
-    "edu.gemini.pit.test"                     -> "false",
+    
+    // NOTE: changing this flag to false works in certain circumstances
+    // but is entirely unreliable. It is better to simply comment this
+    // line out for PIT production releases.
+    // (I think it seems to work if you quit sbt, change it, restart sbt,
+    // clean, compile, and then build the PIT.)
+    "edu.gemini.pit.test"                     -> "true",
+    
     "edu.gemini.ags.host"                     -> "gnauxodb.gemini.edu",
     "edu.gemini.ags.port"                     -> "8443"
   ),


### PR DESCRIPTION
The PIT `build.sbt` file has a property to indicate whether it is a test build or not.

After some investigation, I found that even if the property is changed from `true` to `false` or vice versa, there are many instances in which the compiled code retains the former value, and this has been quite problematic in the past with regards to making release builds.

The most reliable way to make a release build is to simply comment the line out as it defaults to `false`: hence the addition of the warning comment here.

It is used in `AppMode.scala`:
https://github.com/gemini-hlsw/ocs/blob/develop/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/model/AppMode.scala