### PR TITLE
REL-1577: Revert Action

### DIFF
--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/Vcs.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/Vcs.scala
@@ -45,6 +45,16 @@ class Vcs(user: VcsAction[Set[Principal]], server: VcsServer, service: Peer => V
       _ <- server.add(p)
     } yield p
 
+  /** Checks-out the indicated program from the remote peer, replacing any local
+    * version of the same program.
+    */
+  def revert(id: SPProgramID, peer: Peer, cancelled: AtomicBoolean): VcsAction[ISPProgram] =
+    for {
+      p <- Client(peer).checkout(id)
+      _ <- checkCancel(cancelled)
+      _ <- server.replace(p)
+    } yield p
+
   /** Adds the given program to the remote peer, copying it into the remote
     * database. */
   def add(id: SPProgramID, peer: Peer): VcsAction[VersionMap] =

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
@@ -100,6 +100,14 @@ class VcsServer(odb: IDBDatabaseService) { vs =>
     }
   }
 
+  /** Replaces the given program in the database. */
+  def replace(p: ISPProgram): VcsAction[Unit] =
+    (Option(p.getProgramID) \/> MissingId).liftVcs >>= { id =>
+      locked(p.getProgramKey, instance.writeLock, instance.writeUnlock) {
+        putProg(odb.getFactory.copyWithNewLifespanId(p)).liftVcs
+      }
+    }
+
   /** Server implementation of `VcsService`. */
   final class SecureVcsService(user: Set[Principal], vcsLog: VcsLog) extends VcsService {
     def geminiPrincipals: Set[GeminiPrincipal] =

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
@@ -100,8 +100,8 @@ class VcsServer(odb: IDBDatabaseService) { vs =>
     }
   }
 
