### PR TITLE
REL-3412: GMOS-S ITC fails with power-law input SED

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/PowerLawSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/PowerLawSpectrum.java
@@ -26,14 +26,9 @@ public class PowerLawSpectrum extends DefaultSampledSpectrum {
 
         final int n = (int) ((_end - _start) / _sampling + 1);
         double[] fluxArray = new double[n];
-
-
-        int i = 0;
-
-        for (double lam = _start; lam <= _end; lam += _sampling) {
+        for (int i = 0; i < n ; i++) {
+            double lam = _start + i * _sampling;
             fluxArray[i] = _pLawFlux(lam, powerLawIndex);
-            i++;
-
         }
 
         reset(fluxArray, _start, _sampling);

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/PowerLawSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/PowerLawSpectrum.java
@@ -24,7 +24,7 @@ public class PowerLawSpectrum extends DefaultSampledSpectrum {
         _start /= (1 + z);
         _end /= (1 + z);
 
-        final int n = (int) ((_end - _start) / _sampling + 1);
+        final int n = (int) Math.round((_end - _start) / _sampling + 1);
         double[] fluxArray = new double[n];
         for (int i = 0; i < n ; i++) {
             double lam = _start + i * _sampling;


### PR DESCRIPTION
The power-law generator was occasionally going 1 step beyond the predefined dimension of the array due to imprecision in representing the looped variable.  In the case I investigated (B600 @ 500nm) the loop was set to stop at 1181.97, but on what should have been the last step the wavelength was only at 1181.969999999 so it tried to loop through one more time and crashed.  To avoid this I changed the for loop to increment the index rather than the wavelength.
