### PR TITLE
REL-3431: Commented out the culprits in HS2Spec.

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -95,13 +95,7 @@ object HS2Spec extends Specification with ScalaCheck {
         Row(HD.AsteroidNewStyle("A/2017 U1"), "A/2017 U1")
       ))
     }
-
-//    "handle single result (Format 6) A/2017 U7" in {
-//      runSearch(Search.Asteroid("A/2017 U7")) must_== \/-(List(
-//        Row(HD.AsteroidNewStyle("A/2017 U7"), "A/2017 U7")
-//      ))
-//    }
-
+    
   }
 
   "major body search" should {
@@ -159,12 +153,6 @@ object HS2Spec extends Specification with ScalaCheck {
         95 <= s && s <= 105
       }
     }
-
-//    "return a populated ephemeris for A/2017 U7 (asteroid, new style)" in {
-//      runLookup(HD.AsteroidNewStyle("A/2017 U7"), 100).map(_.size).toOption.exists { s =>
-//        95 <= s && s <= 105
-//      }
-//    }
 
     "return a populated ephemeris for Amphitrite (asteroid, old style)" in {
       runLookup(HD.AsteroidOldStyle(29), 100).map(_.size).toOption.exists { s =>

--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -9,6 +9,9 @@ import org.scalacheck.Gen
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
+/** NOTE: there is no test for format 6 because all known examples have been
+  * reclassified as comets.
+  */
 object HS2Spec extends Specification with ScalaCheck {
 
   import HorizonsService2.{ HS2Error, Row, Search, search, lookupEphemeris, EphemerisEmpty }
@@ -95,7 +98,7 @@ object HS2Spec extends Specification with ScalaCheck {
         Row(HD.AsteroidNewStyle("A/2017 U1"), "A/2017 U1")
       ))
     }
-    
+
   }
 
   "major body search" should {

--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -96,11 +96,11 @@ object HS2Spec extends Specification with ScalaCheck {
       ))
     }
 
-    "handle single result (Format 6) A/2017 U7" in {
-      runSearch(Search.Asteroid("A/2017 U7")) must_== \/-(List(
-        Row(HD.AsteroidNewStyle("A/2017 U7"), "A/2017 U7")
-      ))
-    }
+//    "handle single result (Format 6) A/2017 U7" in {
+//      runSearch(Search.Asteroid("A/2017 U7")) must_== \/-(List(
+//        Row(HD.AsteroidNewStyle("A/2017 U7"), "A/2017 U7")
+//      ))
+//    }
 
   }
 
@@ -160,11 +160,11 @@ object HS2Spec extends Specification with ScalaCheck {
       }
     }
 
-    "return a populated ephemeris for A/2017 U7 (asteroid, new style)" in {
-      runLookup(HD.AsteroidNewStyle("A/2017 U7"), 100).map(_.size).toOption.exists { s =>
-        95 <= s && s <= 105
-      }
-    }
+//    "return a populated ephemeris for A/2017 U7 (asteroid, new style)" in {
+//      runLookup(HD.AsteroidNewStyle("A/2017 U7"), 100).map(_.size).toOption.exists { s =>
+//        95 <= s && s <= 105
+//      }
+//    }
 
     "return a populated ephemeris for Amphitrite (asteroid, old style)" in {
       runLookup(HD.AsteroidOldStyle(29), 100).map(_.size).toOption.exists { s =>


### PR DESCRIPTION
This comments out the two test cases in `HS2Spec` that are failing, thus causing all Travis builds to fail and preventing PR merging.

@tpolecat explains why these cases are failing and why it is not a matter of concern:

"We handle that asteroid format but no longer have any way to get horizons to generate it because all the applicable targets have been reclassified as comets, as far as I can tell."