### PR TITLE
REL-2659: Clean up ITC support for summing GMOS IFU elements web forms

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -611,7 +611,7 @@
 			</tr>
 			<tr>
 				<td><input value="sumIFU" name="analysisMethod" type="radio" /></td>
-				<td>Sum all IFU elements within <input name="ifuNum" size="5" value="2" type="text" /> arcsec of the center
+				<td>Sum all IFU elements within <input name="ifuNum" size="5" value="1.0" type="text" /> arcsec of the center
 				</td>
 			</tr>
 			<tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -602,7 +602,11 @@
                 <td><input value="radialIFU" name="analysisMethod" type="radio" /></td>
                 <td>Select multiple IFU elements along a radius with offsets of <input name="ifuMinOffset" size="5" value="0.0" type="text" />  to
                 <input name="ifuMaxOffset" size="5" value="3.0" type="text" /> arcsec </td>
-
+            </tr>
+            <tr>
+                <td><input value="sumIFU" name="analysisMethod" type="radio" /></td>
+                <td>Sum all IFU elements within <input name="ifuNum" size="5" value="1.0" type="text" /> arcsec of the center
+                </td>
             </tr>
         <!--<tr>
                   <td><input value="sumIFU" name="analysisMethod" type="radio" /></td>


### PR DESCRIPTION
Updated GMOS north and south web forms to include radial IFU summing analysis method with a default value of 1 arcsec.

Expecting Travis to fail the checks in bundle_edu_gemini_horizons_api, which Olesja has also encountered and was not modified in this case either.