### PR TITLE
REL-1714-C Report intersection of constraints

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -3,8 +3,6 @@ package edu.gemini.qpt.core.listeners;
 import java.beans.PropertyChangeEvent;
 import java.util.*;
 import java.util.function.*;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.TimeZone;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -32,17 +30,6 @@ public class LimitsListener extends MarkerModelListener<Variant> {
 
 	@SuppressWarnings("unused")
 	private static final Logger LOGGER = Logger.getLogger(LimitsListener.class.getName());
-
-	private static final DateTimeFormatter dateFormat(TimeZone zone) {
-		return DateTimeFormatter.ofPattern("HH:mm").withZone(zone.toZoneId());
-	};
-
-	private static final String formatInterval(TimeZone zone, Interval interval) {
-		final Function<Long, String> f =
-			ms -> dateFormat(zone).format(Instant.ofEpochMilli(ms));
-
-		return String.format("(%s, %s)", f.apply(interval.getStart()), f.apply(interval.getEnd()));
-	}
 
     /**
      * LGS obs have a 40 deg limit by default
@@ -86,30 +73,12 @@ public class LimitsListener extends MarkerModelListener<Variant> {
 				mm.addMarker(false, this, Severity.Warning, String.format("Tracking: target reaches %1.2f\u00B0.", maxElevation), v, a);
 			}
 
-			// Function to create markers that report solver intervals.
-			final BiFunction<String, String, Option<Marker>> createSolverMarker =
-					(cacheName, prefix) -> {
-						final Map<Obs, Union<Interval>> c = v.getSchedule().getCache(cacheName);
-						final Union<Interval>          ws = c.getOrDefault(a.getObs(), new Union<>());
-						final ImList<Interval>         is = DefaultImList.create(ws.getIntervals());
-
-						if (is.isEmpty()) {
-							return None.instance();
-						} else {
-							final String m = is.map(i -> formatInterval(zone, i)).mkString(prefix + " ", ", ", ".");
-							return new Some<>(new Marker(false, this, Severity.Notice, m, v, a));
-						}
-					};
-
 			// Timing window
 			int percentVisible = (int) (100 * a.getMean(Circumstance.TIMING_WINDOW_OPEN, false));
 			switch (percentVisible) {
 			case 100: // good!
 				if (a.getObs().getTimingWindows().size() > 0) {
 					mm.addMarker(true, this, Severity.Info, "Timing constraint is met.", v, a);
-
-					// Report timing windows
-					createSolverMarker.apply(Variant.TIMING_UNION_CACHE, "Must be in the timing window").foreach(m -> mm.addMarker(m));
 				}
                 break;
 			case 0:
@@ -127,7 +96,28 @@ public class LimitsListener extends MarkerModelListener<Variant> {
                 mm.addMarker(false, this, Severity.Warning, msg, v, a);
             }
 
-            // Elevation Constraint
+			// Function to create markers that report solver intervals.
+			final BiFunction<String, String, Option<Marker>> createSolverMarker =
+				(cacheName, prefix) -> {
+					final Map<Obs, Union<Interval>> c = v.getSchedule().getCache(cacheName);
+					final Union<Interval>       valid = c.getOrDefault(a.getObs(), new Union<>());
+
+					final Union<Interval>     invalid = new Union<>(new Interval(v.getSchedule().getStart(), v.getSchedule().getEnd()));
+					invalid.remove(valid);
+
+					final ImList<Interval>         is = DefaultImList.create(valid.getIntervals());
+
+					if (is.isEmpty() || invalid.isEmpty()) {
+						return None.instance();
+					} else {
+						return new Some<>(new Marker(false, this, Severity.Notice, prefix, new Some<>(valid), v, a));
+					}
+				};
+
+			// Report intersection of constraints.
+			createSolverMarker.apply(Variant.CONSTRAINED_UNION_CACHE, "Must be observed between").foreach(m -> mm.addMarker(m));
+
+
             // Elevation Constraint
 			final Double maxAirmass = a.getMax(Circumstance.AIRMASS, false);
 			final Double minAirmass = a.getMin(Circumstance.AIRMASS, false);
@@ -167,24 +157,18 @@ public class LimitsListener extends MarkerModelListener<Variant> {
 				final double airmassLimitMin = a.getObs().getElevationConstraintMin();
 				final double airmassLimitMax = a.getObs().getElevationConstraintMax();
 
-				Option<Marker> airmassMarker = None.instance();
 				if (maxAirmass > airmassLimitMax) {
-					airmassMarker = new Some<>(new Marker(false, this, Severity.Error, String.format("Airmass constraint violated (%1.2f > %1.2f).", maxAirmass, airmassLimitMax), v, a));
+					mm.addMarker(false, this, Severity.Error, String.format("Airmass constraint violated (%1.2f > %1.2f).", maxAirmass, airmassLimitMax), v, a);
 				} else if (maxAirmass > airmassLimitMax * 0.975) {
-					airmassMarker = new Some<>(new Marker(false, this, Severity.Warning, String.format("Observation reaches airmass %1.2f.", maxAirmass), v, a));
+					mm.addMarker(false, this, Severity.Warning, String.format("Observation reaches airmass %1.2f.", maxAirmass), v, a);
 				}
 				if (airmassLimitMin > 1.0) {
 					if (minAirmass < airmassLimitMin) {
-						airmassMarker = new Some<>(new Marker(false, this, Severity.Error, String.format("Airmass constraint violated (%1.2f < %1.2f).", minAirmass, airmassLimitMin), v, a));
+						mm.addMarker(false, this, Severity.Error, String.format("Airmass constraint violated (%1.2f < %1.2f).", minAirmass, airmassLimitMin), v, a);
 					} else if (maxAirmass < airmassLimitMin * 1.025) {
-						airmassMarker = new Some<>(new Marker(false, this, Severity.Warning, String.format("Observation reaches airmass %1.2f.", maxAirmass), v, a));
+						mm.addMarker(false, this, Severity.Warning, String.format("Observation reaches airmass %1.2f.", maxAirmass), v, a);
 					}
 				}
-
-				airmassMarker.orElse(() -> {
-					final String m = String.format("Must be observed in the airmass range %1.2f - %1.2f", airmassLimitMin, airmassLimitMax);
-					return createSolverMarker.apply(Variant.VISIBLE_UNION_CACHE, m);
-				}).foreach(m -> mm.addMarker(m));
 
 				break;
 
@@ -199,23 +183,17 @@ public class LimitsListener extends MarkerModelListener<Variant> {
 				double minDelta = Math.abs(haLimitMin - minHA);
 				double maxDelta = Math.abs(haLimitMax - maxHA);
 
-				Option<Marker> haMarker = None.instance();
 				if (minHA < haLimitMin) {
-					haMarker = new Some<>(new Marker(false, this, Severity.Error, String.format("Hour angle constraint violated (%s < %s).", TimeUtils.hoursToHHMMSS(minHA), TimeUtils.hoursToHHMMSS(haLimitMin)), v, a));
+					mm.addMarker(false, this, Severity.Error, String.format("Hour angle constraint violated (%s < %s).", TimeUtils.hoursToHHMMSS(minHA), TimeUtils.hoursToHHMMSS(haLimitMin)), v, a);
 				} else if (minDelta < 1. / 15.) {
-					haMarker = new Some<>(new Marker(false, this, Severity.Warning, "Target comes within 1\u00B0 of lower HA constraint.", v, a));
+					mm.addMarker(false, this, Severity.Warning, "Target comes within 1\u00B0 of lower HA constraint.", v, a);
 				}
 
 				if (maxHA > haLimitMax) {
-					haMarker = new Some<>(new Marker(false, this, Severity.Error, String.format("Hour angle constraint violated (%s > %s).", TimeUtils.hoursToHHMMSS(maxHA), TimeUtils.hoursToHHMMSS(haLimitMax)), v, a));
+					mm.addMarker(false, this, Severity.Error, String.format("Hour angle constraint violated (%s > %s).", TimeUtils.hoursToHHMMSS(maxHA), TimeUtils.hoursToHHMMSS(haLimitMax)), v, a);
 				} else if (maxDelta < 1. / 15.) {
-					haMarker = new Some<>(new Marker(false, this, Severity.Warning, "Target comes within 1\u00B0 of upper HA constraint.", v, a));
+					mm.addMarker(false, this, Severity.Warning, "Target comes within 1\u00B0 of upper HA constraint.", v, a);
 				}
-
-				haMarker.orElse(() -> {
-					final String m = String.format("Must be observed in the hour angle range %1.2f - %1.2f", haLimitMin, haLimitMax);
-					return createSolverMarker.apply(Variant.VISIBLE_UNION_CACHE, m);
-				}).foreach(m -> mm.addMarker(m));
 
 				break;
 			}
@@ -234,8 +212,6 @@ public class LimitsListener extends MarkerModelListener<Variant> {
 
 			if (sb != null && !a.getObs().getConditions().containsSkyBrightness(sb)) {
 				mm.addMarker(false, this, Severity.Error, "Sky brightness constraint violated.", v, a);
-			} else  {
-				createSolverMarker.apply(Variant.DARK_UNION_CACHE, "Background constraints are met between").foreach(m -> mm.addMarker(m));
 			}
 
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/util/TimePreference.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/util/TimePreference.java
@@ -1,5 +1,13 @@
 package edu.gemini.qpt.ui.util;
 
+import edu.gemini.qpt.core.util.ImprovedSkyCalc;
+import edu.gemini.spModel.core.Site;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
 public enum TimePreference {
 
 	LOCAL,
@@ -9,5 +17,25 @@ public enum TimePreference {
 	;
 	
 	public static EnumBox<TimePreference> BOX = new EnumBox<TimePreference>(LOCAL);
-	
+
+    public static String format(Site site, Long timestamp, String pattern) {
+		final String timeString;
+		final DateTimeFormatter f = DateTimeFormatter.ofPattern(pattern);
+		switch (TimePreference.BOX.get()) {
+			case LOCAL:
+				timeString = f.withZone(site.timezone().toZoneId()).format(Instant.ofEpochMilli(timestamp));
+				break;
+			case UNIVERSAL:
+				timeString = f.withZone(ZoneId.of("UTC")).format(Instant.ofEpochMilli(timestamp));
+				break;
+			// SIDEREAL
+			default:
+				final ImprovedSkyCalc calc = new ImprovedSkyCalc(site);
+				final Long timestamp2 = calc.getLst(new Date(timestamp)).getTime();
+				timeString = f.withZone(ZoneId.of("UTC")).format(Instant.ofEpochMilli(timestamp2));
+				break;
+		}
+		return timeString;
+	}
+
 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/problem/ProblemController.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/problem/ProblemController.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import edu.gemini.qpt.core.Marker;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.util.MarkerManager;
+import edu.gemini.qpt.ui.util.TimePreference;
 import edu.gemini.ui.gface.GTableController;
 import edu.gemini.ui.gface.GViewer;
 
@@ -17,10 +18,10 @@ public class ProblemController implements GTableController<Schedule, Marker, Pro
 	private MarkerManager manager;
 	private Marker[] markers;
 	
-	public Object getSubElement(Marker element, ProblemAttribute subElement) {
+	public synchronized Object getSubElement(Marker element, ProblemAttribute subElement) {
 		if (element != null) {
 			switch (subElement) {
-			case Description: return element.getText();
+			case Description: return element.getUnionText(viewer.getModel().getSite());
 			case Resource: return element.getTarget();
 			case Severity: return element.getSeverity();
 			}
@@ -28,19 +29,24 @@ public class ProblemController implements GTableController<Schedule, Marker, Pro
 		return null;
 	}
 
-	public Marker getElementAt(int row) {		
+	public synchronized Marker getElementAt(int row) {
 		return row < markers.length ? markers[row] : null;
 	}
 
-	public int getElementCount() {
+	public synchronized int getElementCount() {
 		return markers == null ? 0 : markers.length;
 	}
 
-	public void modelChanged(GViewer<Schedule, Marker> viewer, Schedule oldModel, Schedule newModel) {
+	public synchronized void modelChanged(GViewer<Schedule, Marker> viewer, Schedule oldModel, Schedule newModel) {
 		this.viewer = viewer;
+		
 		if (manager != null) manager.removePropertyChangeListener(this);
 		manager = newModel == null ? null : newModel.getMarkerManager();
 		if (manager != null) manager.addPropertyChangeListener(this);
+
+		TimePreference.BOX.removePropertyChangeListener(this);
+		TimePreference.BOX.addPropertyChangeListener(this);
+
 		fetchMarkers();
 	}
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/MarkerAdapter.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/MarkerAdapter.java
@@ -10,11 +10,11 @@ public class MarkerAdapter implements Adapter<Marker> {
 	public static final String PROP_DESCRIPTION = "Description";
 	public static final String PROP_RESOURCE = "Resource";
 	public static final String PROP_SEVERITY = "Severity";
-	
+
 	public void setProperties(Variant variant, Marker target, PropertyTable table) {
 		table.put(PROP_TYPE, "Problem Marker");
 		table.put(PROP_SEVERITY, target.getSeverity());
-		table.put(PROP_DESCRIPTION, target.getText());
+		table.put(PROP_DESCRIPTION, target.getUnionText(variant.getSchedule().getSite()));
 		table.put(PROP_RESOURCE, target.getTarget());
 	}
 


### PR DESCRIPTION
This is yet another iteration on the new constraint messages for the QPT.

This is still WIP, but I'm sending it anyway to make sure I'm on the right path. This is what I was planning to do next.

- [x] Restore error messages for altitude constraints. Get rid of the `Option` code for altitude constraints.
- [x] Don't show message when intersection spans the whole night.
- [x] Figure out how to deal with the timezone.

Notice that now we are reporting the message even when there is an error. We think this is alright since 1. there are not as many messages as when we were reporting messages for each constraint, and 2. whenever there is an error we expect the user to correct it right away.