### PR TITLE
REL-3421: Prevent ITC OutOfMemoryError with oversized user-supplied SEDs

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
@@ -9,10 +9,10 @@ package edu.gemini.itc.base;
  * This interface provides functionality for defining and manipulating a
  * SampledSpectrum.
  * Units are not stored for either axis so the client must know from context.
- * The SampledSpectrum plays the rold of Element in a visitor pattern.
+ * The SampledSpectrum plays the role of Element in a visitor pattern.
  * This pattern is used to separate operations from the SampledSpectrum
  * elements.
- * The SampledSpectrum plays the rold of Element in a visitor pattern.
+ * The SampledSpectrum plays the role of Element in a visitor pattern.
  * This pattern is used to separate operations from the elements.
  * Because of this separation, Concrete Elements must offer enough
  * accessors for the separate Concrete Visitor class to perform the
@@ -47,6 +47,13 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
         double xStart = sp.getStart();
         double xEnd = sp.getEnd();
         int numIntervals = (int) ((xEnd - xStart) / xInterval);
+
+        // If the range of the user-supplied SED is too large for the sampling we run out of memory and die without telling the user why.
+        // This will preemptively exit if the array size is larger than (a fairly arbitrary) 40 million (currently dying at 43M).
+        if ( numIntervals > 40000000 ) {
+            throw new IllegalArgumentException(String.format("range is too large (%.1f - %.1f nm).", xStart, xEnd));
+        }
+
         double[] data = new double[numIntervals + 1];
         for (int i = 0; i <= numIntervals; ++i) {
             data[i] = sp.getY(i * xInterval + xStart);

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
@@ -75,10 +75,10 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
         xStart /= 1+z;
         xEnd /= 1+z;
 
-        int numIntervals = (int) ((xEnd - xStart) / xInterval);
+        int numIntervals = (int) Math.round((xEnd - xStart) / xInterval + 2); // +2 to allow for truncation
         double[] data = new double[numIntervals + 1];
         for (int i = 0; i <= numIntervals; ++i) {
-           data[i] = sp.getY(i * xInterval + xStart);
+           data[i] = sp.getY(xStart + i * xInterval);
         }
         reset(data, xStart, xInterval);
     }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
@@ -104,7 +104,7 @@ public final class SEDFactory {
             return new DefaultSampledSpectrum(as, wavelengthInterval);
 
         } catch (final Exception e) {
-            throw new Error("Could not parse user SED " + userSED.name() + ": " + e.getMessage());
+            throw new IllegalArgumentException("Could not parse user SED " + userSED.name() + ": " + e.getMessage());
         }
     }
 
