### PR TITLE
REL-3395: GHOST P2 check to ensure supported asterism type

### DIFF
--- a/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/AbstractRuleTest.java
+++ b/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/AbstractRuleTest.java
@@ -11,6 +11,7 @@ import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gemini.altair.AltairAowfsGuider;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.altair.InstAltair;
+import edu.gemini.spModel.gemini.ghost.Ghost;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
 import edu.gemini.spModel.gemini.michelle.InstMichelle;
@@ -147,6 +148,13 @@ public class AbstractRuleTest {
 
     protected ISPObsComponent addMichelle() throws SPUnknownIDException, SPTreeStateException, SPNodeNotLocalException {
         final ISPObsComponent obsComp = createObsComp(new InstMichelle());
+        obscomps.add(obsComp);
+        obs.setObsComponents(obscomps);
+        return obsComp;
+    }
+
+    protected ISPObsComponent addGhost() throws SPUnknownIDException, SPTreeStateException, SPNodeNotLocalException {
+        final ISPObsComponent obsComp = createObsComp(new Ghost());
         obscomps.add(obsComp);
         obs.setObsComponents(obscomps);
         return obsComp;

--- a/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/GeneralRuleTest.java
+++ b/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/GeneralRuleTest.java
@@ -6,6 +6,7 @@ import edu.gemini.p2checker.rules.general.GeneralRule;
 import edu.gemini.pot.sp.*;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import org.junit.Test;
+import org.scalacheck.Gen;
 
 import java.util.List;
 
@@ -99,5 +100,20 @@ public final class GeneralRuleTest extends AbstractRuleTest {
         final Problem p = problems.get(0);
         assertEquals(Problem.Type.ERROR, p.getType());
         assertTrue(p.toString(), p.toString().startsWith(ALTAIR_MESSAGE));
+    }
+
+    @Test
+    public void testAsterismType() throws SPUnknownIDException, SPTreeStateException, SPNodeNotLocalException {
+        // This should add GHOST, and then add an asterism of type Single, which is incompatible.
+        addGhost();
+        addTargetObsCompEmpty();
+
+        final ObservationElements elems = new ObservationElements(obs);
+        final GeneralRule rules = new GeneralRule();
+        final List<Problem> problems = rules.check(elems).getProblems();
+        assertEquals(1, problems.size());
+        final Problem p = problems.get(0);
+        assertEquals(Problem.Type.ERROR, p.getType());
+        assertTrue(p.toString(), p.toString().contains("unsupported asterism"));
     }
 }

--- a/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/GeneralRuleTest.java
+++ b/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/GeneralRuleTest.java
@@ -6,7 +6,6 @@ import edu.gemini.p2checker.rules.general.GeneralRule;
 import edu.gemini.pot.sp.*;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import org.junit.Test;
-import org.scalacheck.Gen;
 
 import java.util.List;
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -47,8 +47,8 @@ object GhostAsterism {
     implicit val EqualGuideFiberState: Equal[GuideFiberState] =
       Equal.equalA[GuideFiberState]
 
-    def fromString(s: String): Option[GuideFiberState]
-    = All.findLeft(_.name == s)
+    def fromString(s: String): Option[GuideFiberState] =
+      All.findLeft(_.name == s)
 
     def unsafeFromString(s: String): GuideFiberState =
       fromString(s).getOrElse(sys.error(s"Unknown guide fiber state: $s"))
@@ -113,9 +113,8 @@ object GhostAsterism {
   /** GHOST standard resolution asterism type.  In this mode, one or two targets (one of which may be
     * a sky position) are observed simultaneously with both IFUs at standard resolution.
     */
-  final case class StandardResolution(
-                                       targets: GhostStandardResTargets,
-                                       override val base: Option[Coordinates]) extends GhostAsterism {
+  final case class StandardResolution(targets: GhostStandardResTargets,
+                                      override val base: Option[Coordinates]) extends GhostAsterism {
     import GhostStandardResTargets._
 
     override def allSpTargets: NonEmptyList[SPTarget] = targets match {


### PR DESCRIPTION
This adds a Phase 2 check that determines if the current `Asterism` in the `TargetEnvironment` is compatible with the instrument. If not, an error is generated.

I also added an old-school test case to the existing `GeneralRule` test suite to make sure that when a `Ghost` observation is configured with an unsupported asterism type (`Single`), then it generates the appropriate error.