### PR TITLE
REL-3388: Relabel obsolete components in the ITC web forms

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
@@ -103,8 +103,7 @@
     </tr> 
     <tr>
       <td colspan="3">
-        <p align="right"><input type="reset" value="reset">&nbsp; <input type="image" border="0" src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" width="78" height="24" align="absbottom"></p>
-
+          <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
       </td>
     </tr>
     <tr>
@@ -244,7 +243,7 @@
 
     <tr>
       <td colspan="3">
-        <p align="right"><input type="reset" value="reset">&nbsp; <input type="image" border="0" src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" width="78" height="24" align="absbottom"></p>
+        <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
       </td>
     </tr>
   </table>
@@ -282,10 +281,10 @@
     </tr>
 
     <tr>
-      <td colspan="4">CCD readout noise of 6 e-</td>
+      <td colspan="4">CCD readout noise: &nbsp; 6 e-</td>
     </tr>
     <tr>
-      <td colspan="4">CCD dark current of 20 e-/s</td>
+      <td colspan="4">CCD dark current: &nbsp; 20 e-/s</td>
     </tr>
 
     <tr>
@@ -313,8 +312,7 @@
     </tr>
     <tr>
       <td colspan="4">
-        <p align="right"><input type="reset" value="reset">&nbsp; <input type="image" border="0" src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" width="78" height="24" align="absbottom"></p>
-
+          <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
       </td>
     </tr>
   </table>
@@ -370,8 +368,7 @@
 
     <tr>
       <td colspan="6">
-        <p align="right"><input type="reset" value="reset">&nbsp; <input type="image" border="0" src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" width="78" height="24" align="absbottom"></p>
-
+          <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
       </td>
     </tr>
 
@@ -413,12 +410,17 @@
     <tr>
 
       <td colspan="3">
-        <p align="right"><input type="reset" value="reset">&nbsp; <input type="image" border="0" src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" width="78" height="24" align="absbottom"></p>
+          <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
       </td>
     </tr>
   </table>
-  <div align="center"><center><p><input type="submit" value="calculate"> <img src="spacer.gif" width="40" height="1" style="opacity:0.0"/><input type="reset" value="reset to defaults"> </p>
-  </center></div>
+  <div align="center">
+      <center>
+          <p>
+              <input type="submit" value="calculate"> <img src="spacer.gif" width="40" height="1" style="opacity:0.0"/><input type="reset" value="reset to defaults">
+          </p>
+     </center>
+  </div>
 
 </form>
 </div>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -252,7 +252,7 @@
 
             </tr>
             <tr>
-                <td>Camera: 0.18 arcsec/pix</td>
+                <td>Camera: &nbsp; 0.18 arcsec/pix</td>
 
                 <td>Disperser:
                     <select name="Disperser" size="1">
@@ -302,7 +302,7 @@
             </tr>
 
             <tr>
-                <td colspan="2">Read noise set for:</td>
+                <td colspan="2">Read mode:</td>
             </tr>
 
             <tr>
@@ -325,10 +325,10 @@
 
             </tr>
             <tr>
-                <td colspan="2">Dark current is 0.3 e-/s </td>
+                <td colspan="2">Dark current: &nbsp; 0.3 e-/s </td>
             </tr>
             <tr>
-                <td colspan="2">Gain is 4.44 e-/ADU </td>
+                <td colspan="2">Gain: &nbsp; 4.44 e-/ADU </td>
             </tr>
             <tr>
                 <td colspan="2">The Flamingos-2 Hawaii-II detector is ~1% linear up to 22,000 ADU.</td>
@@ -495,7 +495,6 @@
         <div align="center">
             <center>
                 <p>
-
                     <input value="Calculate" type="submit" /> <img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input value="Reset to defaults" type="reset" />
                 </p>
             </center>
@@ -504,5 +503,3 @@
 </div>
 </body>
 </html>
-
-

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -346,21 +346,19 @@
 				<td>Filter:
 					<select name="instrumentFilter" size="1">
 						<option value="NONE">none</option>
-						<option value="u_G0308">u' (350 nm)</option>
+
+						<option value="none" disabled></option>
+						<option value="none" disabled>Broad Band Filters:</option>
+						<option value="u_G0308">u' (350 nm) (UNAVAILABLE)</option>
 						<option selected="selected" value="g_G0301">g' (475 nm)</option>
 						<option value="r_G0303">r' (630 nm)</option>
 						<option value="i_G0302">i' (780 nm)</option>
 						<option value="z_G0304">z' (950 nm)</option>
 						<option value="Z_G0322">Z (876 nm)</option>
 						<option value="Y_G0323">Y (1010 nm)</option>
