### PR TITLE
REL-3391: Added missing OSGi export package for GHOST.

### DIFF
--- a/bundle/edu.gemini.pot/build.sbt
+++ b/bundle/edu.gemini.pot/build.sbt
@@ -75,6 +75,7 @@ OsgiKeys.exportPackage := Seq(
   "edu.gemini.spModel.gemini.flamingos2.blueprint",
   "edu.gemini.spModel.gemini.flamingos2.test",
   "edu.gemini.spModel.gemini.gems",
+  "edu.gemini.spModel.gemini.ghost",
   "edu.gemini.spModel.gemini.gmos",
   "edu.gemini.spModel.gemini.gmos.blueprint",
   "edu.gemini.spModel.gemini.gmos.test",


### PR DESCRIPTION
I forgot to add GHOST to the `build.sbt` `OSGi.exportPackages`.

After this, the SPDB and OT run fine, and GHOST does not yet (which is what we want) appear in the instrument list in the OT.