### PR TITLE
REL-1502: multi-select in open dialog

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/OpenAction.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/OpenAction.java
@@ -1,6 +1,8 @@
 package jsky.app.ot.viewer.action;
 
 import edu.gemini.pot.sp.ISPProgram;
+import edu.gemini.shared.util.immutable.ImOption;
+
 import jsky.app.ot.viewer.OpenUtils;
 import jsky.app.ot.viewer.SPViewer;
 import jsky.app.ot.viewer.ViewerManager;
@@ -37,9 +39,12 @@ public class OpenAction extends AbstractViewerAction {
         // Messages are produced by above so just return
         if ((progs == null) || (progs.length == 0)) return;
 
-        // If one prog was selected, open it in the current viewer window, otherwise open each one
-        // in a separate viewer window
-        final SPViewer v = (progs.length > 1) ? null : viewer;
+        // Open them all in the current viewer window, if any.  If not find an
+        // empty viewer to recycle.  If none, make a viewer to house them all.
+        final SPViewer v =
+            ImOption.apply(viewer)
+                    .orElse(ImOption.apply(ViewerManager.findEmptyOrNull()))
+                    .getOrElse(() -> ViewerManager.newViewer());
 
         BusyWin.showBusy();
         for (final ISPProgram prog : progs) {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/ViewerManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/ViewerManager.scala
@@ -110,6 +110,12 @@ object ViewerManager {
   /**
    * Finds an open viewer that isn't displaying any program node, if any.
    */
-  def findEmpty(): Option[SPViewer] =
+  def findEmpty: Option[SPViewer] =
     SPViewer.instances.asScala.find(_.getRoot == null)
+
+  /**
+   * Finds an open viewer that isn't displaying any program node, if any.
+   */
+  def findEmptyOrNull: SPViewer =
+    findEmpty.orNull
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/open/ProgTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/open/ProgTableModel.scala
@@ -82,6 +82,9 @@ class ProgTableModel(filter: DBProgramChooserFilter, db: IDBDatabaseService, aut
   def getStatus(i: Int): Option[VersionComparison] =
     get(i).flatMap(_.left.toOption).flatMap { p => statuses.get().get(p.getNodeKey) }
 
+  def getStatus(k: SPNodeKey): Option[VersionComparison] =
+    statuses.get().get(k)
+
   lazy val getColumnCount: Int =
     cols.length
 
@@ -195,7 +198,7 @@ class ProgTableModel(filter: DBProgramChooserFilter, db: IDBDatabaseService, aut
 
     // Refresh the program list from remote sites
     def refreshRemote(): Unit =
-      auth.peers.unsafeRun.fold(_ => Set(), identity).foreach(updateRemote)
+      selectedPeer.foreach(updateRemote)
 
     // Refresh VCS status for a single program
     def updateVCS(p: ISPProgram): Unit = {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/open/ProgTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/viewer/open/ProgTableModel.scala
@@ -91,10 +91,10 @@ class ProgTableModel(filter: DBProgramChooserFilter, db: IDBDatabaseService, aut
   def getRowCount: Int =
     elems.get.length
 
-  def status(id:SPProgramID):Option[String] =
-    locals.get.find(_.getProgramID == id).flatMap(status)
+  def statusMessage(id:SPProgramID): Option[String] =
+    locals.get.find(_.getProgramID == id).flatMap(statusMessage)
 
-  def status(p: ISPProgram): Option[String] = for {
+  def statusMessage(p: ISPProgram): Option[String] = for {
     reg <- vcs
     _   <- reg.registration(p.getProgramID)
   } yield statuses.get.get(p.getNodeKey).map {
@@ -116,7 +116,7 @@ class ProgTableModel(filter: DBProgramChooserFilter, db: IDBDatabaseService, aut
         case 0 => p.programID
         case 1 => p.programName
         case 2 => Long.box(p.size)
-        case 3 => status(p.programID).orNull
+        case 3 => statusMessage(p.programID).orNull
       }
     }.orNull
 


### PR DESCRIPTION
Updates the OT Open dialog to allow multi-interval selection, changing the list selection model from `SINGLE_SELECTION` to `MULTIPLE_INTERVAL_SELECTION`.

It also enforces a total storage size limit and prevents checking out programs that would take the total storage over the size limit.  This wasn't explicitly requested but I worried about the consequences of attempting to check out the entire ODB.

The previous single select model would generate distinct warnings when deleting programs depending upon whether the program is not present in the remote database, has changes that haven't been committed, or is in sync.  Updating this for multi-select required a bit of simplification but nevertheless is the grimmest part of the PR.