-						<option value="GG455_G0305">GG455</option>
-						<option value="OG515_G0306">OG515</option>
-						<option value="RG610_G0307">RG610</option>
-						<option value="g_G0301_GG455_G0305">g_G0301 + GG455_G0305 (506 nm)</option>
-						<option value="g_G0301_OG515_G0306">g_G0301 + OG515_G0306 (536 nm)</option>
-						<option value="r_G0303_RG610_G0307">r_G0303 + RG610_G0307 (657 nm)</option>
-						<option value="i_G0302_CaT_G0309">i_G0302 + CaT_G0309 (815 nm)</option>
-						<option value="z_G0304_CaT_G0309">z_G0304 + CaT_G0309 (890 nm)</option>
+
+						<option value="none" disabled></option>
+						<option value="none" disabled>Narrow Band Filters:</option>
 						<option value="HeII_G0320">HeII (468 nm)</option>
 						<option value="HeIIC_G0321">HeIIC (478 nm)</option>
 						<option value="OIII_G0318">[OIII] (499 nm)</option>
@@ -372,6 +370,21 @@
 						<option value="OVIC_G0346">OVIC (678 nm)</option>
 						<option value="CaT_G0309">CaT (860nm)</option>
 						<option value="DS920_G0312">DS920 (920nm)</option>
+
+						<option value="none" disabled></option>
+						<option value="none" disabled>Spectroscopy Blocking Filters:</option>
+						<option value="GG455_G0305">GG455</option>
+						<option value="OG515_G0306">OG515</option>
+						<option value="RG610_G0307">RG610</option>
+
+						<option value="none" disabled></option>
+						<option value="none" disabled>Filter Combinations:</option>
+						<option value="g_G0301_GG455_G0305">g_G0301 + GG455_G0305 (506 nm)</option>
+						<option value="g_G0301_OG515_G0306">g_G0301 + OG515_G0306 (536 nm)</option>
+						<option value="r_G0303_RG610_G0307">r_G0303 + RG610_G0307 (657 nm)</option>
+						<option value="i_G0302_CaT_G0309">i_G0302 + CaT_G0309 (815 nm)</option>
+						<option value="z_G0304_CaT_G0309">z_G0304 + CaT_G0309 (890 nm)</option>
+
 					</select>
 				</td>
 
@@ -423,8 +436,16 @@
 			</tr>
 			<tr>
 				<td colspan="2">
-					Amp gain:      <select name="AmpGain" size="1"><option value="LOW">Low</option><option value="HIGH">High</option></select>
-					Amp read mode: <select name="AmpReadMode" size="1"><option value="SLOW">Slow</option><option value="FAST">Fast</option></select>
+					Amp gain:
+					<select name="AmpGain" size="1">
+						<option value="LOW">Low</option>
+						<option value="HIGH">High</option>
+					</select> &nbsp; &nbsp;
+					Amp read mode:
+					<select name="AmpReadMode" size="1">
+						<option value="SLOW">Slow</option>
+						<option value="FAST">Fast</option>
+					</select>
 				</td>
 			</tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -345,9 +345,11 @@
 
             <tr>
                 <td>Filter:
-
                     <select name="instrumentFilter" size="1">
                         <option value="NONE">none</option>
+
+                        <option value="none" disabled></option>
+						<option value="none" disabled>Broad Band Filters:</option>
                         <option value="u_G0332">u' (350 nm)</option>
                         <option selected="selected" value="g_G0325">g' (475 nm)</option>
                         <option value="r_G0326">r' (630 nm)</option>
@@ -355,16 +357,9 @@
                         <option value="z_G0328">z' (950 nm)</option>
                         <option value="Z_G0343">Z (876 nm)</option>
                         <option value="Y_G0344">Y (1010 nm)</option>
-                        <option value="GG455_G0329">GG455 (680 nm)</option>
-                        <option value="OG515_G0330">OG515 (710 nm)</option>
-                        <option value="RG610_G0331">RG610 (750 nm)</option>
-                        <option value="RG780_G0334">RG780 (850 nm)</option>
-                        <option value="g_G0325_GG455_G0329">g_G0325 + GG455_G0329 (506 nm)</option>
-                        <option value="g_G0325_OG515_G0330">g_G0325 + OG515_G0330 (536 nm)</option>
-                        <option value="r_G0326_RG610_G0331">r_G0326 + RG610_G0331 (657 nm)</option>
-                        <option value="i_G0327_RG780_G0334">i_G0327 + RG780_G0334 (819 nm)</option>
-                        <option value="i_G0327_CaT_G0333">i_G0327 + CaT_G0333 (815 nm)</option>
-                        <option value="z_G0328_CaT_G0333">z_G0328 + CaT_G0333 (890nm)</option>
+
+						<option value="none" disabled></option>
+						<option value="none" disabled>Narrow Band Filters:</option>
                         <option value="HeII_G0340">HeII (468 nm)</option>
                         <option value="HeIIC_G0341">HeIIC (478 nm)</option>
                         <option value="OIII_G0338">[OIII] (499 nm)</option>
