### PR TITLE
REL-902: add a Masks table

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/ShellAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/ShellAdvisor.java
@@ -40,6 +40,7 @@ import edu.gemini.qpt.ui.view.histo.HistoViewAdvisor;
 import edu.gemini.qpt.ui.view.instrument.InstViewAdvisor;
 import edu.gemini.qpt.ui.view.lchWindow.LchWindowType;
 import edu.gemini.qpt.ui.view.lchWindow.LchWindowViewAdvisor;
+import edu.gemini.qpt.ui.view.mask.MaskViewAdvisor;
 import edu.gemini.qpt.ui.view.problem.ProblemViewAdvisor;
 import edu.gemini.qpt.ui.view.program.ScienceProgramViewAdvisor;
 import edu.gemini.qpt.ui.view.property.PropertyViewAdvisor;
@@ -83,6 +84,7 @@ public class ShellAdvisor implements IShellAdvisor, PropertyChangeListener {
         Visits(new VisitViewAdvisor(), SouthOf, Visualizer),
         Variants(new VariantViewAdvisor(), NorthOf, Candidates),
         Instruments(new InstViewAdvisor(), Beneath, Variants),
+        Masks(new MaskViewAdvisor(), Beneath, Instruments),
         Prperties(new PropertyViewAdvisor(), SouthOf, Visits),
         Problems(new ProblemViewAdvisor(), SouthOf, Prperties),
         Comments(new CommentViewAdvisor(), Beneath, Problems),

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskAttribute.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskAttribute.java
@@ -1,0 +1,7 @@
+package edu.gemini.qpt.ui.view.mask;
+
+enum MaskAttribute {
+
+    Name, Availability
+
+}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
@@ -1,0 +1,79 @@
+package edu.gemini.qpt.ui.view.mask;
+
+import edu.gemini.ictd.CustomMaskKey;
+import edu.gemini.spModel.ictd.Availability;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
+
+import edu.gemini.ui.gface.GTableController;
+import edu.gemini.ui.gface.GViewer;
+
+import edu.gemini.qpt.core.Schedule;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+
+
+public final class MaskController implements GTableController<Schedule, Map.Entry<CustomMaskKey, Availability>, MaskAttribute>, PropertyChangeListener {
+
+    private GViewer<Schedule, Map.Entry<CustomMaskKey, Availability>> viewer;
+    @SuppressWarnings("rawtypes")
+    private Map.Entry<CustomMaskKey, Availability>[] entries = new Map.Entry[0];
+    private Schedule schedule;
+
+    @Override
+    public Object getSubElement(Map.Entry<CustomMaskKey, Availability> element, MaskAttribute subElement) {
+        switch (subElement) {
+            case Name:         return element.getKey().name();
+            case Availability: return element.getValue();
+            default:           throw new IllegalArgumentException(subElement.name());
+        }
+    }
+
+    @Override
+    public synchronized Map.Entry<CustomMaskKey, Availability> getElementAt(int row) {
+        return entries[row];
+    }
+
+    @Override
+    public synchronized int getElementCount() {
+        return entries.length;
+    }
+
+    @Override
+    public synchronized void modelChanged(GViewer<Schedule, Map.Entry<CustomMaskKey, Availability>> viewer, Schedule oldModel, Schedule newModel) {
+        this.viewer = viewer;
+        if (oldModel != null) oldModel.removePropertyChangeListener(Schedule.PROP_ICTD, this);
+        this.schedule = newModel;
+        if (newModel != null) newModel.addPropertyChangeListener(Schedule.PROP_ICTD, this);
+        fetchMasks();
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        fetchMasks();
+        viewer.refresh();
+    }
+
+    private synchronized void fetchMasks() {
+        final Map<CustomMaskKey, Availability> masks;
+        masks = ImOption.apply(schedule)
+                        .flatMap(s -> schedule.getIctd())
+                        .map(i -> i.maskAvailability)
+                        .getOrElse(() -> Collections.emptyMap());
+
+        this.entries = masks.entrySet().toArray(new Map.Entry[masks.size()]);
+
+        Arrays.sort(entries, new Comparator<Map.Entry<CustomMaskKey, Availability>>() {
+            @Override
+            public int compare(Map.Entry<CustomMaskKey, Availability> e1, Map.Entry<CustomMaskKey, Availability> e2) {
+                return e1.getKey().name().compareTo(e2.getKey().name());
+            }
+        });
+    }
+}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskDecorator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskDecorator.java
@@ -1,0 +1,28 @@
+package edu.gemini.qpt.ui.view.mask;
+
+import edu.gemini.ictd.CustomMaskKey;
+import edu.gemini.qpt.core.Schedule;
+import edu.gemini.spModel.ictd.Availability;
+import edu.gemini.ui.gface.GSubElementDecorator;
+import edu.gemini.ui.gface.GViewer;
+
+import java.util.Map;
+import javax.swing.JLabel;
+
+// Decorator just needed to format "SummitCabinet" as "Summit Cabinet".
+public final class MaskDecorator implements GSubElementDecorator<Schedule, Map.Entry<CustomMaskKey, Availability>, MaskAttribute> {
+
+    @Override
+    public void decorate(JLabel label, Map.Entry<CustomMaskKey, Availability> element, MaskAttribute subElement, Object value) {
+        switch (subElement) {
+            case Availability:
+                switch ((Availability) value) {
+                    case SummitCabinet: label.setText("Summit Cabinet"); break;
+                }
+        }
+    }
+
+    @Override
+    public void modelChanged(GViewer<Schedule, Map.Entry<CustomMaskKey, Availability>> viewer, Schedule oldModel, Schedule newModel) {
+    }
+}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskViewAdvisor.java
@@ -1,0 +1,65 @@
+package edu.gemini.qpt.ui.view.mask;
+
+import edu.gemini.qpt.core.Schedule;
+import edu.gemini.qpt.ui.util.ScrollPanes;
+import static edu.gemini.qpt.ui.view.mask.MaskAttribute.*;
+
+import edu.gemini.ictd.CustomMaskKey;
+import edu.gemini.spModel.ictd.Availability;
+
+import edu.gemini.ui.gface.GTableViewer;
+import edu.gemini.ui.workspace.IShell;
+import edu.gemini.ui.workspace.IViewAdvisor;
+import edu.gemini.ui.workspace.IViewContext;
+import edu.gemini.ui.workspace.util.Factory;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import java.util.Map;
+
+import javax.swing.JScrollPane;
+
+
+
+public final class MaskViewAdvisor implements IViewAdvisor, PropertyChangeListener {
+
+    // The table viewer
+    final GTableViewer<Schedule, Map.Entry<CustomMaskKey, Availability>, MaskAttribute> viewer =
+        new GTableViewer<>(new MaskController());
+
+    // The scroll bar
+    final JScrollPane scroll = Factory.createStrippedScrollPane(viewer.getTable());
+
+    public MaskViewAdvisor() {
+
+        // Set up the viewer
+        viewer.setColumns(Name, Availability);
+        viewer.setColumnSize(Name,         110, Integer.MAX_VALUE);
+        viewer.setColumnSize(Availability, 240, Integer.MAX_VALUE);
+        viewer.setDecorator(new MaskDecorator());
+
+        // Add the scroll pane.  Height is ignored so just use 0.
+        ScrollPanes.setViewportHeight(scroll, 0);
+    }
+
+    public void close(IViewContext context) {
+        context.getShell().removePropertyChangeListener(IShell.PROP_MODEL, this);
+    }
+
+    public void open(IViewContext context) {
+        context.setTitle("Masks");
+        context.setContent(scroll);
+        context.setSelectionBroker(viewer);
+        context.getShell().addPropertyChangeListener(IShell.PROP_MODEL, this);
+    }
+
+    public void setFocus() {
+        viewer.getControl().requestFocus();
+    }
+
+    public void propertyChange(PropertyChangeEvent evt) {
+        viewer.setModel((Schedule) evt.getNewValue());
+    }
+
+}


### PR DESCRIPTION
A request was made to display the ICTD mask availability data, which I placed in a table beside "Instruments".

If this seems acceptable, I'll also make a PR for the release branch as well.

![masks](https://user-images.githubusercontent.com/4906023/39782111-9fa1b738-52e7-11e8-9047-b097b16a064a.jpeg)
