### PR TITLE
REL-3400 add support for new horizons formats

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -315,12 +315,26 @@ object HorizonsService2 {
               List(Row(HorizonsDesignation.AsteroidNewStyle(m.group(1)) : HorizonsDesignation.Asteroid, m.group(1)))
             } \/> "Could not match '418993 (2009 MS9)' header pattern."
 
+          // Single result with form: JPL/HORIZONS              1I/'Oumuamua (A/2017 U1)         2018-Apr-16 18:28:59
+          lazy val case5 =
+            """  +\S+\s+\((A/.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+              List(Row(HorizonsDesignation.AsteroidNewStyle(m.group(1)) : HorizonsDesignation.Asteroid, m.group(1)))
+            } \/> "Could not match '1I/'Oumuamua (A/2017 U1)' header pattern."
+
+          // Single result with form: JPL/HORIZONS     A/2017 U7     2015-Dec-31 11:40:21
+          lazy val case6 =
+            """  +(A/\d+ [^(]+?)  """.r.findFirstMatchIn(header).map { m =>
+              List(Row(HorizonsDesignation.AsteroidNewStyle(m.group(1)) : HorizonsDesignation.Asteroid, m.group(1)))
+            } \/> "Could not match 'A/2017 U7' header pattern."
+
           // First one that works!
           case0 orElse
           case1 orElse
           case2 orElse
           case3 orElse
-          case4 orElse "Could not parse the header line as an asteroid".left
+          case4 orElse
+          case5 orElse
+          case6 orElse  "Could not parse the header line as an asteroid".left
 
         case Search.MajorBody(_) =>
 

--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -90,6 +90,18 @@ object HS2Spec extends Specification with ScalaCheck {
       ))
     }
 
+    "handle single result (Format 5) 1I/'Oumuamua (A/2017 U1)" in {
+      runSearch(Search.Asteroid("A/2017 U1")) must_== \/-(List(
+        Row(HD.AsteroidNewStyle("A/2017 U1"), "A/2017 U1")
+      ))
+    }
+
+    "handle single result (Format 6) A/2017 U7" in {
+      runSearch(Search.Asteroid("A/2017 U7")) must_== \/-(List(
+        Row(HD.AsteroidNewStyle("A/2017 U7"), "A/2017 U7")
+      ))
+    }
+
   }
 
   "major body search" should {
@@ -142,7 +154,19 @@ object HS2Spec extends Specification with ScalaCheck {
       }
     }
 
-    "return a populated ephemeris for Amphitrite (asteroid, new style)" in {
+    "return a populated ephemeris for 'Oumuamua (asteroid, new style)" in {
+      runLookup(HD.AsteroidNewStyle("A/2017 U1"), 100).map(_.size).toOption.exists { s =>
+        95 <= s && s <= 105
+      }
+    }
+
+    "return a populated ephemeris for A/2017 U7 (asteroid, new style)" in {
+      runLookup(HD.AsteroidNewStyle("A/2017 U7"), 100).map(_.size).toOption.exists { s =>
+        95 <= s && s <= 105
+      }
+    }
+
+    "return a populated ephemeris for Amphitrite (asteroid, old style)" in {
       runLookup(HD.AsteroidOldStyle(29), 100).map(_.size).toOption.exists { s =>
         95 <= s && s <= 105
       }


### PR DESCRIPTION
This adds support for headers of the form `1I/'Oumuamua (A/2017 U1)` and `A/2017 U7`. The Jira issue also mentions `A/2018 C2` which should be handled by the latter pattern but the object seems to have disappeared. 

Once verified this change needs to be cross-ported to gem.

**Update:**  `A/2018 C2` was renamed to `A/2018 F4`, and it does works as expected.