### PR TITLE
REL-3406: Fix AlmostEqual for Angles.

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/VISITOR_BP.txt
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/VISITOR_BP.txt
@@ -6,13 +6,3 @@ Observations identified by LibraryIDs indicated with {}.
 
 INCLUDE {1} IN target-specific Scheduling Group
 SET Name from Phase-I
-
-
-
-
-What about Alopeke in OverheadsSpec?
-They are defined in OVerheads, thankfully.
-
-
-JIRA: 3406: Fix AlmostEquals for angles.
-Could be nice to have this in developmem!!!

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/VISITOR_BP.txt
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/VISITOR_BP.txt
@@ -7,3 +7,12 @@ Observations identified by LibraryIDs indicated with {}.
 INCLUDE {1} IN target-specific Scheduling Group
 SET Name from Phase-I
 
+
+
+
+What about Alopeke in OverheadsSpec?
+They are defined in OVerheads, thankfully.
+
+
+JIRA: 3406: Fix AlmostEquals for angles.
+Could be nice to have this in developmem!!!

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
@@ -51,7 +51,12 @@ object AlmostEqual {
         (a - b).abs < 0.00001
     }
 
-  implicit val AngleAlmostEqual = by((_: Angle).toDegrees)
+  implicit val AngleAlmostEqual: AlmostEqual[Angle] = new AlmostEqual[Angle] {
+    override def almostEqual(a: Angle, b: Angle): Boolean = {
+      (a.toDegrees ~= b.toDegrees) || (a.toDegrees + b.toDegrees - 360.0 ~= Angle.zero.toDegrees)
+    }
+  }
+
   implicit val RightAscensionAngularVelocityAlmostEqual = by((_: RightAscensionAngularVelocity).velocity.masPerYear)
   implicit val DeclinationAngularVelocityAlmostEqual = by((_: DeclinationAngularVelocity).velocity.masPerYear)
   implicit val RightAscensionAlmostEqual = by((_: RightAscension).toAngle)

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqual.scala
@@ -48,7 +48,7 @@ object AlmostEqual {
   implicit val DoubleAlmostEqual =
     new AlmostEqual[Double] {
       def almostEqual(a: Double, b: Double) =
-        (a - b).abs < 0.00001
+        (a - b).abs <= 1e-5
     }
 
   implicit val AngleAlmostEqual: AlmostEqual[Angle] = new AlmostEqual[Angle] {

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqualSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqualSpec.scala
@@ -22,7 +22,7 @@ object AlmostEqualSpec extends Specification with ScalaCheck with Arbitraries wi
 
   "Adding a very large offset to an angle" should {
     "result in an angle considered not equal to the original" ! forAll { (a: Angle) =>
-      !(a ~= (a + largeDiff)) || !(a ~= (a - largeDiff))
+      !(a ~= (a + largeDiff)) && !(a ~= (a - largeDiff))
     }
   }
 }

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqualSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/AlmostEqualSpec.scala
@@ -1,0 +1,28 @@
+package edu.gemini.spModel.core
+
+import org.scalacheck.Prop._
+import org.specs2.mutable.Specification
+
+import AlmostEqual._
+import org.specs2.ScalaCheck
+
+import scalaz._
+import Scalaz._
+
+
+object AlmostEqualSpec extends Specification with ScalaCheck with Arbitraries with Helpers {
+  val smallDiff: Angle = Angle.fromDegrees(1e-6)
+  val largeDiff: Angle = Angle.fromDegrees(1e-2)
+
+  "Adding a very minute offset to an angle" should {
+    "result in an angle considered almost equal to the original" ! forAll { (a : Angle) =>
+      (a ~= (a + smallDiff)) && (a ~= (a - smallDiff))
+    }
+  }
+
+  "Adding a very large offset to an angle" should {
+    "result in an angle considered not equal to the original" ! forAll { (a: Angle) =>
+      !(a ~= (a + largeDiff)) || !(a ~= (a - largeDiff))
+    }
+  }
+}


### PR DESCRIPTION
In the previous implementation:
`!(Angle.fromDegrees(359.999999) ~= Angle.zero)`.

This fixes that.