@@ -375,6 +370,23 @@
                         <option value="OVI_G0347">OVI (683 nm)</option>
                         <option value="OVIC_G0348">OVIC (678 nm)</option>
                         <option value="CaT_G0333">CaT (860 nm)</option>
+
+						<option value="none" disabled></option>
+						<option value="none" disabled>Spectroscopy Blocking Filters:</option>
+                        <option value="GG455_G0329">GG455 (680 nm)</option>
+                        <option value="OG515_G0330">OG515 (710 nm)</option>
+                        <option value="RG610_G0331">RG610 (750 nm)</option>
+                        <option value="RG780_G0334">RG780 (850 nm)</option>
+
+                        <option value="none" disabled></option>
+						<option value="none" disabled>Filter Combinations:</option>
+                        <option value="g_G0325_GG455_G0329">g_G0325 + GG455_G0329 (506 nm)</option>
+                        <option value="g_G0325_OG515_G0330">g_G0325 + OG515_G0330 (536 nm)</option>
+                        <option value="r_G0326_RG610_G0331">r_G0326 + RG610_G0331 (657 nm)</option>
+                        <option value="i_G0327_RG780_G0334">i_G0327 + RG780_G0334 (819 nm)</option>
+                        <option value="i_G0327_CaT_G0333">i_G0327 + CaT_G0333 (815 nm)</option>
+                        <option value="z_G0328_CaT_G0333">z_G0328 + CaT_G0333 (890nm)</option>
+
                     </select>
                 </td>
                 <td>Focal plane unit:
@@ -420,8 +432,16 @@
             </tr>
             <tr>
                 <td colspan="4">
-                    Amp gain:      <select name="AmpGain" size="1"><option value="LOW">Low</option><option value="HIGH">High</option></select>
-                    Amp read mode: <select name="AmpReadMode" size="1"><option value="SLOW">Slow</option><option value="FAST">Fast</option></select>
+                    Amp gain:
+                    <select name="AmpGain" size="1">
+                        <option value="LOW">Low</option>
+                        <option value="HIGH">High</option>
+                    </select> &nbsp; &nbsp;
+                    Amp read mode:
+                    <select name="AmpReadMode" size="1">
+                        <option value="SLOW">Slow</option>
+                        <option value="FAST">Fast</option>
+                    </select>
                 </td>
             </tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -401,7 +401,7 @@
 				<td colspan="4" height="38" valign="bottom"><b>Detector properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10277#detector','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
 			</tr>
 			<tr>
-				<td colspan="4">Read mode set for:  </td>
+				<td colspan="4">Read mode:</td>
 			</tr>
 			<tr>
 				<td colspan="4" align="left"> <input value="VERY_FAINT" name="ReadMode" type="radio" />
@@ -420,8 +420,7 @@
 				high background (i.e. thermal IR), typically for 3-5 µm observations</td>
 			</tr>
 			<tr>
-				<td colspan="4">Well depth set for:  </td>
-
+				<td colspan="4">Well depth:</td>
 			</tr>
 			<tr>
 				<td colspan="4" align="left"><input value="SHALLOW" name="WellDepth" checked="checked" type="radio" />
@@ -432,7 +431,7 @@
 				deep well; typically for 3-5µm observations</td>
 			</tr>
 			<tr>
-				<td colspan="4" height="21">Dark current of 0.1 e-/s </td>
+				<td colspan="4" height="21">Dark current: &nbsp; 0.1 e-/s</td>
 			</tr>
 		</tbody>
 	</table>
@@ -461,18 +460,19 @@
 				<td colspan="4" height="50" valign="bottom"><b>Altair properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10269','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
 			</tr>
 			<tr>
-				<td align="left">AO guide star <br />
-					separation: <input name="guideSep" size="5" value="0.0" type="text" />  arcsec</td>
-                <td> AO guide star brightness <br />
-					(R-band):
+				<td align="left">AO guide star separation: <input name="guideSep" size="5" value="0.0" type="text" /> arcsec</td>
+                <td> AO guide star brightness (R-band):
 				<input name="guideMag" size="5" value="12.0" type="text" /> mag</td>
 			</tr>
 			<tr>
 
 				<td align="left">Field Lens:
-				<input value="OUT" name="FieldLens" checked="checked" type="radio" /> OUT <input value="IN" name="FieldLens" size="1" type="radio" /> IN (Required for LGS)</td>
+					<input value="OUT" name="FieldLens" checked="checked" type="radio" /> OUT
+					<input value="IN" name="FieldLens" size="1" type="radio" /> IN (Required for LGS)</td>
 				<td>
-                  Altair Mode: <input value="NGS" name="GuideStarType" checked="checked" type="radio" /> NGS <input value="LGS" name="GuideStarType" size="1" type="radio" />LGS </p></td>
+                  Altair Mode:
+					<input value="NGS" name="GuideStarType" checked="checked" type="radio" /> NGS
+					<input value="LGS" name="GuideStarType" size="1" type="radio" />LGS </td>
 
 			</tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
@@ -332,21 +332,24 @@
                     <tr>
                         <td>Filter:</td>
                             <td colspan="3"><select name="Filter" size="1">
+								<option value="none" disabled>Broad band:</option>
                                 <option value="Z">Z (1.015 µm)</option>
                                 <option value="J">J (1.250 µm)</option>
                                 <option value="H">H (1.650 µm)</option>
                                 <option value="K_PRIME">K(prime) (2.120 µm)</option>
                                 <option value="K_SHORT">K(short) (2.150 µm)</option>
                                 <option value="K">K (2.200 µm)</option>
-                                <option value="J_CONTINUUM">J-continuum(1.207 µm)</option>
-                                <option value="H_CONTINUUM">H-continuum(1.570 µm)</option>
+								<option value="none" disabled></option>
+								<option value="none" disabled>Narrow band:</option>
+                                <option value="J_CONTINUUM">J-continuum (1.207 µm)</option>
+                                <option value="H_CONTINUUM">H-continuum (1.570 µm)</option>
                                 <option value="CH4_SHORT">CH4(short) (1.580 µm)</option>
                                 <option value="CH4_LONG">CH4(long) (1.690 µm)</option>
                                 <option value="K_CONTINUUM1">Ks-continuum (2.093 µm)</option>
                                 <option value="K_CONTINUUM2">Kl-continuum (2.270 µm)</option>
-                                <option value="HEI">HeI(1.083 µm)</option>
-                                <option value="PA_GAMMA">Pa(gamma)(1.094 µm)</option>
-                                <option value="PA_BETA">Pa(beta)(1.282 µm)</option>
+                                <option value="HEI">HeI (1.083 µm)</option>
+                                <option value="PA_GAMMA">Pa(gamma) (1.094 µm)</option>
+                                <option value="PA_BETA">Pa(beta) (1.282 µm)</option>
                                 <option value="FE_II">[FeII] (1.644 µm)</option>
                                 <option value="H20_ICE">H2O ice (2.000 µm)</option>
                                 <option value="HEI_2P2S">HeI (2p2s) (2.058 µm)</option>
@@ -370,20 +373,20 @@
             </tr>
             <tr>
                 <td colspan="4" align="right" height="21"><input value="BRIGHT" name="ReadMode" checked="checked" type="radio" />
-                Bright Objects (Low Noise Read=2, readnoise=28e-) </td>
+                Bright Objects (Low Noise Reads = 2, Read noise = 28e-) </td>
             </tr>
             <tr>
                 <td colspan="4" align="right" height="21"><input value="FAINT" name="ReadMode" type="radio" />
 
-                Faint Objects / Broad band imaging (Low Noise Read=8, readnoise=13e-) </td>
+                Faint Objects / Broad band imaging (Low Noise Reads = 8, Read noise = 13e-) </td>
             </tr>
             <tr>
                 <td colspan="4" align="right" height="21"><input value="VERY_FAINT" name="ReadMode" type="radio" />
-                Very Faint Objects / Narrow Band imaging (Low Noise Read = 16, readnoise=10e-) </td>
+                Very Faint Objects / Narrow Band imaging (Low Noise Reads = 16, Read noise = 10e-) </td>
             </tr>
             
             <tr>
-				<td colspan="4">Dark current of 0.01 e-/s/pix  </td>
+				<td colspan="4">Dark current: &nbsp; 0.01 e-/s/pix  </td>
 			</tr>
 			<!-- Telescope definition-->
 			<tr>
@@ -542,7 +545,6 @@
 	<div align="center">
 	<center>
 	<p>
-
 	<input value="Calculate" type="submit" /> <img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input value="Reset to defaults" type="reset" />
 	</p>
 	</center>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -289,28 +289,29 @@
 			</tr>
 
 			<tr>
-				<td colspan="4">Read noise of 4,000 e- per pixel</td>
+				<td colspan="4">Read noise: &nbsp; 4,000 e- per pixel</td>
 			</tr>
 			<tr>
