### PR TITLE
REL-3390B: GHOST major refactor

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
@@ -1,8 +1,6 @@
 package edu.gemini.spModel.target.env;
 
 import edu.gemini.pot.sp.Instrument;
-import edu.gemini.pot.sp.SPComponentBroadType;
-import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.gemini.ghost.AsterismConverters;
 import edu.gemini.spModel.gemini.ghost.GhostAsterism$;
@@ -19,23 +17,23 @@ public enum AsterismType {
      */
     Single("single", "Single Target", None.instance(), Asterism$.MODULE$::createSingleAsterism),
 
-    GhostStandardResolutionSingleTarget("ghostStandardRes", "Single Target",
+    GhostSingleTarget("ghostSingleTarget", "Single Target",
             new Some<>(AsterismConverters.GhostSingleTargetConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptyStandardResolutionSingleTargetAsterism),
+            GhostAsterism$.MODULE$::createEmptySingleTargetAsterism),
 
-    GhostStandardResolutionDualTarget("ghostStandardRes", "Dual Target",
+    GhostDualTarget("ghostDualTarget", "Dual Target",
             new Some<>(AsterismConverters.GhostDualTargetConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptyStandardResolutionDualTargetAsterism),
+            GhostAsterism$.MODULE$::createEmptyDualTargetAsterism),
 
-    GhostStandardResolutionTargetPlusSky("ghostStandardRes", "SRIFU1 Target, SRIFU2 Sky",
+    GhostTargetPlusSky("ghostTargetPlusSky", "SRIFU1 Target, SRIFU2 Sky",
             new Some<>(AsterismConverters.GhostTargetPlusSkyConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptyStandardResolutionTargetPlusSkyAsterism),
+            GhostAsterism$.MODULE$::createEmptyTargetPlusSkyAsterism),
 
-    GhostStandardResolutionSkyPlusTarget("ghostStandardRes", "SRIFU1 Sky, SRIFU2 Target",
+    GhostSkyPlusTarget("ghostSkyPlusTarget", "SRIFU1 Sky, SRIFU2 Target",
             new Some<>(AsterismConverters.GhostSkyPlusTargetConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptyStandardResolutionSkyPlusTargetAsterism),
+            GhostAsterism$.MODULE$::createEmptySkyPlusTargetAsterism),
 
-    GhostHighResolution("ghostHighRes", "High Resolution",
+    GhostHighResolution("ghostHighResolution", "High Resolution",
             new Some<>(AsterismConverters.GhostHighResolutionConverter$.MODULE$),
             GhostAsterism$.MODULE$::createEmptyHighResolutionAsterism),
     ;
@@ -65,10 +63,10 @@ public enum AsterismType {
         switch (instType) {
             case Ghost:
                 final Set<AsterismType> s = new TreeSet<>();
-                s.add(GhostStandardResolutionSingleTarget);
-                s.add(GhostStandardResolutionDualTarget);
-                s.add(GhostStandardResolutionTargetPlusSky);
-                s.add(GhostStandardResolutionSkyPlusTarget);
+                s.add(GhostSingleTarget);
+                s.add(GhostDualTarget);
+                s.add(GhostTargetPlusSky);
+                s.add(GhostSkyPlusTarget);
                 s.add(GhostHighResolution);
                 return Collections.unmodifiableSet(s);
             default:

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismConverters.scala
@@ -13,7 +13,6 @@ import Scalaz._
   */
 object AsterismConverters {
   import GhostAsterism._
-  import GhostAsterism.GhostStandardResTargets._
 
   type BasePosition = Option[Coordinates]
   type SkyPosition  = Option[Coordinates]
@@ -28,11 +27,11 @@ object AsterismConverters {
       env.getAsterism match {
         case ga: GhostAsterism =>
           ga match {
-            case StandardResolution(SingleTarget(t), b)     => creator(env, t, None, None, b).some
-            case StandardResolution(DualTarget(t1, t2), b)  => creator(env, t1, t2.some, None, b).some
-            case StandardResolution(TargetPlusSky(t, s), b) => creator(env, t, None, s.some, b).some
-            case StandardResolution(SkyPlusTarget(s, t), b) => creator(env, t, None, s.some, b).some
-            case HighResolution(t, s, b)                    => creator(env, t, None, s, b).some
+            case SingleTarget(t, b)      => creator(env, t, None, None, b).some
+            case DualTarget(t1, t2, b)   => creator(env, t1, t2.some, None, b).some
+            case TargetPlusSky(t, s, b)  => creator(env, t, None, s.some, b).some
+            case SkyPlusTarget(s, t, b)  => creator(env, t, None, s.some, b).some
+            case HighResolution(t, s, b) => creator(env, t, None, s, b).some
           }
         case _                                              => None
       }
@@ -47,7 +46,7 @@ object AsterismConverters {
     override def name: String = "GhostAsterism.SingleTarget"
 
     override protected def creator(env: TargetEnvironment, t: GhostTarget, t2: Option[GhostTarget], s: SkyPosition, b: BasePosition): TargetEnvironment = {
-      val asterism    = StandardResolution(SingleTarget(t), b)
+      val asterism    = SingleTarget(t, b)
       val userTargets = appendCoords(appendTarget(env.getUserTargets, gT2UT(t2)), s)
       TargetEnvironment.createWithClonedTargets(asterism, env.getGuideEnvironment, userTargets)
     }
@@ -57,7 +56,7 @@ object AsterismConverters {
     override def name: String = "GhostAsterism.DualTarget"
 
     override protected def creator(env: TargetEnvironment, t: GhostTarget, t2: Option[GhostTarget], s: SkyPosition, b: BasePosition): TargetEnvironment = {
-      val asterism    = StandardResolution(DualTarget(t, t2.getOrElse(GhostTarget.empty)), b)
+      val asterism    = DualTarget(t, t2.getOrElse(GhostTarget.empty), b)
       val userTargets = appendCoords(env.getUserTargets, s)
       TargetEnvironment.createWithClonedTargets(asterism, env.getGuideEnvironment, userTargets)
     }
@@ -67,7 +66,7 @@ object AsterismConverters {
     override def name: String = "GhostAsterism.TargetPlusSky"
 
     override protected def creator(env: TargetEnvironment, t: GhostTarget, t2: Option[GhostTarget], s: SkyPosition, b: BasePosition): TargetEnvironment = {
-      val asterism    = StandardResolution(TargetPlusSky(t, s.getOrElse(Coordinates.zero)), b)
+      val asterism    = TargetPlusSky(t, s.getOrElse(Coordinates.zero), b)
       val userTargets = appendTarget(env.getUserTargets, gT2UT(t2))
       TargetEnvironment.createWithClonedTargets(asterism, env.getGuideEnvironment, userTargets)
     }
@@ -77,7 +76,7 @@ object AsterismConverters {
     override def name: String = "GhostAsterism.SkyPlusTarget"
 
     override protected def creator(env: TargetEnvironment, t: GhostTarget, t2: Option[GhostTarget], s: SkyPosition, b: BasePosition): TargetEnvironment = {
-      val asterism    = StandardResolution(SkyPlusTarget(s.getOrElse(Coordinates.zero), t), b)
+      val asterism    = SkyPlusTarget(s.getOrElse(Coordinates.zero), t, b)
       val userTargets = appendTarget(env.getUserTargets, gT2UT(t2))
       TargetEnvironment.createWithClonedTargets(asterism, env.getGuideEnvironment, userTargets)
     }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -84,7 +84,7 @@ object Ghost {
         val toc = oc.getDataObject.asInstanceOf[TargetObsComp]
 
         // Create a single target GHOST asterism as the default.
-        val a   = GhostAsterism.createEmptyStandardResolutionSingleTargetAsterism
+        val a   = GhostAsterism.createEmptySingleTargetAsterism
         val env = TargetEnvironment.create(a)
 
         toc.setTargetEnvironment(env)
@@ -94,7 +94,7 @@ object Ghost {
         case Success(_)               =>
           // Do nothing.
         case Failure(ex: SPException) =>
-          throw new RuntimeException("Unable to create and initialize GHOST target environment")
+          throw new RuntimeException("Unable to create and initialize GHOST target environment", ex)
         case Failure(_)               =>
           // This should never happen.
           throw new RuntimeException("Unknown failure in creating GHOST target environment")

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostParamSetCodecs.scala
@@ -1,30 +1,17 @@
 package edu.gemini.spModel.gemini.ghost
 
-import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostStandardResTargets._
 import edu.gemini.spModel.gemini.ghost.GhostAsterism._
-import edu.gemini.spModel.pio.{ParamSet, Pio}
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.StandardResolution._
 import edu.gemini.spModel.pio.codec._
-import edu.gemini.spModel.pio.xml.PioXmlFactory
-import edu.gemini.spModel.target.env.AsterismType
 import edu.gemini.spModel.target.TargetParamSetCodecs._
-
-import scalaz._
-import Scalaz._
 
 
 object GhostParamSetCodecs {
   private val IFU1 = "ifu1"
   private val IFU2 = "ifu2"
   private val Target = "target"
-  private val Targets = "targets"
   private val ExplicitGuideFiberState = "explicitGuideFiberState"
-  private val SingleTarget  = "singleTarget"
-  private val DualTarget    = "dualTarget"
-  private val TargetPlusSky = "targetPlusSky"
-  private val SkyPlusTarget = "skyPlusTarget"
-  private val GhostType = "ghostType"
   private val Base = "base"
-  private val Tag = "tag"
   
   implicit val GuideFiberStateParamCodec: ParamCodec[GuideFiberState] =
     ParamCodec[String].xmap(GuideFiberState.unsafeFromString, _.name)
@@ -37,83 +24,29 @@ object GhostParamSetCodecs {
   implicit val SingleTargetParamSetCodec: ParamSetCodec[SingleTarget] =
     ParamSetCodec.initial(emptySingleTarget)
       .withParamSet(IFU1, SingleTargetIFU1)
+      .withOptionalParamSet(Base, SingleTargetBase)
 
   implicit val DualTargetParamSetCodec: ParamSetCodec[DualTarget] =
     ParamSetCodec.initial(emptyDualTarget)
       .withParamSet(IFU1, DualTargetIFU1)
       .withParamSet(IFU2, DualTargetIFU2)
+      .withOptionalParamSet(Base, DualTargetBase)
 
   implicit val TargetPlusSkyParamSetCodec: ParamSetCodec[TargetPlusSky] =
     ParamSetCodec.initial(emptyTargetPlusSky)
       .withParamSet(IFU1, TargetPlusSkyIFU1)
       .withParamSet(IFU2, TargetPlusSkyIFU2)
+      .withOptionalParamSet(Base, TargetPlusSkyBase)
 
   implicit val SkyPlusTargetParamSetCodec: ParamSetCodec[SkyPlusTarget] =
     ParamSetCodec.initial(emptySkyPlusTarget)
       .withParamSet(IFU1, SkyPlusTargetIFU1)
       .withParamSet(IFU2, SkyPlusTargetIFU2)
-
-  implicit val GhostStandardResTargetsParamSetCodec: ParamSetCodec[GhostStandardResTargets] =
-    new ParamSetCodec[GhostStandardResTargets] {
-      val pf = new PioXmlFactory
-
-      override def encode(key: String, a: GhostStandardResTargets): ParamSet = {
-        val (tag, ps) = a match {
-          case t: SingleTarget  => (SingleTarget,  SingleTargetParamSetCodec.encode(key, t))
-          case t: DualTarget    => (DualTarget,    DualTargetParamSetCodec.encode(key, t))
-          case t: TargetPlusSky => (TargetPlusSky, TargetPlusSkyParamSetCodec.encode(key, t))
-          case t: SkyPlusTarget => (SkyPlusTarget, SkyPlusTargetParamSetCodec.encode(key, t))
-        }
-        Pio.addParam(pf, ps, Tag, tag)
-        ps
-      }
-
-      override def decode(ps: ParamSet): PioError \/ GhostStandardResTargets = {
-        Option(ps.getParam(Tag)).map(_.getValue) \/> MissingKey(Tag) flatMap {
-          case SingleTarget  => SingleTargetParamSetCodec.decode(ps)
-          case DualTarget    => DualTargetParamSetCodec.decode(ps)
-          case TargetPlusSky => TargetPlusSkyParamSetCodec.decode(ps)
-          case SkyPlusTarget => SkyPlusTargetParamSetCodec.decode(ps)
-          case other           => UnknownTag(other, "GhostStandardResTargets").left
-        }
-      }
-    }
-
-  implicit val StandardResolutionParamSetCodec: ParamSetCodec[StandardResolution] =
-    ParamSetCodec.initial(StandardResolution.empty)
-      .withParamSet(Targets, StandardResolution.Targets)
-      .withOptionalParamSet(Base, StandardResolution.Base)
+      .withOptionalParamSet(Base, SkyPlusTargetBase)
 
   implicit val HighResolutionParamSetCodec: ParamSetCodec[HighResolution] =
     ParamSetCodec.initial(HighResolution.empty)
       .withParamSet(IFU1, HighResolution.IFU1)
       .withOptionalParamSet(IFU2, HighResolution.IFU2)
       .withOptionalParamSet(Base, HighResolution.Base)
-
-  implicit val GhostAsterismParamSetCodec: ParamSetCodec[GhostAsterism] =
-    new ParamSetCodec[GhostAsterism] {
-      val pf = new PioXmlFactory
-
-      override def encode(key: String, a: GhostAsterism): ParamSet = {
-        val tag = a.asterismType.tag
-        val ps = a match {
-          case a: StandardResolution => StandardResolutionParamSetCodec.encode(key, a)
-          case a: HighResolution     => HighResolutionParamSetCodec.encode(key, a)
-        }
-        Pio.addParam(pf, ps, GhostType, tag)
-        ps
-      }
-
-      override def decode(ps: ParamSet): PioError \/ GhostAsterism = {
-        Option(ps.getParam(GhostType)).map(_.getValue) \/> MissingKey(GhostType) flatMap {
-          case
-            AsterismType.GhostStandardResolutionSingleTarget.tag  |
-            AsterismType.GhostStandardResolutionDualTarget.tag    |
-            AsterismType.GhostStandardResolutionTargetPlusSky.tag |
-            AsterismType.GhostStandardResolutionSkyPlusTarget.tag => StandardResolutionParamSetCodec.decode(ps)
-          case AsterismType.GhostHighResolution.tag               => HighResolutionParamSetCodec.decode(ps)
-          case other                                              => UnknownTag(other, "GhostAsterism").left
-        }
-      }
-    }
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -132,9 +132,14 @@ object Asterism {
       val pf = new PioXmlFactory
 
       def encode(key: String, a: Asterism): ParamSet = {
-        val (tag, ps) = a match {
-          case a: Single         => (AsterismType.Single.tag, Single.SingleParamSetCodec.encode(key, a))
-          case a: GhostAsterism  => ("ghostAsterism",         GhostParamSetCodecs.GhostAsterismParamSetCodec.encode(key, a))
+        val tag = a.asterismType.tag
+        val ps = a match {
+          case a: Single                       => Single.SingleParamSetCodec.encode(key, a)
+          case a: GhostAsterism.SingleTarget   => GhostParamSetCodecs.SingleTargetParamSetCodec.encode(key, a)
+          case a: GhostAsterism.DualTarget     => GhostParamSetCodecs.DualTargetParamSetCodec.encode(key, a)
+          case a: GhostAsterism.TargetPlusSky  => GhostParamSetCodecs.TargetPlusSkyParamSetCodec.encode(key, a)
+          case a: GhostAsterism.SkyPlusTarget  => GhostParamSetCodecs.SkyPlusTargetParamSetCodec.encode(key, a)
+          case a: GhostAsterism.HighResolution => GhostParamSetCodecs.HighResolutionParamSetCodec.encode(key, a)
         }
         Pio.addParam(pf, ps, "tag", tag)
         ps
@@ -142,8 +147,12 @@ object Asterism {
 
       def decode(ps: ParamSet): PioError \/ Asterism =
         (Option(ps.getParam("tag")).map(_.getValue) \/> MissingKey("tag")) flatMap {
-          case AsterismType.Single.tag => Single.SingleParamSetCodec.decode(ps)
-          case "ghostAsterism"         => GhostParamSetCodecs.GhostAsterismParamSetCodec.decode(ps)
+          case AsterismType.Single.tag              => Single.SingleParamSetCodec.decode(ps)
+          case AsterismType.GhostSingleTarget.tag   => GhostParamSetCodecs.SingleTargetParamSetCodec.decode(ps)
+          case AsterismType.GhostDualTarget.tag     => GhostParamSetCodecs.DualTargetParamSetCodec.decode(ps)
+          case AsterismType.GhostTargetPlusSky.tag  => GhostParamSetCodecs.TargetPlusSkyParamSetCodec.decode(ps)
+          case AsterismType.GhostSkyPlusTarget.tag  => GhostParamSetCodecs.SkyPlusTargetParamSetCodec.decode(ps)
+          case AsterismType.GhostHighResolution.tag => GhostParamSetCodecs.HighResolutionParamSetCodec.decode(ps)
           case other                   => UnknownTag(other, "Asterism").left
         }
     }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/ghost/AsterismConvertersSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/ghost/AsterismConvertersSpec.scala
@@ -2,115 +2,84 @@ package edu.gemini.spModel.gemini.ghost
 
 import edu.gemini.spModel.core.AlmostEqual._
 import edu.gemini.spModel.gemini.ghost.AsterismConverters._
-import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostStandardResTargets._
-import edu.gemini.spModel.gemini.ghost.GhostAsterism._
 import edu.gemini.spModel.target.env.{Almosts, Arbitraries, TargetEnvironment}
 
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
+import org.scalacheck.{Gen, Prop}
 import org.scalacheck.Prop._
 
 import scalaz._
 import Scalaz._
 
-// TODO:GHOST Fill these in with more test cases? Right now, we only check the lossless conversions, complete fails,
-// and expected successes without delving deeper into the correctness of the conversions in the latter case.
-// I am currently unsure if there is a way to test conversions that move information into UserTargets without
-// duplicating the actual conversion code, or testing with specific, concrete examples.
+
 object AsterismConvertersSpec extends Specification with ScalaCheck with Arbitraries with Almosts {
 
   "Asterism conversion" should {
     "Convert SingleTarget to itself losslessly" in {
-      forAll(genStandardResAsterismTargetEnvironment) { env =>
-        env.getAsterism.asInstanceOf[StandardResolution].targets.isInstanceOf[SingleTarget] ==> {
-          GhostSingleTargetConverter.convert(env).exists(_ ~= env) should beTrue
-        }
-      }
+      oneWayTest(genGhostSingleTargetTargetEnvironment, GhostSingleTargetConverter)
     }
 
     "Convert DualTarget to itself losslessly" in {
-      forAll(genStandardResAsterismTargetEnvironment) { env =>
-        env.getAsterism.asInstanceOf[StandardResolution].targets.isInstanceOf[DualTarget] ==> {
-          GhostDualTargetConverter.convert(env).exists(_ ~= env) should beTrue
-        }
-      }
+      oneWayTest(genGhostDualTargetTargetEnvironment, GhostDualTargetConverter)
     }
 
     "Convert TargetPlusSky to itself losslessly" in {
-      forAll(genStandardResAsterismTargetEnvironment) { env =>
-        env.getAsterism.asInstanceOf[StandardResolution].targets.isInstanceOf[TargetPlusSky] ==> {
-          GhostTargetPlusSkyConverter.convert(env).exists(_ ~= env) should beTrue
-        }
-      }
+      oneWayTest(genGhostTargetPlusSkyTargetEnvironment, GhostTargetPlusSkyConverter)
     }
 
     "Convert SkyPlusTarget to itself losslessly" in {
-      forAll(genStandardResAsterismTargetEnvironment) { env =>
-        env.getAsterism.asInstanceOf[StandardResolution].targets.isInstanceOf[SkyPlusTarget] ==> {
-          GhostSkyPlusTargetConverter.convert(env).exists(_ ~= env) should beTrue
-        }
-      }
-    }
-
-    "Convert between TargetPlusSky and SkyPlusTarget losslessly" in {
-      forAll(genStandardResAsterismTargetEnvironment) { env =>
-        env.getAsterism.asInstanceOf[StandardResolution].targets.isInstanceOf[SkyPlusTarget] ==> {
-          convertBackAndForth(env, GhostTargetPlusSkyConverter, GhostSkyPlusTargetConverter).exists(_ ~= env) should beTrue
-        }
-      }
-    }
-
-    "Convert between SkyPlusTarget and TargetPlusSky losslessly" in {
-      forAll(genStandardResAsterismTargetEnvironment) { env =>
-        env.getAsterism.asInstanceOf[StandardResolution].targets.isInstanceOf[TargetPlusSky] ==> {
-          convertBackAndForth(env, GhostSkyPlusTargetConverter, GhostTargetPlusSkyConverter).exists(_ ~= env) should beTrue
-        }
-      }
-    }
-
-    "Convert between TargetPlusSky and HighResolution losslessly" in {
-      forAll(genStandardResAsterismTargetEnvironment) { env =>
-        env.getAsterism.asInstanceOf[StandardResolution].targets.isInstanceOf[TargetPlusSky] ==> {
-          convertBackAndForth(env, GhostHighResolutionConverter, GhostTargetPlusSkyConverter).exists(_ ~= env) should beTrue
-        }
-      }
-    }
-
-    "Convert between SkyPlusTarget and HighResolution losslessly" in {
-      forAll(genStandardResAsterismTargetEnvironment) { env =>
-        env.getAsterism.asInstanceOf[StandardResolution].targets.isInstanceOf[SkyPlusTarget] ==> {
-          convertBackAndForth(env, GhostHighResolutionConverter, GhostSkyPlusTargetConverter).exists(_ ~= env) should beTrue
-        }
-      }
+      oneWayTest(genGhostSkyPlusTargetTargetEnvironment, GhostSkyPlusTargetConverter)
     }
 
     "Convert HighResolution to itself losslessly" in {
-      forAll(genHighResAsterismTargetEnvironment) { env =>
-        GhostHighResolutionConverter.convert(env).exists(_ ~= env) should beTrue
-      }
+      oneWayTest(genHighResAsterismTargetEnvironment, GhostHighResolutionConverter)
+    }
+
+    "Convert between TargetPlusSky and SkyPlusTarget losslessly" in {
+      twoWayTest(genGhostTargetPlusSkyTargetEnvironment, GhostSkyPlusTargetConverter, GhostTargetPlusSkyConverter)
+    }
+
+    "Convert between SkyPlusTarget and TargetPlusSky losslessly" in {
+      twoWayTest(genGhostSkyPlusTargetTargetEnvironment, GhostTargetPlusSkyConverter, GhostSkyPlusTargetConverter)
+    }
+
+    "Convert between TargetPlusSky and HighResolution losslessly" in {
+      twoWayTest(genGhostTargetPlusSkyTargetEnvironment, GhostHighResolutionConverter, GhostTargetPlusSkyConverter)
+    }
+
+    "Convert between SkyPlusTarget and HighResolution losslessly" in {
+      twoWayTest(genGhostSkyPlusTargetTargetEnvironment, GhostHighResolutionConverter, GhostSkyPlusTargetConverter)
     }
 
     "Be able to convert any GHOST asterism to any other" in {
       forAll(genGhostAsterismTargetEnvironment) { env =>
-        GhostSingleTargetConverter.convert(env)   should not(beEmpty)
-        GhostDualTargetConverter.convert(env)     should not(beEmpty)
-        GhostTargetPlusSkyConverter.convert(env)  should not(beEmpty)
-        GhostSkyPlusTargetConverter.convert(env)  should not(beEmpty)
-        GhostHighResolutionConverter.convert(env) should not(beEmpty)
+        GhostConverters.forall(_.convert(env) should not(beEmpty))
       }
     }
 
     "Not convert any Single asterism to a GHOST asterism" in {
       forAll(genSingleAsterismTargetEnvironment) { env =>
-        GhostSingleTargetConverter.convert(env)   should beEmpty
-        GhostDualTargetConverter.convert(env)     should beEmpty
-        GhostTargetPlusSkyConverter.convert(env)  should beEmpty
-        GhostSkyPlusTargetConverter.convert(env)  should beEmpty
-        GhostHighResolutionConverter.convert(env) should beEmpty
+        GhostConverters.forall(_.convert(env) should beEmpty)
       }
     }
   }
 
-  private def convertBackAndForth(env: TargetEnvironment, c1: GhostAsterismConverter, c2: GhostAsterismConverter): Option[TargetEnvironment] =
-    c1.convert(env).flatMap(c2.convert)
+  private val GhostConverters: List[AsterismConverter] = List(
+    GhostSingleTargetConverter,
+    GhostDualTargetConverter,
+    GhostTargetPlusSkyConverter,
+    GhostSkyPlusTargetConverter,
+    GhostHighResolutionConverter
+  )
+
+  private def oneWayTest(gen: Gen[TargetEnvironment], converter: AsterismConverter): Prop =
+    forAll(gen) { env =>
+      converter.convert(env).exists(_ ~= env) should beTrue
+    }
+
+  private def twoWayTest(gen: Gen[TargetEnvironment], c1: GhostAsterismConverter, c2: GhostAsterismConverter): Prop =
+    forAll(gen) { env =>
+      c1.convert(env).flatMap(c2.convert).exists(_ ~= env) should beTrue
+    }
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
@@ -4,7 +4,6 @@ import edu.gemini.shared.util.immutable.{ImOption, Option => GemOption}
 import edu.gemini.spModel.core.{AlmostEqual, Target}
 import edu.gemini.spModel.core.AlmostEqual.{AlmostEqualOps, AlmostEqualOption}
 import edu.gemini.spModel.gemini.ghost.GhostAsterism
-import edu.gemini.spModel.gemini.ghost.GhostAsterism.{GhostStandardResTargets, GhostTarget, HighResolution, StandardResolution}
 import edu.gemini.spModel.target.SPTarget
 
 import scala.collection.JavaConverters._
@@ -29,11 +28,11 @@ trait Almosts {
 
   implicit val AlmostEqualSPTarget =
     new AlmostEqual[SPTarget] {
-      val Now = ImOption.apply[java.lang.Long](System.currentTimeMillis)
+      val Now: GemOption[java.lang.Long] = ImOption.apply[java.lang.Long](System.currentTimeMillis)
 
       def almostEqual(at: SPTarget, bt: SPTarget): Boolean = {
         (at.getName === bt.getName) &&
-          (at.getRaDegrees(Now) ~= bt.getRaDegrees(Now)) &&
+          (at.getRaDegrees(Now)  ~= bt.getRaDegrees(Now)) &&
           (at.getDecDegrees(Now) ~= bt.getDecDegrees(Now))
       }
     }
@@ -128,64 +127,51 @@ trait Almosts {
     AlmostEqual[SPTarget].contramap[Asterism.Single](_.t)
 
 
-  implicit val GhostTargetAlmostEqual: AlmostEqual[GhostTarget] =
-    new AlmostEqual[GhostTarget] {
-      override def almostEqual(a: GhostTarget, b: GhostTarget): Boolean =
+  implicit val GhostTargetAlmostEqual: AlmostEqual[GhostAsterism.GhostTarget] =
+    new AlmostEqual[GhostAsterism.GhostTarget] {
+      override def almostEqual(a: GhostAsterism.GhostTarget, b: GhostAsterism.GhostTarget): Boolean =
         (a.spTarget ~= b.spTarget) && (a.explicitGuideFiberState === b.explicitGuideFiberState)
     }
 
-  implicit val GhostStdResSingleTargetAlmostEqual: AlmostEqual[GhostStandardResTargets.SingleTarget] =
-    AlmostEqual[GhostTarget].contramap[GhostStandardResTargets.SingleTarget](_.target)
-
-  implicit val GhostStdResDualTargetAlmostEqual: AlmostEqual[GhostStandardResTargets.DualTarget] =
-    new AlmostEqual[GhostStandardResTargets.DualTarget] {
-      override def almostEqual(a: GhostStandardResTargets.DualTarget, b: GhostStandardResTargets.DualTarget): Boolean =
-        (a.target1 ~= b.target1) && (a.target2 ~= b.target2)
+  implicit val GhostSingleTargetAlmostEqual: AlmostEqual[GhostAsterism.SingleTarget] =
+    new AlmostEqual[GhostAsterism.SingleTarget] {
+      override def almostEqual(a: GhostAsterism.SingleTarget, b: GhostAsterism.SingleTarget): Boolean =
+        (a.target ~= b.target) && (a.base ~= b.base)
     }
 
-  implicit val GhostStdResTargetPlusSkyAlmostEqual: AlmostEqual[GhostStandardResTargets.TargetPlusSky] =
-    new AlmostEqual[GhostStandardResTargets.TargetPlusSky] {
-      override def almostEqual(a: GhostStandardResTargets.TargetPlusSky, b: GhostStandardResTargets.TargetPlusSky): Boolean =
-        (a.target ~= b.target) && (a.sky ~= b.sky)
-    }
-  implicit val GhostStdResSkyPlusTargetAlmostEqual: AlmostEqual[GhostStandardResTargets.SkyPlusTarget] =
-    new AlmostEqual[GhostStandardResTargets.SkyPlusTarget] {
-      override def almostEqual(a: GhostStandardResTargets.SkyPlusTarget, b: GhostStandardResTargets.SkyPlusTarget): Boolean =
-        (a.target ~= b.target) && (a.sky ~= b.sky)
+  implicit val GhostDualTargetAlmostEqual: AlmostEqual[GhostAsterism.DualTarget] =
+    new AlmostEqual[GhostAsterism.DualTarget] {
+      override def almostEqual(a: GhostAsterism.DualTarget, b: GhostAsterism.DualTarget): Boolean =
+        (a.target1 ~= b.target1) && (a.target2 ~= b.target2) && (a.base ~= b.base)
     }
 
-  implicit val GhostAsterismStdResolutionAlmostEqual: AlmostEqual[GhostAsterism.StandardResolution] =
-    new AlmostEqual[GhostAsterism.StandardResolution] {
-      override def almostEqual(a: StandardResolution, b: StandardResolution): Boolean = (a.base ~= b.base) && ((a.targets, b.targets) match {
-        case (at: GhostStandardResTargets.SingleTarget,  bt: GhostStandardResTargets.SingleTarget)  => at ~= bt
-        case (at: GhostStandardResTargets.DualTarget,    bt: GhostStandardResTargets.DualTarget)    => at ~= bt
-        case (at: GhostStandardResTargets.TargetPlusSky, bt: GhostStandardResTargets.TargetPlusSky) => at ~= bt
-        case (at: GhostStandardResTargets.SkyPlusTarget, bt: GhostStandardResTargets.SkyPlusTarget) => at ~= bt
-        case _ => false
-      })
+  implicit val GhostTargetPlusSkyAlmostEqual: AlmostEqual[GhostAsterism.TargetPlusSky] =
+    new AlmostEqual[GhostAsterism.TargetPlusSky] {
+      override def almostEqual(a: GhostAsterism.TargetPlusSky, b: GhostAsterism.TargetPlusSky): Boolean =
+        (a.target ~= b.target) && (a.sky ~= b.sky) && (a.base ~= b.base)
+    }
+  implicit val GhostSkyPlusTargetAlmostEqual: AlmostEqual[GhostAsterism.SkyPlusTarget] =
+    new AlmostEqual[GhostAsterism.SkyPlusTarget] {
+      override def almostEqual(a: GhostAsterism.SkyPlusTarget, b: GhostAsterism.SkyPlusTarget): Boolean =
+        (a.target ~= b.target) && (a.sky ~= b.sky) && (a.base ~= b.base)
     }
 
   implicit val GhostAsterismHighResolutionAlmostEqual: AlmostEqual[GhostAsterism.HighResolution] =
     new AlmostEqual[GhostAsterism.HighResolution] {
-      override def almostEqual(a: HighResolution, b: HighResolution): Boolean =
+      override def almostEqual(a: GhostAsterism.HighResolution, b: GhostAsterism.HighResolution): Boolean =
         (a.ghostTarget ~= b.ghostTarget) && (a.sky ~= b.sky) && (a.base ~= b.base)
-    }
-
-  implicit val GhostAsterismAlmostEqual: AlmostEqual[GhostAsterism] =
-    new AlmostEqual[GhostAsterism] {
-      override def almostEqual(a: GhostAsterism, b: GhostAsterism): Boolean = (a,b) match {
-        case (a: GhostAsterism.StandardResolution, b: GhostAsterism.StandardResolution) => a ~= b
-        case (a: GhostAsterism.HighResolution,     b: GhostAsterism.HighResolution)     => a ~= b
-        case _ => false
-      }
     }
 
   implicit val AsterismAlmostEqual: AlmostEqual[Asterism] =
     new AlmostEqual[Asterism] {
       def almostEqual(a: Asterism, b: Asterism): Boolean =
         (a, b) match {
-          case (a: Asterism.Single, b: Asterism.Single) => a ~= b
-          case (a: GhostAsterism,   b: GhostAsterism)   => a ~= b
+          case (a: Asterism.Single,              b: Asterism.Single)              => a ~= b
+          case (a: GhostAsterism.SingleTarget,   b: GhostAsterism.SingleTarget)   => a ~= b
+          case (a: GhostAsterism.DualTarget,     b: GhostAsterism.DualTarget)     => a ~= b
+          case (a: GhostAsterism.TargetPlusSky,  b: GhostAsterism.TargetPlusSky)  => a ~= b
+          case (a: GhostAsterism.SkyPlusTarget,  b: GhostAsterism.SkyPlusTarget)  => a ~= b
+          case (a: GhostAsterism.HighResolution, b: GhostAsterism.HighResolution) => a ~= b
           case _ => false
         }
     }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/AsterismParamSetCodecSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/AsterismParamSetCodecSpec.scala
@@ -25,9 +25,11 @@ object AsterismParamSetCodecSpec extends Specification with ScalaCheck with Arbi
 
   "Asterism ParamSet Codecs" >> {
     close[Asterism.Single]
-    close[GhostAsterism.StandardResolution]
+    close[GhostAsterism.SingleTarget]
+    close[GhostAsterism.DualTarget]
+    close[GhostAsterism.TargetPlusSky]
+    close[GhostAsterism.SkyPlusTarget]
     close[GhostAsterism.HighResolution]
-    close[GhostAsterism]
     close[Asterism]
   }
 }

--- a/bundle/jsky.app.ot/src/main/resources/resources/conf/UIInfo.xml
+++ b/bundle/jsky.app.ot/src/main/resources/resources/conf/UIInfo.xml
@@ -388,13 +388,13 @@
       uiClassName="jsky.app.ot.gemini.flamingos2.EdCompInstFlamingos2"/>
     -->
 
-    <UIInfo site="GS"
+    <!--UIInfo site="GS"
             dataObject="edu.gemini.spModel.gemini.ghost.Ghost"
             name="GHOST instrument"
             type="instrument"
             imageKey="component.gif"
             shortDescription="The GHOST instrument is configured with this component."
-            uiClassName="jsky.app.ot.gemini.ghost.GhostEditor"/>
+            uiClassName="jsky.app.ot.gemini.ghost.GhostEditor"/-->
     <UIInfo
             site="GS"
             dataObject="edu.gemini.spModel.gemini.flamingos2.SeqConfigFlamingos2"

--- a/bundle/jsky.app.ot/src/main/resources/resources/conf/UIInfo.xml
+++ b/bundle/jsky.app.ot/src/main/resources/resources/conf/UIInfo.xml
@@ -388,13 +388,13 @@
       uiClassName="jsky.app.ot.gemini.flamingos2.EdCompInstFlamingos2"/>
     -->
 
-    <!--UIInfo site="GS"
+    <UIInfo site="GS"
             dataObject="edu.gemini.spModel.gemini.ghost.Ghost"
             name="GHOST instrument"
             type="instrument"
             imageKey="component.gif"
             shortDescription="The GHOST instrument is configured with this component."
-            uiClassName="jsky.app.ot.gemini.ghost.GhostEditor"/-->
+            uiClassName="jsky.app.ot.gemini.ghost.GhostEditor"/>
     <UIInfo
             site="GS"
             dataObject="edu.gemini.spModel.gemini.flamingos2.SeqConfigFlamingos2"

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -73,10 +73,10 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
 
     /** A list of available asterism types. */
     val asterismList: List[AsterismType] = List(
-      GhostStandardResolutionSingleTarget,
-      GhostStandardResolutionDualTarget,
-      GhostStandardResolutionTargetPlusSky,
-      GhostStandardResolutionSkyPlusTarget,
+      GhostSingleTarget,
+      GhostDualTarget,
+      GhostTargetPlusSky,
+      GhostSkyPlusTarget,
       GhostHighResolution
     )
 


### PR DESCRIPTION
This is a major refactoring of `GhostAsterism` to divvy up `StandardAsterism` into four subclasses, one for each type of standard asterism as per discussion with @swalker2m earlier today.

(It also includes REL-3395, as I branched from that PR to create this one.)

Everything else in here is a consequence of that refactor.

I think this is an improvement, especially to `AsterismType`, and simplifies a number of things.

This PR is largely to ensure that all test cases still pass and to get feedback from @swalker2m.