### PR TITLE
REL-3390: GHOST Asterism model updates.

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/MagnitudeConstraints.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/MagnitudeConstraints.scala
@@ -1,7 +1,8 @@
 package edu.gemini.catalog.api
 
 import edu.gemini.spModel.core.SiderealTarget
-import edu.gemini.spModel.core.{BandsList, MagnitudeBand, Magnitude}
+import edu.gemini.spModel.core.{BandsList, Magnitude, MagnitudeBand}
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.MagnitudeAdjuster
 
 import scalaz._
 import Scalaz._
@@ -58,6 +59,13 @@ sealed trait MagnitudeFilter {
  */
 trait ConstraintsAdjuster[T] {
   def adjust(t: T, mc: MagnitudeConstraints): MagnitudeConstraints
+}
+
+object ConstraintsAdjuster {
+  def fromMagnitudeAdjuster[M <: MagnitudeAdjuster]: ConstraintsAdjuster[M] = new ConstraintsAdjuster[M] {
+    override def adjust(t: M, mc: MagnitudeConstraints): MagnitudeConstraints =
+      mc.adjust(_ + t.getAdjustment(mc.searchBands))
+  }
 }
 
 /**

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -6,8 +6,6 @@ import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env.Asterism
 import java.time.Instant
 
-import edu.gemini.spModel.gemini.ghost.GhostAsterism.GuideFiberState.Disabled
-
 import scalaz._
 import Scalaz._
 
@@ -132,7 +130,7 @@ object GhostAsterism {
       StandardResolution.guideFiberState(targets.ifu1, cc)
 
     def ifu2GuideFiberState(cc: CloudCover): GuideFiberState = {
-      targets.ifu2.map(t => StandardResolution.guideFiberState(t, cc)).getOrElse(Disabled)
+      targets.ifu2.map(t => StandardResolution.guideFiberState(t, cc)).getOrElse(GuideFiberState.Disabled)
     }
 
     override def copyWithClonedTargets: Asterism =
@@ -141,7 +139,7 @@ object GhostAsterism {
 
   object StandardResolution {
     def guideFiberState(e: Either[Coordinates, GhostTarget], cc: CloudCover): GuideFiberState =
-      e.rightMap(t => GhostTarget.standardResGuideFiberState(t, cc)).right.getOrElse(Disabled)
+      e.rightMap(t => GhostTarget.standardResGuideFiberState(t, cc)).right.getOrElse(GuideFiberState.Disabled)
   }
 
   /** GHOST standard resolution asterism types.

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -170,17 +170,17 @@ object GhostAsterism {
 
     def defaultBasePosition(when: Option[Instant]): Option[Coordinates] = this match {
       case SingleTarget(t)    => t.coordinates(when)
-      case DualTarget(t1,t2)  => extrapolateCoords(t1.coordinates(when), t2.coordinates(when))
-      case TargetPlusSky(t,s) => extrapolateCoords(t.coordinates(when), Some(s))
-      case SkyPlusTarget(s,t) => extrapolateCoords(Some(s), t.coordinates(when))
+      case DualTarget(t1,t2)  => interpolateCoords(t1.coordinates(when), t2.coordinates(when))
+      case TargetPlusSky(t,s) => interpolateCoords(t.coordinates(when), Some(s))
+      case SkyPlusTarget(s,t) => interpolateCoords(Some(s), t.coordinates(when))
     }
   }
 
   object GhostStandardResTargets {
-    def extrapolateCoords(c1Opt: Option[Coordinates], c2Opt: Option[Coordinates]): Option[Coordinates] = for {
+    def interpolateCoords(c1Opt: Option[Coordinates], c2Opt: Option[Coordinates]): Option[Coordinates] = for {
       c1 <- c1Opt
       c2 <- c2Opt
-    } yield c1.interpolate(c2, 0.5d)
+    } yield c1.interpolate(c2, 0.5)
 
     case class SingleTarget(target: GhostTarget) extends GhostStandardResTargets
     case class DualTarget(target1: GhostTarget, target2: GhostTarget) extends GhostStandardResTargets

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProperMotion.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProperMotion.scala
@@ -20,4 +20,9 @@ object ProperMotion {
   val deltaDec: ProperMotion @> DeclinationAngularVelocity    = Lens(t => Store(s => t.copy(deltaDec = s), t.deltaDec))
   val epoch:    ProperMotion @> Epoch                         = Lens(t => Store(s => t.copy(epoch = s), t.epoch))
 
+  // Warning: This assumes the same epoch across proper motion.
+  // We use it in GhostAsterism to simplify, where we assume same epoch.
+  implicit val monoid: Monoid[ProperMotion] = Monoid.instance(
+    (pm1,pm2) => ProperMotion(pm1.deltaRA |+| pm2.deltaRA, pm1.deltaDec |+| pm2.deltaDec),
+    zero)
 }


### PR DESCRIPTION
This PR does three things:

1. Makes (hopefully all of) the model updates for GHOST targets / asterisms for now as per discussions with Steve.
2. Turns (I don't know if this is a bad idea due to possibly differing epochs) `ProperMotion` into a `Monoid`. Either way, I suspect we're going to have to assume same epochs at some point, as we were before in `DualTarget`, or throw an exception. This greatly simplifies adding `Option[ProperMotion]`s.
3. Refactors the code for making magnitude adjustments based on conditions out of both `edu.gemini.spModel.gemini.ghost` and the `edu.gemini.catalog` API and puts it into `SPSiteQuality`, where it probably belongs.