### PR TITLE
REL-902: fix case of MOS table

### DIFF
--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/dao/CustomMaskDao.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/dao/CustomMaskDao.scala
@@ -67,7 +67,7 @@ object CustomMaskDao {
                m.ProgramNo,
                m.ODF,
                c.Location
-          FROM Mos m
+          FROM MOS m
                LEFT OUTER JOIN Component c
                  ON c.ComponentID = m.ComponentID
          WHERE m.Site = $s


### PR DESCRIPTION
This is a followup for #1473.  It fixes the case of the `MOS` table.  It turns out that mysql tables are case insensitive on OS X where I did the development, but case sensitive on Linux where the official test server runs. 