### PR TITLE
REL-397 (3) tweak QPT scoring algorithm

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
@@ -1005,8 +1005,10 @@ public final class Variant extends BaseMutableBean implements PioSerializable, C
 			score *= 0.5;
 
 		// Decrease if can only be partially scheduled
+		// Note that this is the only factor that is influenced by the state of the
+		// plan; everything else is an intrinsic property of the observation.
 		if (flags.contains(Flag.PARTIALLY_BLOCKED))
-			score *= 0.75;
+			score *= 0.8; // slightly less than the user priority penalty
 
 		// QPT-211: Make observations requiring dark time more important
 		// than those which don't require dark time,


### PR DESCRIPTION
This tweaks the scoring algorithm to make the penalty for a partially-blocked observation (i.e., one that cannot be scheduled in its entirety) slightly less than the penalty for a one-step decrease in user priority. This means that (all other things being equal) a higher-priority observation will always be recommended, even if it's partially blocked.