### PR TITLE
REL-902: move initialization of ICTD

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
@@ -186,11 +186,11 @@ public final class Schedule extends BaseMutableBean implements PioSerializable, 
         }
 
         // ok, now the data should be up to date and ready to be processed
+        this.ictd = ImOption.apply(params.getParamSet(PROP_ICTD)).map(p -> new Ictd(p));
         this.blocks = getBlockUnion(params);
         this.variants = new VariantList(this, params.getParamSet(PROP_VARIANTS));
         this.extraSemesters = getExtraSemesters(params);
         this.comment = Pio.getValue(params, PROP_COMMENT);
-        this.ictd = ImOption.apply(params.getParamSet(PROP_ICTD)).map(p -> new Ictd(p));
         init(false, ImOption.empty());
     }
 


### PR DESCRIPTION
This PR fixes, or works around, an initialization issue.  When opening a QPT plan from the web, parts of the `Schedule` being created are accessed during initialization.  In particular, the `Variants` take the `Schedule` with which they are associated and use it as part of their own initialization. Unfortunately one of things that a `Variant` queries is the ICTD data, which wasn't yet available when needed. 