### PR TITLE
REL-902: distinguish config unavailable vs mask unavailable

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
@@ -685,10 +685,7 @@ public final class Variant extends BaseMutableBean implements PioSerializable, C
 						if (a == Availability.SummitCabinet) {
 							maskFlags.add(Flag.MASK_IN_CABINET);
 						} else if (a != Availability.Installed) {
-							// TODO: distinguish this case from standard
-							// facilities unavailable with a different Flag?
-							// MASK_UNAVAILABLE?
-							maskFlags.add(Flag.CONFIG_UNAVAILABLE);
+							maskFlags.add(Flag.MASK_UNAVAILABLE);
 						}
 					}
 				});
@@ -954,6 +951,7 @@ public final class Variant extends BaseMutableBean implements PioSerializable, C
 	private static final EnumSet<Flag> AUTOMATIC_DEATH_FLAGS = EnumSet.of(
 			Flag.CONFIG_UNAVAILABLE,
 			Flag.MASK_IN_CABINET,
+			Flag.MASK_UNAVAILABLE,
             Flag.LGS_UNAVAILABLE,
 			Flag.INSTRUMENT_UNAVAILABLE,
 			Flag.ELEVATION_CNS,

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -199,6 +199,10 @@ public class LimitsListener extends MarkerModelListener<Variant> {
 					mm.addMarker(false, this, Severity.Error, "Required custom mask is in cabinet.", v, a);
 					break;
 
+				case MASK_UNAVAILABLE:
+					mm.addMarker(false, this, Severity.Error, "Required custom mask is unavailable.", v, a);
+					break;
+
 				case INSTRUMENT_UNAVAILABLE:
 					mm.addMarker(false, this, Severity.Error, "Required instrument is unavailable.", v, a);
 					break;

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/ObsWeighter.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/ObsWeighter.java
@@ -15,6 +15,7 @@ public class ObsWeighter {
 	private static final EnumSet<Flag> AUTOMATIC_DEATH_FLAGS = EnumSet.of(
         Flag.CONFIG_UNAVAILABLE,
 		Flag.MASK_IN_CABINET,
+		Flag.MASK_UNAVAILABLE,
         Flag.LGS_UNAVAILABLE,
 		Flag.INSTRUMENT_UNAVAILABLE,
 		Flag.ELEVATION_CNS,

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/util/CandidateDecorator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/util/CandidateDecorator.java
@@ -5,6 +5,7 @@ import static edu.gemini.qpt.core.Variant.Flag.BLOCKED;
 import static edu.gemini.qpt.core.Variant.Flag.CC_UQUAL;
 import static edu.gemini.qpt.core.Variant.Flag.CONFIG_UNAVAILABLE;
 import static edu.gemini.qpt.core.Variant.Flag.MASK_IN_CABINET;
+import static edu.gemini.qpt.core.Variant.Flag.MASK_UNAVAILABLE;
 import static edu.gemini.qpt.core.Variant.Flag.LGS_UNAVAILABLE;
 import static edu.gemini.qpt.core.Variant.Flag.ELEVATION_CNS;
 import static edu.gemini.qpt.core.Variant.Flag.INACTIVE;
@@ -40,6 +41,7 @@ public class CandidateDecorator {
             INSTRUMENT_UNAVAILABLE,
             CONFIG_UNAVAILABLE,
             MASK_IN_CABINET,
+            MASK_UNAVAILABLE,
             LGS_UNAVAILABLE,
             BLOCKED,
             INACTIVE,
@@ -60,6 +62,7 @@ public class CandidateDecorator {
             INSTRUMENT_UNAVAILABLE,
             CONFIG_UNAVAILABLE,
             MASK_IN_CABINET,
+            MASK_UNAVAILABLE,
             LGS_UNAVAILABLE,
             ELEVATION_CNS,
             BACKGROUND_CNS,

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/ClientExclusion.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/candidate/ClientExclusion.java
@@ -144,7 +144,7 @@ public enum ClientExclusion {
             return HIDDEN_BLOCKED_OBSERVATIONS;
         if (!VIEW_OVER_QUALIFIED_OBSERVATIONS.get() && flags.contains(Flag.OVER_QUALIFIED))
             return HIDDEN_OVER_QUALIFIED_OBSERVATIONS;
-        if (!VIEW_UNAVAILABLE.get() && (flags.contains(Flag.INSTRUMENT_UNAVAILABLE) || flags.contains(Flag.CONFIG_UNAVAILABLE) || flags.contains(Flag.LGS_UNAVAILABLE)))
+        if (!VIEW_UNAVAILABLE.get() && (flags.contains(Flag.INSTRUMENT_UNAVAILABLE) || flags.contains(Flag.CONFIG_UNAVAILABLE) || flags.contains(Flag.LGS_UNAVAILABLE) || flags.contains(Flag.MASK_UNAVAILABLE)))
             return HIDDEN_UNAVAILABLE;
         if (!VIEW_MASK_IN_CABINET.get() && (flags.contains(Flag.MASK_IN_CABINET)))
             return HIDDEN_MASK_IN_CABINET;


### PR DESCRIPTION
A small update to the ICTD/QPT integration.  It was requested to distinguish observations with an unavailable custom mask from those with an unavailable filter/grating, etc.

If there isn't a problem with this change, I'll make another PR for the release branch.