@@ -194,7 +194,8 @@ public final class SEDFactory {
         // TODO: what about Nifs and Gnirs (other near-ir instruments)?
         if (instrument instanceof Gsaoi || instrument instanceof Niri || instrument instanceof Flamingos2) {
             if (sed.getStart() > instrument.getObservingStart() || sed.getEnd() < instrument.getObservingEnd()) {
-                throw new IllegalArgumentException("Shifted spectrum lies outside of observed wavelengths");
+                throw new IllegalArgumentException(String.format("Input SED (%.1f - %.1f nm) does not cover range of instrument configuration (%.1f - %.1f nm).",
+                        sed.getStart(), sed.getEnd(), instrument.getObservingStart(), instrument.getObservingEnd()));
             }
         }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
@@ -98,10 +98,10 @@ public final class SEDFactory {
      *  ...
      * </pre>
      */
-    private static VisitableSampledSpectrum getUserSED(final UserDefinedSpectrum userSED, final double wavelengthInterval) {
+    private static VisitableSampledSpectrum getUserSED(final UserDefinedSpectrum userSED, final double start, final double end, final double wavelengthInterval, final double redshift) {
         try {
             final DefaultArraySpectrum as = DefaultArraySpectrum.fromUserSpectrum(userSED.spectrum());
-            return new DefaultSampledSpectrum(as, wavelengthInterval);
+            return new DefaultSampledSpectrum(as, start, end, wavelengthInterval, redshift);
 
         } catch (final Exception e) {
             throw new IllegalArgumentException("Could not parse user SED " + userSED.name() + ": " + e.getMessage());
@@ -142,7 +142,11 @@ public final class SEDFactory {
 
         } else if (sdp.distribution() instanceof UserDefinedSpectrum) {
             final UserDefinedSpectrum userDefined = (UserDefinedSpectrum) sdp.distribution();
-            temp = getUserSED(userDefined, instrument.getSampling());
+            temp = getUserSED(userDefined,
+                    instrument.getObservingStart(),
+                    instrument.getObservingEnd(),
+                    instrument.getSampling(),
+                    sdp.redshift().z());
             temp.applyWavelengthCorrection();
             return temp;
 
@@ -175,7 +179,7 @@ public final class SEDFactory {
         //
         // inputs: instrument, SED
         // calculates: redshifted SED
-        // output: redshifteed SED
+        // output: redshifted SED
 
         final VisitableSampledSpectrum sed = SEDFactory.getSED(sdp, instrument);
         final SampledSpectrumVisitor redshift = new RedshiftVisitor(sdp.redshift());
@@ -194,7 +198,7 @@ public final class SEDFactory {
         // TODO: what about Nifs and Gnirs (other near-ir instruments)?
         if (instrument instanceof Gsaoi || instrument instanceof Niri || instrument instanceof Flamingos2) {
             if (sed.getStart() > instrument.getObservingStart() || sed.getEnd() < instrument.getObservingEnd()) {
-                throw new IllegalArgumentException(String.format("Input SED (%.1f - %.1f nm) does not cover range of instrument configuration (%.1f - %.1f nm).",
+                throw new IllegalArgumentException(String.format("Redshifted SED (%.1f - %.1f nm) does not cover range of instrument configuration (%.1f - %.1f nm).",
                         sed.getStart(), sed.getEnd(), instrument.getObservingStart(), instrument.getObservingEnd()));
             }
         }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Validation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Validation.java
@@ -5,8 +5,6 @@ import edu.gemini.spModel.core.EmissionLine;
 import edu.gemini.spModel.core.GaussianSource;
 import edu.gemini.spModel.core.SpatialProfile;
 
-
-
 /**
  * This is a collection of validation methods that originally were implemented repeatedly for the different
  * instruments and were rehomed here in a central location. It is questionable if this is the best place for all
@@ -19,6 +17,7 @@ public final class Validation {
     public static void validate(final Instrument instrument, final ObservationDetails obs, final SourceDefinition source) {
         checkElineWidth(instrument, source);
         checkGaussianFwhm(source.profile());
+        checkRedshift(source);
 
         if (obs.analysisMethod() instanceof ApertureMethod) {
             checkSkyAperture((ApertureMethod) obs.analysisMethod());
@@ -26,7 +25,12 @@ public final class Validation {
         if (obs.calculationMethod() instanceof S2NMethod) {
             checkSourceFraction(((S2NMethod) obs.calculationMethod()).exposures(), obs.calculationMethod().sourceFraction());
         }
+    }
 
+    private static void checkRedshift(final SourceDefinition source) {
+        if (source.redshift().z() <= -0.9) {
+            throw new IllegalArgumentException("Redshift must be > -0.9");
+        }
     }
 
     private static void checkSkyAperture(final ApertureMethod am) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/RedshiftVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/RedshiftVisitor.java
@@ -9,7 +9,7 @@ import edu.gemini.spModel.core.Redshift;
  */
 public class RedshiftVisitor implements SampledSpectrumVisitor {
     /**
-     * For efficiency, no shift will be performed unless z is
+     * For efficiency, no shift will be performed unless |z| is
      * larger than this value
      */
     public static final double MIN_SHIFT = 0.0001;
@@ -27,7 +27,9 @@ public class RedshiftVisitor implements SampledSpectrumVisitor {
      * Performs the redshift on specified spectrum.
      */
     public void visit(final SampledSpectrum sed) {
-        if (getShift() > MIN_SHIFT) {
+        if (getShift() <= -0.9) {
+            throw new IllegalArgumentException("Redshift must be > -0.9");
+        } else if (Math.abs(getShift()) > MIN_SHIFT) {
             sed.rescaleX(1.0 + getShift());
         }
     }


### PR DESCRIPTION
If a user supplies a SED which covers too broad a range in wavelength the ITC will resample it from start to finish and end up with an array which is too large for memory and it will silently crash, providing no feedback to the user about what is wrong.  The SED that was submitted by a user extends from 944 - 2,000,000 nm and the resampled SED has 99,952,807 points.

The solution implemented here is to extract only the wavelength range required by the instrument configuration, ignoring the unnecessary ends.  This required adding yet another implementation of DefaultSampledSpectrum which takes the desired wavelength range and the target redshift.

During testing, I noticed that some redshifts (e.g. 0.3) would truncate the input SED by one element when the redshift was applied.  Thus there is a +2 in the calculation of the number of points to compensate for this and allow for any integer truncation.