-  /** Replaces the program in the database in the database with key and id
-    * matching program p with program p.
+  /** Replaces the program in the database whose key and id match program the
+    * given program with program p.
     */
   def replace(p: ISPProgram): VcsAction[Unit] = {
     def failIfNotExists(id: SPProgramID, key: SPNodeKey): VcsAction[Unit] =

--- a/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/TestEnv.scala
+++ b/bundle/edu.gemini.sp.vcs/src/test/scala/edu/gemini/sp/vcs2/TestEnv.scala
@@ -66,11 +66,13 @@ case class TestPeer(odb: IDBDatabaseService, server: VcsServer, service: Princip
   def progTitle_=(t: String): Unit = set(_.setTitle(t))
 
   // Create a new program but don't add it to the database
-  def newProgram(id: SPProgramID): ISPProgram = {
+  def newProgramWithKey(key: SPNodeKey, id: SPProgramID): ISPProgram = {
     val fact = odb.getFactory
-    val key  = new SPNodeKey()
     fact.createProgram(key, id)
   }
+
+  def newProgram(id: SPProgramID): ISPProgram =
+    newProgramWithKey(new SPNodeKey(), id)
 
   def addProgram(p: ISPProgram): Unit =
     odb.put(p)
@@ -78,6 +80,9 @@ case class TestPeer(odb: IDBDatabaseService, server: VcsServer, service: Princip
   // Create and add a new program to the database
   def addNewProgram(id: SPProgramID): ISPProgram =
     newProgram(id) <| addProgram
+
+  def addNewProgramWithKey(key: SPNodeKey, id: SPProgramID): ISPProgram =
+    newProgramWithKey(key, id) <| addProgram
 
   def delete(child: SPNodeKey): Unit = {
     val p = descendant(child).getParent

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerActions.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerActions.java
@@ -22,6 +22,7 @@ public final class SPViewerActions {
     // Individual actions
     public final AbstractViewerAction vcsSyncAction;
     public final AbstractViewerAction syncAllAction;
+    public final AbstractViewerAction revertChangesAction;
     public final AbstractViewerAction conflictPrevAction;
     public final AbstractViewerAction conflictNextAction;
     public final AbstractViewerAction resolveConflictsAction;
@@ -65,15 +66,15 @@ public final class SPViewerActions {
     public final AbstractViewerAction purgeEphemerisAction;
 
     // Groups of actions. In some cases these appear in the list above, in other cases not.
-    final List<AbstractViewerAction> templateActions = new ArrayList<AbstractViewerAction>();
-    final List<AbstractViewerAction> addGroupActions = new ArrayList<AbstractViewerAction>();
-    final List<AddObservationAction> addObservationActions = new ArrayList<AddObservationAction>();
-    final List<AddObsCompAction> addNoteActions = new ArrayList<AddObsCompAction>();
-    final List<AddObsCompAction> addInstrumentActions = new ArrayList<AddObsCompAction>();
-    final List<AddObsCompAction> addAOActions = new ArrayList<AddObsCompAction>();
-    final List<AddObsCompAction> addEngineeringActions = new ArrayList<AddObsCompAction>();
-    final List<AddSeqCompAction> addInstrumentIteratorActions = new ArrayList<AddSeqCompAction>();
-    final List<AddSeqCompAction> addGenericSeqCompActions = new ArrayList<AddSeqCompAction>();
+    final List<AbstractViewerAction> templateActions = new ArrayList<>();
+    final List<AbstractViewerAction> addGroupActions = new ArrayList<>();
+    final List<AddObservationAction> addObservationActions = new ArrayList<>();
+    final List<AddObsCompAction> addNoteActions = new ArrayList<>();
+    final List<AddObsCompAction> addInstrumentActions = new ArrayList<>();
+    final List<AddObsCompAction> addAOActions = new ArrayList<>();
+    final List<AddObsCompAction> addEngineeringActions = new ArrayList<>();
+    final List<AddSeqCompAction> addInstrumentIteratorActions = new ArrayList<>();
+    final List<AddSeqCompAction> addGenericSeqCompActions = new ArrayList<>();
 
 
     public SPViewerActions(SPViewer viewer) {
@@ -133,8 +134,9 @@ public final class SPViewerActions {
         resolveConflictsAction = new ResolveConflictsAction(viewer);
 
         // VCS Actions
-        vcsSyncAction = new VcsSyncAction(viewer);
-        syncAllAction = new SyncAllAction(viewer);
+        vcsSyncAction       = new VcsSyncAction(viewer);
+        syncAllAction       = new SyncAllAction(viewer);
+        revertChangesAction = new RevertChangesAction(viewer);
 
         // General Edit Actions
         cutAction = new CutAction(viewer);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerMenuBar.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerMenuBar.java
@@ -82,6 +82,7 @@ final class SPViewerMenuBar extends JMenuBar {
         menu.add(new ExportAction(_viewer));
         menu.add(_viewer._actions.vcsSyncAction);
         menu.add(_viewer._actions.syncAllAction);
+        menu.add(_viewer._actions.revertChangesAction);
         menu.addSeparator();
         menu.add(new FetchLibrariesAction(_viewer));
         menu.addSeparator();

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsIcon.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsIcon.scala
@@ -23,31 +23,34 @@ object VcsIcon {
   val Update = load("up")
   val Commit = load("ci")
 
-  private val InSyncColor = OtColor.HONEY_DEW.darker
-  private val NoPeerColor = OtColor.SKY.darker
-  private val ErrorColor = OtColor.SALMON
-  private val PendingSyncColor = OtColor.SALMON
-  private val PendingUpdateColor = new Color(255, 175, 0)
+  private val InSyncColor         = OtColor.HONEY_DEW.darker
+  private val NoPeerColor         = OtColor.SKY.darker
+  private val ErrorColor          = OtColor.SALMON
+  private val PendingSyncColor    = OtColor.SALMON
+  private val PendingUpdateColor  = new Color(255, 175, 0)
   private val PendingCheckInColor = PendingUpdateColor
+  private val RevertColor         = OtColor.SALMON
 
   private type Drawing = (Graphics2D, Int, Int) => Unit
 
   private val DownArrow: Drawing = (g2, w, h) => {
     g2.fill(new Polygon(Array(4, w - 4, w / 2), Array(h / 2 - 4, h / 2 - 4, h - 4), 3))
-    //    g2.fill(new Polygon(Array(5, w-5, w/2), Array(h/2, h/2, h-4), 3))
-    //    g2.fill(new Rectangle2D.Double(w/2-2,4,4,8))
   }
 
   private val UpArrow: Drawing = (g2, w, h) => {
     g2.fill(new Polygon(Array(4, w - 4, w / 2), Array(h / 2 + 4, h / 2 + 4, 4), 3))
-    //    g2.fill(new Polygon(Array(5, w-5, w/2), Array(h/2, h/2, 4), 3))
-    //    g2.fill(new Rectangle2D.Double(w/2-2,h/2,4,8))
   }
 
   private val CycleArrow: Drawing = (g2, w, h) => {
     g2.fill(new Polygon(Array(w / 2, w / 2 + 4, w / 2), Array(2, 7, 12), 3))
     g2.setStroke(new BasicStroke(2.0f))
     g2.draw(new Arc2D.Double(6, 6, w - 12, h - 12, 90.0, 270.0, Arc2D.OPEN))
+  }
+
+  private val BackCycleArrow: Drawing = (g2, w, h) => {
+    g2.fill(new Polygon(Array(w / 2, w / 2 - 4, w / 2), Array(2, 7, 12), 3))
+    g2.setStroke(new BasicStroke(2.0f))
+    g2.draw(new Arc2D.Double(6, 6, w - 12, h - 12, 180.0, 270.0, Arc2D.OPEN))
   }
 
   private val Question: Drawing = (g2, w, h) => {
@@ -88,10 +91,11 @@ object VcsIcon {
     new ImageIcon(image)
   }
 
-  val PendingSync = makeIcon(CycleArrow, PendingSyncColor)
-  val PendingUpdate = makeIcon(DownArrow, PendingUpdateColor)
-  val PendingCheckIn = makeIcon(UpArrow, PendingCheckInColor)
-  val UpToDate = makeIcon(CycleArrow, InSyncColor)
-  val NoPeer = makeIcon(Question, NoPeerColor)
-  val BrokenLink = makeIcon(Network, ErrorColor)
+  val PendingSync    = makeIcon(CycleArrow,     PendingSyncColor)
+  val PendingUpdate  = makeIcon(DownArrow,      PendingUpdateColor)
+  val PendingCheckIn = makeIcon(UpArrow,        PendingCheckInColor)
+  val UpToDate       = makeIcon(CycleArrow,     InSyncColor)
+  val NoPeer         = makeIcon(Question,       NoPeerColor)
+  val BrokenLink     = makeIcon(Network,        ErrorColor)
+  val Revert         = makeIcon(BackCycleArrow, RevertColor)
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsOtClient.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsOtClient.scala
@@ -37,13 +37,18 @@ case class VcsOtClient(vcs: Vcs, reg: VcsRegistrar) {
     for {
       p <- vcs.checkout(id, peer, cancelled)
       _ <- VcsAction(reg.register(id, peer))
-    } yield vmStore(id, p)(_.getVersions)
+    } yield vmStore(id, p, force = false)(_.getVersions)
+
+  def revert(id: SPProgramID, peer: Peer, cancelled: AtomicBoolean): VcsAction[ISPProgram] =
+      vcs.revert(id, peer, cancelled).map { p =>
+        vmStore(id, p, force = true)(_.getVersions)
+      }
 
   def add(id: SPProgramID, peer: Peer): VcsAction[VersionMap] =
     for {
       vm <- vcs.add(id, peer)
       _  <- VcsAction(reg.register(id, peer))
-    } yield vmStore(id, vm)(identity)
+    } yield vmStore(id, vm, force = false)(identity)
 
   private def lookupAndThen[A](id: SPProgramID)(f: (Vcs, Peer) => VcsAction[A]): VcsAction[A] =
     for {
@@ -52,7 +57,7 @@ case class VcsOtClient(vcs: Vcs, reg: VcsRegistrar) {
     } yield a
 
   private def recording[A](id: SPProgramID)(f: (Vcs, Peer) => VcsAction[A])(g: A => VersionMap): VcsAction[A] =
-    lookupAndThen(id)(f).map(vmStore(id, _)(g))
+    lookupAndThen(id)(f).map(vmStore(id, _, force = false)(g))
 
   def version(id: SPProgramID): VcsAction[VersionMap] =
     recording(id)(_.version(id, _))(identity)
@@ -67,8 +72,8 @@ case class VcsOtClient(vcs: Vcs, reg: VcsRegistrar) {
     lookupAndThen(id)(_.log(id, _, offset, length))
 
   // Performs the side-effect of updating the map from id to VersionMap.
-  private def vmStore[A](id: SPProgramID, a: A)(f: A => VersionMap): A = {
-    Swing.onEDT { VmStore.update(id, f(a)) }
+  private def vmStore[A](id: SPProgramID, a: A, force: Boolean)(f: A => VersionMap): A = {
+    Swing.onEDT { VmStore.update(id, f(a), force) }
     a
   }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsOtClient.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/VcsOtClient.scala
@@ -37,18 +37,21 @@ case class VcsOtClient(vcs: Vcs, reg: VcsRegistrar) {
     for {
       p <- vcs.checkout(id, peer, cancelled)
       _ <- VcsAction(reg.register(id, peer))
-    } yield vmStore(id, p, force = false)(_.getVersions)
+      _ <- vmStore(id, p, force = false)(_.getVersions)
+    } yield p
 
   def revert(id: SPProgramID, peer: Peer, cancelled: AtomicBoolean): VcsAction[ISPProgram] =
-      vcs.revert(id, peer, cancelled).map { p =>
-        vmStore(id, p, force = true)(_.getVersions)
-      }
+    for {
+      p <- vcs.revert(id, peer, cancelled)
+      _ <- vmStore(id, p, force = true)(_.getVersions)
+    } yield p
 
   def add(id: SPProgramID, peer: Peer): VcsAction[VersionMap] =
     for {
       vm <- vcs.add(id, peer)
       _  <- VcsAction(reg.register(id, peer))
-    } yield vmStore(id, vm, force = false)(identity)
+      _  <- vmStore(id, vm, force = false)(identity)
+    } yield vm
 
   private def lookupAndThen[A](id: SPProgramID)(f: (Vcs, Peer) => VcsAction[A]): VcsAction[A] =
     for {
@@ -57,7 +60,10 @@ case class VcsOtClient(vcs: Vcs, reg: VcsRegistrar) {
     } yield a
 
   private def recording[A](id: SPProgramID)(f: (Vcs, Peer) => VcsAction[A])(g: A => VersionMap): VcsAction[A] =
-    lookupAndThen(id)(f).map(vmStore(id, _, force = false)(g))
+    for {
+      a <- lookupAndThen(id)(f)
+      _ <- vmStore(id, a, force = false)(g)
+    } yield a
 
   def version(id: SPProgramID): VcsAction[VersionMap] =
     recording(id)(_.version(id, _))(identity)
@@ -72,8 +78,6 @@ case class VcsOtClient(vcs: Vcs, reg: VcsRegistrar) {
     lookupAndThen(id)(_.log(id, _, offset, length))
 
   // Performs the side-effect of updating the map from id to VersionMap.
-  private def vmStore[A](id: SPProgramID, a: A, force: Boolean)(f: A => VersionMap): A = {
-    Swing.onEDT { VmStore.update(id, f(a), force) }
-    a
-  }
+  private def vmStore[A](id: SPProgramID, a: A, force: Boolean)(f: A => VersionMap): VcsAction[Unit] =
+    VcsAction(Swing.onEDT { VmStore.update(id, f(a), force) })
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/vm/VmStore.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/vcs/vm/VmStore.scala
@@ -17,13 +17,13 @@ object VmStore extends mutable.Publisher[VmUpdateEvent] {
 
   private var versionMaps = Map.empty[SPProgramID, VersionMap]
 
-  def update(u: VmUpdate): Unit = update(u.pid, u.vm)
+  def update(u: VmUpdate): Unit = update(u.pid, u.vm, force = false)
 
-  def update(kv: (SPProgramID, VersionMap)): Unit = update(kv._1, kv._2)
+  def update(kv: (SPProgramID, VersionMap)): Unit = update(kv._1, kv._2, force = false)
 
-  def update(pid: SPProgramID, newVm: VersionMap): Unit = {
+  def update(pid: SPProgramID, newVm: VersionMap, force: Boolean): Unit = {
     val oldVm = versionMaps.getOrElse(pid, EmptyVersionMap)
-    if (VersionMap.isNewer(newVm, oldVm)) {
+    if (force || VersionMap.isNewer(newVm, oldVm)) {
       versionMaps = versionMaps + (pid -> newVm)
       publish(VmUpdateEvent(pid, Some(newVm)))
     }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/RevertChangesAction.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/RevertChangesAction.scala
@@ -1,0 +1,100 @@
+package jsky.app.ot.viewer.action
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import edu.gemini.pot.client.SPDB
+import edu.gemini.pot.sp.ISPProgram
+import edu.gemini.shared.util.VersionComparison._
+import edu.gemini.sp.vcs2.VcsAction._
+import edu.gemini.sp.vcs2.VcsFailure
+import edu.gemini.spModel.core.{ Peer, SPProgramID }
+import edu.gemini.spModel.util.DBProgramInfo
+
+import jsky.app.ot.vcs.{ VcsIcon, VcsOtClient, VcsStateEvent }
+import jsky.app.ot.viewer.{ SPViewer, ViewerManager }
+import java.awt.event.ActionEvent
+
+import javax.swing.Action._
+import javax.swing.JComponent
+
+import scala.swing.{ Component, Dialog, Reactor }
+/**
+  *
+  */
+final class RevertChangesAction(viewer: SPViewer) extends AbstractViewerAction(viewer, "Revert changes", VcsIcon.Revert) with Reactor {
+  import RevertChangesAction._
+
+  putValue(AbstractViewerAction.SHORT_NAME, "Revert")
+  putValue(SHORT_DESCRIPTION, "Revert changes to this program since the last sync.")
+
+  private def pid: Option[SPProgramID] =
+    for {
+      r <- Option(viewer.getRoot)
+      p <- Option(r.getProgramID)
+    } yield p
+
+  listenTo(viewer.getVcsStateTracker)
+
+  reactions += {
+    case VcsStateEvent(pid, peer, status, conflicts) =>
+      setEnabled(computeEnabledState)
+  }
+
+  override def computeEnabledState: Boolean =
+    viewer.getVcsStateTracker.currentState.status.exists {
+      case Newer | Conflicting => true
+      case Same  | Older       => false
+    }
+
+  override def actionPerformed(evt: ActionEvent): Unit = {
+    def success(p: ISPProgram): Unit =
+      ViewerManager.open(p, viewer)
+
+    def fail(pid: SPProgramID, loc: Peer)(f: VcsFailure): Unit = {
+      val msg = VcsFailure.explain(f, pid, "revert", Some(loc))
+      Dialog.showMessage(scalaComponent(evt).orNull, msg, "Error", Dialog.Message.Error)
+    }
+
+    for {
+      client  <- VcsOtClient.ref
+      program <- Option(viewer.getRoot)
+      pid     <- Option(program.getProgramID)
+      peer    <- client.peer(pid)
+      if client.reg.allRegistrations.isDefinedAt(pid) && userConfirms(evt)
+    } {
+      println("Okay revert")
+      SPDB.get().remove(program)
+      client.checkout(pid, peer, new AtomicBoolean(false)).unsafeRun.fold(fail(pid, peer),success)
+    }
+  }
+
+}
+
+object RevertChangesAction {
+
+  private val ConfirmationMessage =
+    """Delete all changes since the last sync and restore the program from the
+      |remote Observing Database?
+      |
+      |Continue?
+    """.stripMargin
+
+  private def scalaComponent(evt: ActionEvent): Option[Component] =
+    evt.getSource match {
+      case j: JComponent            => Some(Component.wrap(j))
+      case s: scala.swing.Component => Some(s)
+      case _                        => None
+    }
+
+  private def userConfirms(evt: ActionEvent): Boolean =
+    scalaComponent(evt).exists { c =>
+      Dialog.showConfirmation(
+        c,
+        ConfirmationMessage,
+        "Confirm Revert Changes",
+        Dialog.Options.YesNo,
+        Dialog.Message.Warning
+      ) == Dialog.Result.Ok
+    }
+
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/RevertChangesAction.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/RevertChangesAction.scala
@@ -18,8 +18,9 @@ import javax.swing.Action._
 import javax.swing.JComponent
 
 import scala.swing.{ Component, Dialog, Reactor }
-/**
-  *
+
+/** An action that fetches the remote version of the program and puts it into
+  * the local database, wiping out any local changes.
   */
 final class RevertChangesAction(viewer: SPViewer) extends AbstractViewerAction(viewer, "Revert Changes...", VcsIcon.Revert) with Reactor {
   import RevertChangesAction._

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/RevertChangesAction.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/RevertChangesAction.scala
@@ -21,7 +21,7 @@ import scala.swing.{ Component, Dialog, Reactor }
 /**
   *
   */
-final class RevertChangesAction(viewer: SPViewer) extends AbstractViewerAction(viewer, "Revert changes", VcsIcon.Revert) with Reactor {
+final class RevertChangesAction(viewer: SPViewer) extends AbstractViewerAction(viewer, "Revert Changes...", VcsIcon.Revert) with Reactor {
   import RevertChangesAction._
 
   putValue(AbstractViewerAction.SHORT_NAME, "Revert")
@@ -62,9 +62,7 @@ final class RevertChangesAction(viewer: SPViewer) extends AbstractViewerAction(v
       peer    <- client.peer(pid)
       if client.reg.allRegistrations.isDefinedAt(pid) && userConfirms(evt)
     } {
-      println("Okay revert")
-      SPDB.get().remove(program)
-      client.checkout(pid, peer, new AtomicBoolean(false)).unsafeRun.fold(fail(pid, peer),success)
+      client.revert(pid, peer, new AtomicBoolean(false)).unsafeRun.fold(fail(pid, peer),success)
     }
   }
 
@@ -73,8 +71,9 @@ final class RevertChangesAction(viewer: SPViewer) extends AbstractViewerAction(v
 object RevertChangesAction {
 
   private val ConfirmationMessage =
-    """Delete all changes since the last sync and restore the program from the
-      |remote Observing Database?
+    """This action will delete all local changes made
+      |since the last sync and restore the program
+      |from the remote database.
       |
       |Continue?
     """.stripMargin

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/VcsSyncAction.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/action/VcsSyncAction.scala
@@ -27,7 +27,7 @@ object VcsSyncAction {
     }
 }
 
-final class VcsSyncAction(viewer: SPViewer) extends AbstractViewerAction(viewer, "Sync changes to this program with the database", VcsIcon.UpToDate) with Reactor {
+final class VcsSyncAction(viewer: SPViewer) extends AbstractViewerAction(viewer, "Sync Program Changes", VcsIcon.UpToDate) with Reactor {
   putValue(AbstractViewerAction.SHORT_NAME, "Sync")
   putValue(SHORT_DESCRIPTION, "Sync program with any changes from the database.")
   putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_S, AbstractViewerAction.platformEventMask()))


### PR DESCRIPTION
Adds a "revert" option to VCS.  "Revert" isn't exactly what it does but is a close enough approximation. Revert will fetch the current version of a program from the remote database and use it to replace the local version, wiping out any changes that may have been made.  It's like a checkout but for programs that already exist.  Of course, if updates have been stored remotely since the user last did a sync, the "revert" pulls those in as well.

Here is the new menu item, which is only active for programs that were fetched remotely and have been edited:
![revertchanges](https://user-images.githubusercontent.com/4906023/39095614-d121df70-4619-11e8-8038-8eec4c70bf4d.jpeg)

Here is the dialog that it displays for confirmation:
![confirmrevert](https://user-images.githubusercontent.com/4906023/39095625-e762b69c-4619-11e8-8a8b-b1af55e747eb.jpeg)