-				<td colspan="4">Dark current of 270,000 e-/s per pixel</td>
+				<td colspan="4">Dark current: &nbsp; 270,000 e-/s per pixel</td>
 			</tr>
 			<!-- Telescope definition-->
 			<tr>
-
 				<td colspan="4" height="50" valign="bottom"><b>Telescope configuration:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10271','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>
 			</tr>
 			<tr>
 				<td colspan="4">Mirror coating: <input value="SILVER" name="Coating" checked="checked" type="radio" /> silver </td>
-
 			</tr>
 			<tr>
-				<td colspan="4">Instrument port: <input value="UP_LOOKING" name="IssPort" checked="checked" type="radio" /> up-looking (2 reflections)  <input value="SIDE_LOOKING" name="IssPort" type="radio" />
-				side-looking (3 reflections) </td>
+				<td colspan="4">Instrument port:
+					<input value="UP_LOOKING" name="IssPort" checked="checked" type="radio" /> up-looking (2 reflections)
+					<input value="SIDE_LOOKING" name="IssPort" type="radio" />side-looking (3 reflections)
+				</td>
 			</tr>
-			<!--tr>
-				<td colspan="4">Wavefront sensor for tip-tilt compensation: <input value="PWFS" name="Type" checked="checked" type="radio" /> PWFS   (no OIWFS) </td>
-
-			</tr-->
+			<tr>
+				<td colspan="4">Wavefront sensor for tip-tilt compensation:
+					<input value="PWFS" name="Type" checked="checked" type="radio" /> PWFS (no OIWFS)
+				</td>
+			</tr>
 			<tr>
 				<td colspan="4">
 					<p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
@@ -344,11 +344,11 @@
 				<td height="25"> Spectrum central wavelength:
 				<input name="instrumentCentralWavelength" size="5" value="2.20" type="text" /> µm</td>
 			</tr>
-			<!---->
+
 			<tr>
 				<td colspan="4" height="38" valign="bottom"><b>Detector properties:</b></td>
 			</tr>
-			<!---->
+
 			<tr>
 				<td colspan="4" height="20">Read mode: </td>
 
@@ -356,19 +356,18 @@
             <!-- REL-481 Update NIFS read noise estimates -->
 			<tr>
 				<td colspan="4" align="left" height="21"><input value="BRIGHT_OBJECT_SPEC" name="ReadMode" type="radio" />
-				 Medium background for observation of bright objects (standard stars, 15.4 e- read noise) </td>
+				 Medium background for observations of bright objects, e.g. standard stars (Read noise = 15.4 e-) </td>
 			</tr>
 			<tr>
 				<td colspan="4" align="left" height="21"><input value="MEDIUM_OBJECT_SPEC" name="ReadMode" checked="checked" type="radio" />
-					Low background for observation of faint objects (science targets, 8.1 e- read noise) </td>
+					Low background for observations of faint objects, e.g. science targets (Read noise = 8.1 e-) </td>
 			</tr>
 			<tr>
 				<td colspan="4" align="left" height="21"><input value="FAINT_OBJECT_SPEC" name="ReadMode" type="radio" />
-				Very low background for observation of faintest objects (faint science targets, 4.6 e- read noise) </td>
+				Very low background for observations of the faintest targets (Read noise = 4.6 e-) </td>
 			</tr>
 			<tr>
-
-				<td colspan="4" height="21">Dark current of 0.01 e-/s </td>
+				<td colspan="4" height="21">Dark current: &nbsp; 0.01 e-/s </td>
 			</tr>
 			<tr>
 				<td colspan="4" height="38" valign="bottom"><b>Telescope configuration:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10271','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>
@@ -391,20 +390,19 @@
 
 			</tr>
 			<tr>
-				<td>AO guide star <br />
-				separation:
+				<td>AO guide star separation:
 				<input name="guideSep" size="5" value="0.0" type="text" />  arcsec</td>
-				<td>AO guide star brightness <br />
-
-				(R-band):
+				<td>AO guide star brightness (R-band):
 				<input name="guideMag" size="5" value="12.0" type="text" /> mag</td>
 			</tr>
 			<tr>
 				<td>Field Lens:
-				<input value="OUT" name="FieldLens" checked="checked" type="radio" /> OUT <input value="IN" name="FieldLens" size="1" type="radio" /> IN(Required for LGS)</td>
+					<input value="OUT" name="FieldLens" checked="checked" type="radio" /> OUT
+					<input value="IN" name="FieldLens" size="1" type="radio" /> IN (Required for LGS)</td>
 
 				<td>Altair Mode:
