### PR TITLE
REL-1714 Extra notice messages for constraints

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
@@ -70,6 +70,11 @@ public final class Variant extends BaseMutableBean implements PioSerializable, C
 	private Map<Obs, Union<Interval>> constrainedUnionCache;
 	private Map<Obs, Union<Interval>> timingUnionCache;
 
+	// Cache names
+	public static final String DARK_UNION_CACHE = "darkUnionCache";
+	public static final String VISIBLE_UNION_CACHE = "visibleUnionCache";
+	public static final String TIMING_UNION_CACHE = "timingUnionCache";
+
 	// The list of all groups encountered in the plan, by first appearance.
 	private List<Group> groups = new ArrayList<>();
 	private boolean flagUpdatesEnabled = true;


### PR DESCRIPTION
This PR is still not complete but it's intended as a request for feedback. These are the main points of contention.

- Multiple constraint intervals. Right now it only uses the first interval of the night, but how do we really want to represent these cases? I'd try to show the interval that affects more allocations but I'm not sure how to do it and that might require much more time than are willing to spend on.

- Open ended constraints. I'd use the start/end of the night, but would that be correct?

- Conditions to show messages. Right now they are always shown when there are constraints present, but I guess maybe we don't want to show them when the condition is not met, is that the case?

- Background constraint. It's still pending but since it seems the trickiest I'm leaving it until the end, after confirming the way I'm doing the other constraints is correct.

I had several issues with null exceptions when dragging allocations around. I think I ironed out most cases but I can't be completely sure I got them all, so please let me know if you catch any.

Sorry for the mess with the tabs/spaces, I realized late there was already a mix of them in this file. I decided not to convert them all to spaces in this PR because it would make harder to review it. I can do it in a different PR.