### PR TITLE
REL-3421: Fix ITC failure when user-supplied SED range is too large

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -100,6 +100,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2018-May-2</footer>
+<footer>Last updated 2018-May-7</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
@@ -67,7 +67,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
 
         if ( (1+z) * sp.getStart() > xStart || (1+z) * sp.getEnd() < xEnd ) {
             throw new IllegalArgumentException(
-                    String.format("Redshifted SED (%.1f - %.1f nm) does not cover range of instrument configuration (%.1f - %.1f nm).",
+                    String.format("Redshifted SED (%.1f - %.1f nm) does not cover the range of the instrument and normalization band (%.1f - %.1f nm).",
                             (1+z)*sp.getStart(), (1+z)*sp.getEnd(), xStart, xEnd));
         }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
@@ -142,9 +142,11 @@ public final class SEDFactory {
 
         } else if (sdp.distribution() instanceof UserDefinedSpectrum) {
             final UserDefinedSpectrum userDefined = (UserDefinedSpectrum) sdp.distribution();
+            final MagnitudeBand band = sdp.normBand();
+            // The user-supplied SED must cover the range of the instrument configuration and the normalization band.
             temp = getUserSED(userDefined,
-                    instrument.getObservingStart(),
-                    instrument.getObservingEnd(),
+                    Math.min(instrument.getObservingStart(), band.start().toNanometers()),
+                    Math.max(instrument.getObservingEnd(), band.end().toNanometers()),
                     instrument.getSampling(),
                     sdp.redshift().z());
             temp.applyWavelengthCorrection();
@@ -206,7 +208,8 @@ public final class SEDFactory {
         // any sed except BBODY and ELINE have normalization regions
         if (!(sdp.distribution() instanceof EmissionLine) && !(sdp.distribution() instanceof BlackBody)) {
             if (sed.getStart() > start || sed.getEnd() < end) {
-                throw new IllegalArgumentException("Shifted spectrum lies outside of specified normalisation waveband.");
+                throw new IllegalArgumentException(String.format("Redshifted SED (%.1f - %.1f nm) does not cover the specified normalization waveband (%.1f - %.1f nm).",
+                        sed.getStart(), sed.getEnd(), start, end));
             }
         }
 


### PR DESCRIPTION
This PR expands the range of the extracted user-supplied SED to cover the specified normalization band.