-				<input value="NGS" name="GuideStarType" checked="checked" type="radio" /> NGS <input value="LGS" name="GuideStarType" size="1" type="radio" />LGS</td>
+					<input value="NGS" name="GuideStarType" checked="checked" type="radio" /> NGS
+					<input value="LGS" name="GuideStarType" size="1" type="radio" />LGS</td>
 			</tr>
 			<tr>
 				<td colspan="3">
@@ -541,7 +539,6 @@
 	<div align="center">
 	<center>
 	<p>
-
 	<input value="Calculate" type="submit" /> <img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input value="Reset to defaults" type="reset" />
 	</p>
 	</center>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
@@ -327,78 +327,83 @@
 				</select></td>
 
 				<td>Disperser:
-				<select name="Disperser" size="1">
-				<option value="NONE">none</option>
-				<option value="J">J grism</option>
-				<option value="H">H grism</option>
-				<option value="K">K grism</option>
-				<option value="L">L grism</option>
-				<option value="M">M grism</option>
-				</select></td>
-
+					<select name="Disperser" size="1">
+						<option value="NONE">none</option>
+						<option value="none" disabled></option>
+						<option value="J">J grism (UNAVAILABLE)</option>
+						<option value="H">H grism (UNAVAILABLE)</option>
+						<option value="K">K grism (UNAVAILABLE)</option>
+						<option value="L">L grism (UNAVAILABLE)</option>
+						<option value="M">M grism (UNAVAILABLE)</option>
+					</select>
+				</td>
 			</tr>
+
 			<tr>
 				<td>Filter:
+					<select name="Filter" size="1">
 
-				<select name="Filter" size="1">
-				<option value="none" disabled>Broad band...</option>
+						<option value="none" disabled>Broad band:</option>
+						<option value="BBF_Y">Y (1.02 µm)</option>
+						<option value="BBF_J">J (1.25 µm)</option>
+						<option value="BBF_H">H (1.65 µm)</option>
+						<option value="BBF_KPRIME">K' (2.12 µm)</option>
+						<option value="BBF_KSHORT">K(short) (2.15 µm)</option>
+						<option value="BBF_K" selected="selected">K (2.20 µm)</option>
+						<option value="BBF_LPRIME">L' (3.78 µm)</option>
+						<option value="BBF_MPRIME">M' (4.68 µm)</option>
 
-				<option value="BBF_Y">Y (1.02 µm)</option>
-				<option value="BBF_J">J (1.25 µm)</option>
-				<option value="BBF_H">H (1.65 µm)</option>
-				<option value="BBF_KPRIME">K' (2.12 µm)</option>
-				<option value="BBF_KSHORT">K(short) (2.15 µm)</option>
-				<option value="BBF_K" selected="selected">K (2.20 µm)</option>
-				<option value="BBF_LPRIME">L' (3.78 µm)</option>
-				<option value="BBF_MPRIME">M' (4.68 µm)</option>
+						<option value="none" disabled></option>
+						<option value="none" disabled>Narrow band:</option>
+						<option value="NBF_HEI">HeI (2p2s triplet) (1.083 µm)</option>
+						<option value="NBF_PAGAMMA">Pa-gamma (1.094 µm)</option>
+						<option value="NBF_H">J-continuum (1.207 µm)</option>
+						<option value="NBF_PABETA">Pa-beta (1.282 µm)</option>
+						<option value="NBF_CH4SHORT">CH4(short) (1.580 µm)</option>
+						<option value="NBF_CH4LONG">CH4(long) (1.690 µm)</option>
+						<option value="NBF_HCONT">H-continuum (1.570 µm)</option>
+						<option value="NBF_FEII">[FeII] (1.644 µm)</option>
+						<option value="NBF_H2O_2045">H20 ice (2.045 µm)</option>
+						<option value="NBF_HE12P2S">HeI (2p2s singlet) (2.059 µm)</option>
+						<option value="NBF_KCONT1">K-continuum (2.090 µm)</option>
+						<option value="NBF_H210">H2 1-0S(1) (2.122 µm)</option>
+						<option value="NBF_BRGAMMA">Br-gamma (2.166 µm)</option>
+						<option value="NBF_H221">H2 2-1S(1) (2.248 µm)</option>
+						<option value="NBF_KCONT2">K-continuum (2.270 µm)</option>
+						<option value="NBF_CH4ICE">CH4 ice (2.275 µm)</option>
+						<option value="NBF_CO20">CO 2-0(bh) (2.294 µm)</option>
+						<option value="NBF_CO31">CO 3-1(bh) (2.323 µm) (UNAVAILABLE)</option>
+						<option value="NBF_H2O">H2O ice (3.050 µm)</option>
+						<option value="NBF_HC">hydrocarbon (3.295 µm)</option>
+						<option value="NBF_BRACONT">Br-alpha continuum (3.990 µm)</option>
+						<option value="NBF_BRA">Br-alpha (4.052 µm)</option>
 
