### PR TITLE
Feature/REL-3222 - Update GSAOI ITC web form

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -86,7 +86,7 @@ Note that these forms are not the same ones as in the production server.
 </tr>
 
 <tr>
-<td>GSAOI (near-infrared AO imager)</td>
+<td>GSAOI</td>
 <td><a href="servlets/web/ITCgsaoi.html">ITCgsaoi.html</a></td>
 </tr>
 
@@ -100,6 +100,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated March 3rd, 2017</footer>
+<footer>Last updated 2018-May-2</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
@@ -252,7 +252,7 @@
 
 <!-- Instrument definition-->
   <p><font color="#FF0000"><b>Instrument (Acquisition Camera) and telescope configuration</b></font></p>
-  <table border="0" width="100%" background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" cellpadding="6" cellspacing="0">
+  <table border="0" width="100%" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" cellpadding="6" cellspacing="0">
     <tr>
       <td colspan="4"><b>Instrument optical properties:</b><i><font size="-1">(</font><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10274#optical','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><font size="-1">more info</font></a><font size="-1">)</font></i></td>
     </tr>
@@ -321,7 +321,7 @@
   </p>
 <!-- Observing conditions definition-->
   <p><font color="#FF0000"><b>Observing condition constraints</b></font></p>
-  <table border="0" width="100%" background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" cellpadding="6"
+  <table border="0" width="100%" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" cellpadding="6"
   cellspacing="0">
     <tr>
 
@@ -377,7 +377,7 @@
   </p>
 <!-- Observation method and output control-->
   <p><font color="#FF0000"><b>Details of observation</b></font></p>
-  <table border="0" width="100%" height="70" background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif"
+  <table border="0" width="100%" height="70" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif"
   cellpadding="6" cellspacing="0">
     <tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -245,7 +245,7 @@
         <p>
             <span style="color: #ff0000"><b>Instrument (Flamingos-2), telescope</b></span>
         </p>
-        <table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+        <table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
             <tbody>
             <tr>
                 <td colspan="2"><b>Instrument optical properties:</b><i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10270#optical','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no');return false"><span>more info</span></a><span>)</span></i></td>
@@ -295,7 +295,7 @@
 
         </table>
 
-        <table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0"  width="100%">
+        <table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0"  width="100%">
             <tbody>
             <tr>
                 <td colspan="2" height="38" valign="bottom"><b>Detector properties:</b><i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/sciops/instruments/flamingos2/imaging/detector-characteristics','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
@@ -440,7 +440,7 @@
         <p>
             <span style="color: #ff0000"><b>Details of observation</b></span>
         </p>
-        <table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
+        <table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
             <tbody>
             <tr>
                 <td colspan="2" height="50" valign="bottom"><b>Calculation method:</b>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -313,7 +313,7 @@
 	<span style="color: #ff0000"><b>Instrument (GMOS North) and telescope configuration</b></span>
 	</p>
 
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<input name="Site" value="GN" type="hidden" />
 		<tbody>
 			<tr>
@@ -493,7 +493,7 @@
 	<span style="color: #ff0000"><b>Observing condition constraints</b></span>
 
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="6">Note: you should read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no');return false">explanatory
@@ -558,7 +558,7 @@
 
 	<span style="color: #ff0000"><b>Details of observation</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="2" height="50" valign="bottom"><b>Calculation method:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no');return false">more info</a>)</span></i><br />

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -312,7 +312,7 @@
     <span style="color: #ff0000"><b>Instrument (GMOS South) and telescope configuration</b></span>
     </p>
 
-    <table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+    <table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
         <input name="Site" value="GS" type="hidden" />
         <tbody>
             <tr>
@@ -488,7 +488,7 @@
     <span style="color: #ff0000"><b>Observing condition constraints</b></span>
 
     </p>
-    <table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+    <table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
         <tbody>
             <tr>
                 <td colspan="6">Note: you should read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory
@@ -552,7 +552,7 @@
 
     <span style="color: #ff0000"><b>Details of observation</b></span>
     </p>
-    <table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
+    <table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
         <tbody>
             <tr>
                 <td colspan="2" height="50" valign="bottom"><b>Calculation method:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i><br />

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -394,7 +394,7 @@
 
     </table>
 
-    <table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0"  width="100%">
+    <table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0"  width="100%">
         <tbody>
 			<!--end gnirs stuff-->
 			<tr>
@@ -435,7 +435,7 @@
 			</tr>
 		</tbody>
 	</table>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0"  width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0"  width="100%">
 		<tbody>
 			<!-- Telescope definition-->
 			<tr>
@@ -493,7 +493,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Observing condition constraints</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="6">Note: you should read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory
@@ -556,7 +556,7 @@
 
 	<span style="color: #ff0000"><b>Details of observation</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="2" height="40" valign="bottom"><b>Calculation method:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
@@ -313,10 +313,13 @@
 	<p>
 	<span style="color: #ff0000"><b>Instrument (GSAOI), telescope, and GeMS configuration</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
-				<td colspan="4"><b>Instrument optical properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10270#optical','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
+				<td colspan="4"><b>Instrument optical properties:</b>
+					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/21054','mywindow',
+					'width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,
+					scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
 			</tr>
 			<tr>
                 <td colspan="4">
@@ -364,12 +367,13 @@
                 </td>
 			</tr>
 			<tr>
-				<td colspan="4" height="50" valign="bottom"><b>Detector properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10270#detector','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
-
+				<td colspan="4" height="50" valign="bottom"><b>Detector properties:</b>
+					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/21054','mywindow',
+					'width=1000,height=700,toolbar=no,location=no,directories=no,status=no,menubar=no,
+					scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
 			</tr>
             <tr>
                 <td colspan="4" height="20">Read mode:  </td>
-
             </tr>
             <tr>
                 <td colspan="4" align="right" height="21"><input value="BRIGHT" name="ReadMode" checked="checked" type="radio" />
@@ -377,7 +381,6 @@
             </tr>
             <tr>
                 <td colspan="4" align="right" height="21"><input value="FAINT" name="ReadMode" type="radio" />
-
                 Faint Objects / Broad band imaging (Low Noise Reads = 8, Read noise = 13e-) </td>
             </tr>
             <tr>
@@ -391,7 +394,6 @@
 			<!-- Telescope definition-->
 			<tr>
 				<td colspan="4" height="50" valign="bottom"><b>Telescope configuration:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10271','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>
-
 			</tr>
 			<tr>
 				<td colspan="4" height="21">Mirror coating:
@@ -413,8 +415,12 @@
                        </select>
                 </td>
             </tr-->
-
-
+			<tr>
+				<td colspan="4" height="50" valign="bottom">The Strehl ratio is estimated from the selected filter and image quality.
+					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/21054','mywindow',
+					'width=1000,height=700,toolbar=no,location=no,directories=no,status=no,menubar=no,
+					scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
+			</tr>
 			<tr>
 				<td colspan="4">
 					<p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->
@@ -432,7 +438,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Observing condition constraints</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="6">Note: you should read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory
@@ -441,10 +447,6 @@
 				available on the <a href="#" onclick="window.open('http://www.gemini.edu/sciops/ObsProcess/obsConstraints/obsConstraintsIndex.html','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">observing
 				condition constraints</a> pages. </td>
 			</tr>
-            <tr>
-                <td colspan="6"><font color="red">Be sure to update the Average Strehl Ratio when changing the IQ.</font> </td>
-            </tr>
-
             <tr>
                 <td><b>Image quality:</b></td>
                 <td><input name="ImageQuality" value="PERCENT_20" type="radio" /> 20%/Best</td>
@@ -497,7 +499,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Details of observation</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
 		<tbody>
 
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
@@ -317,9 +317,7 @@
 		<tbody>
 			<tr>
 				<td colspan="4"><b>Instrument optical properties:</b>
-					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/21054','mywindow',
-					'width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,
-					scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
+					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/21054','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
 			</tr>
 			<tr>
                 <td colspan="4">
@@ -368,9 +366,7 @@
 			</tr>
 			<tr>
 				<td colspan="4" height="50" valign="bottom"><b>Detector properties:</b>
-					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/21054','mywindow',
-					'width=1000,height=700,toolbar=no,location=no,directories=no,status=no,menubar=no,
-					scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
+					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/21054','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
 			</tr>
             <tr>
                 <td colspan="4" height="20">Read mode:  </td>
@@ -393,7 +389,8 @@
 			</tr>
 			<!-- Telescope definition-->
 			<tr>
-				<td colspan="4" height="50" valign="bottom"><b>Telescope configuration:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10271','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>
+				<td colspan="4" height="50" valign="bottom"><b>Telescope configuration:</b>
+					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10271','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
 			</tr>
 			<tr>
 				<td colspan="4" height="21">Mirror coating:
@@ -417,9 +414,7 @@
             </tr-->
 			<tr>
 				<td colspan="4" height="50" valign="bottom">The Strehl ratio is estimated from the selected filter and image quality.
-					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/21054','mywindow',
-					'width=1000,height=700,toolbar=no,location=no,directories=no,status=no,menubar=no,
-					scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
+					<i>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/21054','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</i></td>
 			</tr>
 			<tr>
 				<td colspan="4">

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -229,7 +229,7 @@
 	<span style="color: #ff0000"><b>Instrument (Michelle) and telescope configuration</b></span>
 	</p>
 
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="4"><b>Instrument optical properties:</b></td>
@@ -330,7 +330,7 @@
 	<span style="color: #ff0000"><b>Observing condition constraints</b></span>
 
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="6">Note: you should read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory
@@ -394,7 +394,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Details of observation</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
 		<tbody>
 
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
@@ -308,7 +308,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Instrument (NIFS), telescope, and Altair configuration</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="545" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="545" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="4" height="21"><b>Instrument optical properties:</b></td>
@@ -422,7 +422,7 @@
 	<span style="color: #ff0000"><b>Observing condition constraints</b></span>
 	</p>
 
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="6">Note: you should read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory
@@ -484,7 +484,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Details of observation</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
 		<tbody>
 
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
@@ -312,7 +312,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Instrument (NIRI), telescope, and Altair configuration</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="4"><b>Instrument optical properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10270#optical','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
@@ -487,7 +487,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Observing condition constraints</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="6">Note: you should read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory
@@ -550,7 +550,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Details of observation</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
 		<tbody>
 
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
@@ -232,7 +232,7 @@
 	<span style="color: #ff0000"><b>Instrument (T-ReCS) and telescope configuration</b></span>
 	</p>
 
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 			<tr>
 				<td colspan="4"><b>Instrument optical properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10276#optical','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
@@ -344,7 +344,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Observing condition constraints</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" width="100%">
 		<tbody>
 
 			<tr>
@@ -407,7 +407,7 @@
 	<p>
 	<span style="color: #ff0000"><b>Details of observation</b></span>
 	</p>
-	<table background="http://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
+	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
 		<tbody>
 
 			<tr>


### PR DESCRIPTION
This PR includes a minor update to the GSAOI ITC web form, removing some obsolete text after the implementation of the automatic Strehl lookup, and fixing the "(more info)" links which were pointing to more info about NIRI.  I also fixed a few background links which were still using http instead of https (per REL-3332).