### PR TITLE
REL-3293: Stop PI ToO trigger attempt in inactive program

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/obscomp/package.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/obscomp/package.scala
@@ -1,0 +1,10 @@
+package edu.gemini.spModel.gemini
+
+import scalaz.Equal
+
+package object obscomp {
+
+  implicit val EqualActive: Equal[SPProgram.Active] =
+    Equal.equalA
+
+}

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/ObsEditValidator.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/ObsEditValidator.scala
@@ -4,6 +4,8 @@ import edu.gemini.shared.util.VersionComparison.{Same, Older, Newer, Conflicting
 import edu.gemini.sp.vcs2.MergeCorrection._
 import edu.gemini.sp.vcs2.ObsEdit.{ObsDelete, ObsUpdate, ObsCreate}
 import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.gemini.obscomp._
+import edu.gemini.spModel.gemini.obscomp.SPProgram.Active
 import edu.gemini.spModel.gemini.security._
 import edu.gemini.spModel.gemini.security.UserRolePrivileges._
 import edu.gemini.spModel.obs._
@@ -22,7 +24,7 @@ import Scalaz._
 /**
  * Evaluates whether a local observation edit should be considered legal.
  */
-class ObsEditValidator(privs: UserRolePrivileges, too: TooType) {
+class ObsEditValidator(privs: UserRolePrivileges, too: TooType, active: Active) {
   import ObsEditValidator._
 
   def isLegal(edit: ObsEdit): Boolean = {
@@ -35,6 +37,7 @@ class ObsEditValidator(privs: UserRolePrivileges, too: TooType) {
 
       (   privs === PI
        && too =/= TooType.none
+       && active === Active.YES
        && isTooSwitch(local.status)
        && remote.forall(o => isTooSwitch(o.status))
       )
@@ -85,8 +88,8 @@ class ObsEditValidator(privs: UserRolePrivileges, too: TooType) {
 
 object ObsEditValidator {
 
-  def apply(pid: SPProgramID, hasPermission: PermissionCheck, too: TooType): VcsAction[ObsEditValidator] =
-    userRolePrivileges(pid, hasPermission).map(new ObsEditValidator(_, too))
+  def apply(pid: SPProgramID, hasPermission: PermissionCheck, too: TooType, active: Active): VcsAction[ObsEditValidator] =
+    userRolePrivileges(pid, hasPermission).map(new ObsEditValidator(_, too, active))
 
   def userRolePrivileges(pid: SPProgramID, hasPermission: PermissionCheck): VcsAction[UserRolePrivileges] = {
     val somePid = Some(pid)

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdObservation2.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdObservation2.java
@@ -761,6 +761,7 @@ public final class EdObservation2 extends OtItemEditor<ISPObservation, SPObserva
             // PI can set it directly to Ready. Otherwise the PI can only set to
             // Phase2 or For Review.
             if (Too.isToo(getNode()) &&
+                    getProgramDataObject().isActive() &&
                     ((current == ObsPhase2Status.ON_HOLD) ||
                      (ObservationStatus.computeFor(getNode()) == ObservationStatus.READY))) {
                 _editorPanel.phase2StatusBox.setEnabledObject(ObsPhase2Status.ON_HOLD, true);


### PR DESCRIPTION
ToO trigger attempts in inactive programs are not actually carried out, but nothing stops a PI from trying.  That is, the OT allows the PI to toggle a ToO observation from "on hold" to "prepared" and submit the update.  Nothing indicates that the trigger attempt will ultimately fail.  This PR addresses the problem in both the UI and during the sync.  In particular:

* The OT observation editor will no longer allow a  PI to change the observation status of an "on hold" or "prepared" ToO observation in an inactive program.

* Nevertheless, before a sync the OT might be working with a copy of the program that is still marked active though it is in fact now been made inactive in the database.  Therefore we raise a sync permission error when we detect a trigger attempt in a now inactive program.