-				<option value="none" disabled></option>
-				<option value="none" disabled>Grism order sorting...</option>
+						<option value="none" disabled></option>
+						<option value="none" disabled>Grism Order Sorting:</option>
+						<option value="BBF_J_ORDER_SORT">J sorting (UNAVAILABLE)</option>
+						<option value="BBF_H_ORDER_SORT">H sorting (UNAVAILABLE)</option>
+						<option value="BBF_K_ORDER_SORT">K sorting (UNAVAILABLE)</option>
+						<option value="BBF_L_ORDER_SORT">L sorting (UNAVAILABLE)</option>
+						<option value="BBF_M_ORDER_SORT">M sorting (UNAVAILABLE)</option>
 
-				<option value="BBF_J_ORDER_SORT">J sorting</option>
-				<option value="BBF_H_ORDER_SORT">H sorting</option>
-				<option value="BBF_K_ORDER_SORT">K sorting</option>
-				<option value="BBF_L_ORDER_SORT">L sorting</option>
-				<option value="BBF_M_ORDER_SORT">M sorting</option>
-
-				<option value="none" disabled></option>
-				<option value="none" disabled>Narrow band...</option>
-
-				<option value="NBF_HEI">HeI (2p2s triplet) (1.083 µm)</option>
-				<option value="NBF_PAGAMMA">Pa-gamma (1.094 µm)</option>
-				<option value="NBF_H">J-continuum (1.207 µm)</option>
-				<option value="NBF_PABETA">Pa-beta (1.282 µm)</option>
-				<option value="NBF_CH4SHORT">CH4(short) (1.580 µm)</option>
-				<option value="NBF_CH4LONG">CH4(long) (1.690 µm)</option>
-				<option value="NBF_HCONT">H-continuum (1.570 µm)</option>
-				<option value="NBF_FEII">[FeII] (1.644 µm)</option>
-				<option value="NBF_H2O_2045">H20 ice (2.045 µm)</option>
-				<option value="NBF_HE12P2S">HeI (2p2s singlet) (2.059 µm)</option>
-				<option value="NBF_KCONT1">K-continuum (2.090 µm)</option>
-				<option value="NBF_H210">H2 1-0S(1) (2.122 µm)</option>
-				<option value="NBF_BRGAMMA">Br-gamma (2.166 µm)</option>
-				<option value="NBF_H221">H2 2-1S(1) (2.248 µm)</option>
-				<option value="NBF_KCONT2">K-continuum (2.270 µm)</option>
-				<option value="NBF_CH4ICE">CH4 ice (2.275 µm)</option>
-				<option value="NBF_CO20">CO 2-0(bh) (2.294 µm)</option>
-				<option value="NBF_CO31">CO 3-1(bh) (2.323 µm)</option>
-				<option value="NBF_H2O">H2O ice (3.050 µm)</option>
-				<option value="NBF_HC">hydrocarbon (3.295 µm)</option>
-				<option value="NBF_BRACONT">Br-alpha continuum (3.990 µm)</option>
-				<option value="NBF_BRA">Br-alpha (4.052 µm)</option>
-				</select></td>
+					</select>
+				</td>
 
 				<td>Focal plane mask:
-                <select name="Mask" size="1">
-				<option value="MASK_IMAGING">none</option>
-				<option value="MASK_1">2-pix slit center</option>
-				<option value="MASK_2">4-pix slit center</option>
-				<option value="MASK_3">6-pix slit center</option>
-				<option value="MASK_4">2-pix slit blue</option>
-				<option value="MASK_5">4-pix slit blue</option>
-				<option value="MASK_6">6-pix slit blue</option>
-				</select></td>
+                	<select name="Mask" size="1">
+						<option value="MASK_IMAGING">none</option>
+						<option value="none" disabled></option>
+						<option value="MASK_1">2-pix slit center (UNAVAILABLE)</option>
+						<option value="MASK_2">4-pix slit center (UNAVAILABLE)</option>
+						<option value="MASK_3">6-pix slit center (UNAVAILABLE)</option>
+						<option value="MASK_4">2-pix slit blue (UNAVAILABLE)</option>
+						<option value="MASK_5">4-pix slit blue (UNAVAILABLE)</option>
+						<option value="MASK_6">6-pix slit blue (UNAVAILABLE)</option>
+					</select>
+				</td>
+
 			</tr>
+
 			<tr>
 				<td colspan="4" height="50" valign="bottom"><b>Detector properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10270#detector','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
 
@@ -428,7 +433,7 @@
 					high flux mode, typically for wavelengths &gt;2.5µm </td>
 			</tr>
 			<tr>
