### PR TITLE
REL-3279: Use full exposure time for GMOS in ITC

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -107,7 +107,6 @@ public abstract class InstGmosCommon<
 
     public static final PropertyDescriptor ADC_PROP;
     public static final PropertyDescriptor AMP_GAIN_SETTING_PROP;
-//    public static final PropertyDescriptor AMP_GAIN_READ_COMBO_PROP;
 
     public static final PropertyDescriptor BUILTIN_ROI_PROP;
     public static final PropertyDescriptor CUSTOM_ROI_PROP;
@@ -132,6 +131,10 @@ public abstract class InstGmosCommon<
     public static final PropertyDescriptor SHUFFLE_OFFSET_PROP;
     public static final PropertyDescriptor NUM_NS_CYCLES_PROP;
     public static final PropertyDescriptor DETECTOR_ROWS_PROP;
+
+    // This is a derived property whose value is equal to the number of n&s
+    // offset positions.
+    public static final String             NS_STEP_COUNT_PROP_NAME = "nsStepCount";
 
     public static final PropertyDescriptor IS_MOS_PREIMAGING_PROP;
 
@@ -269,18 +272,6 @@ public abstract class InstGmosCommon<
         POS_ANGLE_PROP = initProp("posAngle", query_no, iter_no);
         CUSTOM_SLIT_WIDTH = initProp("customSlitWidth", query_yes, iter_no);
         POS_ANGLE_CONSTRAINT_PROP = initProp("posAngleConstraint", query_no, iter_no);
-
-        /*
-        try {
-            AMP_GAIN_READ_COMBO_PROP = new PropertyDescriptor("gainReadCombo", InstGmosCommon.class);
-            PropertySupport.setQueryable(AMP_GAIN_READ_COMBO_PROP,false);
-            PropertySupport.setIterable(AMP_GAIN_READ_COMBO_PROP,true);
-            AMP_GAIN_READ_COMBO_PROP.setDisplayName("CCD Readout");
-            PRIVATE_PROP_MAP.put(AMP_GAIN_READ_COMBO_PROP.getName(), AMP_GAIN_READ_COMBO_PROP);
-        } catch (IntrospectionException ex) {
-            throw new RuntimeException(ex);
-        }
-        */
     }
 
 
@@ -1645,9 +1636,14 @@ public abstract class InstGmosCommon<
 
         sc.putParameter(DefaultParameter.getInstance(DTAX_OFFSET_PROP.getName(), getDtaXOffset()));
 
+        sc.putParameter(DefaultParameter.getInstance(USE_NS_PROP, useNS()));
+
         if (useNS()) {
             sc.putParameter(DefaultParameter.getInstance(USE_ELECTRONIC_OFFSETTING_PROP.getName(),
                     isUseElectronicOffsetting()));
+
+            sc.putParameter(DefaultParameter.getInstance(NS_STEP_COUNT_PROP_NAME,
+                    getPosList().size()));
 
             sc.putParameter(DefaultParameter.getInstance(NUM_NS_CYCLES_PROP.getName(),
                     getNsNumCycles()));
@@ -1661,8 +1657,6 @@ public abstract class InstGmosCommon<
 
         sc.putParameter(DefaultParameter.getInstance(DETECTOR_MANUFACTURER_PROP_NAME,
                 getDetectorManufacturer()));
-
-//        sc.putParameter(DefaultParameter.getInstance(AMP_GAIN_READ_COMBO_PROP.getName(), getGainReadCombo()));
 
         return sc;
     }
@@ -1911,4 +1905,5 @@ public abstract class InstGmosCommon<
     public ScienceAreaGeometry getVignettableScienceArea() {
         return GmosScienceAreaGeometry$.MODULE$;
     }
