### PR TITLE
REL-3028: make ToO guide star optional

### DIFF
--- a/bundle/edu.gemini.oodb.too.url/README.md
+++ b/bundle/edu.gemini.oodb.too.url/README.md
@@ -56,8 +56,10 @@ This bundle originated from `edu.gemini.oodb.too.url` in the OCS 1.5 build.
 Supported magnitude systems.
 
 
-
 #### Guide Star Details
+
+Guide stars are optional, but if any of the parameters are specified then all
+required parameters must be specified.
 
 | Parameter | Format/Example            | Reqd?  | Notes
 |-----------|---------------------------|:------:|-------
@@ -68,6 +70,18 @@ Supported magnitude systems.
 | `gsprobe` | `PWFS1`                 |✓       | guide probe
 
 Allowed guide probe values are `PWFS1`, `PWFS2`, `OIWFS`, and `AOWFS`.
+
+#### Example Queries
+
+* With guide star
+```
+curl -k "https://localhost:8443/too?prog=GS-2018A-Q-1&posangle=0.0&note=hello&ready=true&email=bob@burger.com&password=password&obsnum=4&target=canopus&ra=06:23:57.110&dec=-52:41:44.38&gstarget=187-007980&gsra=06:23:39.584&gsdec=-52:41:16.43&gsprobe=OIWFS"
+```
+
+* Without guide star
+```
+curl -k "https://localhost:8443/too?prog=GS-2018A-Q-1&posangle=0.0&note=hello&ready=true&email=bob@burger.com&password=password&obsnum=4&target=canopus&ra=06:23:57.110&dec=-52:41:44.38"
+```
 
 
 

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/TooUpdate.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/TooUpdate.java
@@ -4,6 +4,7 @@
 
 package edu.gemini.spdb.rapidtoo;
 
+import edu.gemini.shared.util.immutable.Option;
 import java.io.Serializable;
 
 /**
@@ -24,7 +25,7 @@ public interface TooUpdate extends Serializable {
     /**
      * Gets the guide star coordinate, etc. information.
      */
-    TooGuideTarget getGuideStar();
+    Option<TooGuideTarget> getGuideStar();
 
     /**
      * Gets the instrument position angle to apply to the cloned template

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
@@ -230,8 +230,7 @@ final class TooUpdateServiceImpl implements TooUpdateService {
         targetObsComp.setTargetEnvironment(env0);
 
         // Set the guide star, if present.
-        final TooGuideTarget gs = update.getGuideStar();
-        if (gs != null) {
+        update.getGuideStar().foreach(gs -> {
             final TooGuideTarget.GuideProbe tooProbe = gs.getGuideProbe();
             if (tooProbe == null) {
                 LOG.warning("Guide star probe not specified.");
@@ -273,7 +272,7 @@ final class TooUpdateServiceImpl implements TooUpdateService {
                     targetObsComp.setTargetEnvironment(env1);
                 }
             }
-        }
+        });
 
         // Store the data object back.
         targetComp.setDataObject(targetObsComp);

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/www/HttpTarget.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/www/HttpTarget.java
@@ -9,6 +9,10 @@ import edu.gemini.spModel.core.Angle$;
 import edu.gemini.spModel.core.Magnitude;
 import edu.gemini.spdb.rapidtoo.TooTarget;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -28,6 +32,17 @@ public abstract class HttpTarget implements TooTarget {
     public static final String TARGET_RA_PARAM   = "ra";
     public static final String TARGET_DEC_PARAM  = "dec";
     public static final String TARGET_MAGS_PARAM = "mags";
+
+    public static Set<String> allParams(final String prefix) {
+        return Arrays.asList(
+            TARGET_NAME_PARAM,
+            TARGET_RA_PARAM,
+            TARGET_DEC_PARAM,
+            TARGET_MAGS_PARAM
+        ).stream()
+         .map(p -> prefix + p)
+         .collect(Collectors.toCollection(() -> new HashSet<String>()));
+    }
 
     private static Double parseRa(String val) throws BadRequestException {
         try {

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/www/HttpTooUpdate.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/www/HttpTooUpdate.java
@@ -5,6 +5,7 @@
 package edu.gemini.spdb.rapidtoo.www;
 
 import edu.gemini.spdb.rapidtoo.*;
+import edu.gemini.shared.util.immutable.Option;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -28,7 +29,7 @@ public final class HttpTooUpdate implements TooUpdate {
 
     private final TooIdentity _id;
     private final TooTarget _target;
-    private final TooGuideTarget _guide;
+    private final Option<TooGuideTarget> _guide;
     private final Double _posAngle;
     private final String _note;
     private final TooElevationConstraint _elevation;
@@ -45,7 +46,7 @@ public final class HttpTooUpdate implements TooUpdate {
     public HttpTooUpdate(HttpServletRequest req) throws BadRequestException {
         _id     = new HttpTooIdentity(req);
         _target = new HttpTooTarget(req);
-        _guide  = new HttpTooGuideTarget(req);
+        _guide  = HttpTooGuideTarget.parse(req);
 
         double posAngle = 0.0;
         String val = req.getParameter(POSITION_ANGLE_PARAM);
@@ -86,7 +87,7 @@ public final class HttpTooUpdate implements TooUpdate {
         return _target;
     }
 
-    public TooGuideTarget getGuideStar() {
+    public Option<TooGuideTarget> getGuideStar() {
         return _guide;
     }
 


### PR DESCRIPTION
Skips setting the guide star if not specified in the ToO trigger request.