-				<td colspan="4">Dark current of 0.25 e-/s </td>
+				<td colspan="4">Dark current: &nbsp; 0.25 e-/s </td>
 			</tr>
 			<!-- Telescope definition-->
 			<tr>
@@ -450,19 +455,19 @@
 				<td colspan="4" height="50" valign="bottom"><b>Altair properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10269','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
 			</tr>
 			<tr>
-				<td align="left">AO guide star <br />
-				separation:
+				<td align="left">AO guide star separation:
                     <input name="guideSep" size="5" value="0.0" type="text" />  arcsec</td>
-				<td>AO guide star brightness <br />
-				(R-band):
+				<td>AO guide star brightness (R-band):
 				<input name="guideMag" size="5" value="12.0" type="text" /> mag</td>
 			</tr>
 			<tr>
 
 				<td align="left">Field Lens:
-				<input value="OUT" name="FieldLens" checked="checked" type="radio" /> OUT <input value="IN" name="FieldLens" size="1" type="radio" /> IN(Required for LGS)</td>
+					<input value="OUT" name="FieldLens" checked="checked" type="radio" /> OUT
+					<input value="IN" name="FieldLens" size="1" type="radio" /> IN (Required for LGS)</td>
 				<td>Altair Mode:
-				<input value="NGS" name="GuideStarType" checked="checked" type="radio" /> NGS <input value="LGS" name="GuideStarType" size="1" type="radio" />LGS</td>
+					<input value="NGS" name="GuideStarType" checked="checked" type="radio" /> NGS
+					<input value="LGS" name="GuideStarType" size="1" type="radio" />LGS</td>
 
 			</tr>
 			<tr>
@@ -599,7 +604,6 @@
 	<div align="center">
 	<center>
 	<p>
-
 	<input value="Calculate" type="submit" /> <img src="/spacer.gif" height="1" width="40" style="opacity:0.0"/><input value="Reset to defaults" type="reset" />
 	</p>
 	</center>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
@@ -300,34 +300,33 @@
 				<td><input name="instrumentCentralWavelength" size="8" value=" " type="text" /> µm</td>
 			</tr>
 			<tr>
-
 				<td colspan="4" height="50" valign="bottom"><b>Detector properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10276#detector','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
 			</tr>
-			<tr>
-				<td colspan="4">Read noise of 3,000 e- per pixel (and with 4x extra low
-				frequency noise)</td>
 
+			<tr>
+				<td colspan="4">Read noise: &nbsp; 3,000 e- per pixel (and with 4x extra low frequency noise)</td>
 			</tr>
 			<tr>
-				<td colspan="4">Dark current of 50,000 e-/s per pixel</td>
+				<td colspan="4">Dark current: &nbsp; 50,000 e-/s per pixel</td>
 			</tr>
 			<!-- Telescope definition-->
 			<tr>
 				<td colspan="4" height="50" valign="bottom"><b>Telescope configuration:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10271','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>
-
 			</tr>
 			<tr>
 				<td colspan="4">Mirror coating: <input value="SILVER" name="Coating" checked="checked" type="radio" /> silver </td>
 			</tr>
 			<tr>
-				<td colspan="4">Instrument port: <input value="UP_LOOKING" name="IssPort" checked="checked" type="radio" /> up-looking
-				(2 reflections)  <input value="SIDE_LOOKING" name="IssPort" type="radio" />
-
-				side-looking (3 reflections) </td>
+				<td colspan="4">Instrument port:
+					<input value="UP_LOOKING" name="IssPort" checked="checked" type="radio" /> Up-looking (2 reflections)
+					<input value="SIDE_LOOKING" name="IssPort" type="radio" /> Side-looking (3 reflections)
+				</td>
 			</tr>
-			<!--tr>
-				<td colspan="4">Wavefront sensor for tip-tilt compensation: <input value="PWFS" name="Type" checked="checked" type="radio" /> PWFS   (no OIWFS) </td>
-			</tr-->
+			<tr>
+				<td colspan="4">Wavefront sensor for tip-tilt compensation:
+					<input value="PWFS" name="Type" checked="checked" type="radio" /> PWFS (no OIWFS)
+				</td>
+			</tr>
 			<tr>
 				<td colspan="4">
 					<p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->


### PR DESCRIPTION
This PR adds the label "UNAVAILABLE" to the ITC components which are no longer available, and makes several other purely cosmetic improvements to the web forms, including re-organizing the GMOS filter lists, and making various labels more consistent.  I also re-instated the PWFS to the Michelle and TRECS ITCs, as they were throwing errors.  Finally, I updated the Acq-Cam ITC to use the new style "Calculate" button for consistency with the other ITC forms.