### PR TITLE
REL-3411: synchronize access to formatter

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/SPTargetPio.java
@@ -19,9 +19,15 @@ public class SPTargetPio {
 
     private static final String _TARGET = "target";
 
-    public static final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.FULL);
+    // DateFormat is not synchronized so it must be kept private and accessed
+    // through synchronized methods.
+    private static final DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.FULL);
     static {
         formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    public static synchronized String formatDate(final Date date) {
+        return formatter.format(date);
     }
 
     public static synchronized Date parseDate(final String dateStr) {

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2016A/PlutoDemotionTest.scala
@@ -7,6 +7,8 @@ import edu.gemini.spModel.target.{SPTargetPio, SPTarget}
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 import org.junit.{Assert, Test}
 
+import java.util.Date
+
 import scala.collection.JavaConverters._
 
 class PlutoDemotionTest extends MigrationTest {
@@ -28,7 +30,7 @@ class PlutoDemotionTest extends MigrationTest {
             e.toList match {
               case List((t, c)) =>
 
-                  Assert.assertEquals("ValidAt", "10/28/15 7:39:58 PM UTC", SPTargetPio.formatter.format(t))
+                  Assert.assertEquals("ValidAt", "10/28/15 7:39:58 PM UTC", SPTargetPio.formatDate(new Date(t)))
                   Assert.assertEquals("RA",      "15:41:38.379", c.ra.toAngle.formatHMS)
                   Assert.assertEquals("Dec",     "-15:52:28.70", c.dec.formatDMS)
 


### PR DESCRIPTION
This PR synchronizes access to a `DateFormat` object to prevent a potential test case failure.  I had originally intended to switch to `java.time.format.DateTimeFormatter` so that synchronization wouldn't be necessary but the existing `SPTargetPio.parseDate` method seemed complicated and would have to be modified.