+
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/FullExposureTime.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/gmos/FullExposureTime.scala
@@ -1,0 +1,76 @@
+package edu.gemini.spModel.gemini.gmos
+
+import edu.gemini.spModel.config2.{ Config, ItemKey }
+import edu.gemini.spModel.gemini.calunit.calibration.CalDictionary.OBS_TYPE_ITEM
+import edu.gemini.spModel.gemini.gmos.InstGmosCommon.{ NS_STEP_COUNT_PROP_NAME, NUM_NS_CYCLES_PROP, USE_NS_PROP }
+import edu.gemini.spModel.obscomp.InstConstants.{ EXPOSURE_TIME_PROP, OBSERVE_TYPE_PROP }
+
+import edu.gemini.spModel.seqcomp.SeqConfigNames.{ INSTRUMENT_CONFIG_NAME, OBSERVE_CONFIG_NAME }
+
+import java.time.Duration
+
+import scalaz._
+import Scalaz._
+
+/** Adds support for calculating and inserting "full" exposure time for GMOS,
+  * even for nod and shuffle steps.  Nod and shuffle takes a number of exposures
+  * per step (cycle count * offset position step count) so the full exposure
+  * time is the nominal instrument exposure time times the nod and shuffle count.
+  */
+object FullExposureTime {
+
+  private object keys {
+    val StepCount:        ItemKey = new ItemKey(s"$INSTRUMENT_CONFIG_NAME:$NS_STEP_COUNT_PROP_NAME")
+    val CycleCount:       ItemKey = new ItemKey(s"$INSTRUMENT_CONFIG_NAME:${NUM_NS_CYCLES_PROP.getName}")
+    val UseNs:            ItemKey = new ItemKey(s"$INSTRUMENT_CONFIG_NAME:${USE_NS_PROP.getName}")
+    val ExposureTime:     ItemKey = new ItemKey(s"$INSTRUMENT_CONFIG_NAME:$EXPOSURE_TIME_PROP")
+    val ObsType:          ItemKey = OBS_TYPE_ITEM.key
+  }
+
+  private implicit class ConfigOps(c: Config) {
+
+    import keys._
+
+    def value(k: ItemKey): Option[Object] =
+      Option(c.getItemValue(k))
+
+    def useNs: Boolean =
+     value(UseNs).map {
+       case b: java.lang.Boolean => b.booleanValue
+       case _                    => false
+     }.getOrElse(false)
+
+    def isNsObsType: Boolean =
+      value(ObsType).map { o =>
+        InstGmosCommon.isNodAndShuffleableObsType(o.toString)
+      }.getOrElse(false)
+
+    def count(k: ItemKey): Int =
+      value(k).map {
+        case i: java.lang.Integer => i.intValue
+        case _                    => 0
+      }.filter(_ >= 0).getOrElse(0)
+
+    def nsStepCount: Int =
+      count(StepCount)
+
+    def nsCycleCount: Int =
+      count(CycleCount)
+
+    def exposureTime: Duration =
+      value(ExposureTime).map {
+        case d: java.lang.Double => Duration.ofMillis((d.doubleValue * 1000.0).round)
+        case _                   => Duration.ofMillis(0)
+      }.filter(_.toMillis >= 0).getOrElse(Duration.ZERO)
+
+    def fullExposureTime: Duration =
+      exposureTime.multipliedBy(if (useNs && isNsObsType) nsStepCount * nsCycleCount else 1)
+  }
+
+  /** Calculates full exposure time, even for nod and shuffle steps. */
+  def asDuration(c: Config): Duration =
+    c.fullExposureTime
+
+  def asDoubleSecs(c: Config): Double =
+    asDuration(c).toMillis.toDouble / 1000.0
+}


### PR DESCRIPTION
This PR updates the OT ITC to use full nod and shuffle time for GMOS observations.  Normally, the ITC reports single exposure time from the sequence, but the total time on source for nod and shuffle should be multiplied by the cycle count and the number of positions (usually 2).

Unfortunately after a couple of days of working on this, I couldn't come up with a more general solution. The ITC works with config steps so I initially added a `fullExposureTime` property to the sequence for GMOS and had ITC prefer `fullExposureTime` to `exposureTime` when present.  Unfortunately that adds another "exposure time" to the sequence display tables which gets confusing, particularly in the ITC. 