### PR TITLE
REL-3435: GHOST now can be loaded by the TCC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2018B", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2018B", false, 2, 1, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2018B", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2018B", false, 2, 1, 0)
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -1,11 +1,13 @@
 package edu.gemini.spModel.target.env;
 
 import edu.gemini.shared.util.immutable.*;
+import edu.gemini.spModel.gemini.ghost.GhostAsterism;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.target.SPCoordinates;
+import edu.gemini.spModel.target.SPSkyObject;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.SPTargetPio;
 
@@ -89,10 +91,25 @@ public final class TargetEnvironment implements Serializable, TargetContainer {
     }
 
     /** Returns an arbitrary target from the asterism. This method will be removed for 18A. */
+    public SPSkyObject getPrimaryTargetFromAsterism() {
+        if (asterism instanceof GhostAsterism) {
+            final GhostAsterism ga = (GhostAsterism) asterism;
+            if (ga.base().isDefined())
+                return ga.base().get();
+            else if (ga instanceof GhostAsterism.DualTarget) {
+                final Option<SPCoordinates> c =
+                        ImOption.fromScalaOpt(ga.basePosition(ImOption.scalaNone())).map(SPCoordinates::new);
+                if (c.isDefined())
+                    return c.getValue();
+            }
+        }
+        return asterism.allSpTargets().head();
+    }
+
     // TODO:ASTERISM
     @Deprecated
     public SPTarget getArbitraryTargetFromAsterism() {
-      return getAsterism().allSpTargets().head();
+        return getAsterism().allSpTargets().head();
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/TargetEnvironment.java
@@ -90,8 +90,8 @@ public final class TargetEnvironment implements Serializable, TargetContainer {
         this.user     = user;
     }
 
-    /** Returns an arbitrary target from the asterism. This method will be removed for 18A. */
-    public SPSkyObject getPrimaryTargetFromAsterism() {
+    /** Returns the sky object from the asterism that dictates the slew position. */
+    public SPSkyObject getSlewPositionObjectFromAsterism() {
         if (asterism instanceof GhostAsterism) {
             final GhostAsterism ga = (GhostAsterism) asterism;
             if (ga.base().isDefined())

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsComp.java
@@ -104,11 +104,6 @@ public final class TargetObsComp extends AbstractDataObject implements GuideProb
       return getTargetEnvironment().getAsterism();
     }
 
-    @Deprecated
-    public SPTarget getArbitraryTargetFromAsterism() {
-      return getTargetEnvironment().getArbitraryTargetFromAsterism();
-    }
-
     /**
      * Set the TargetEnvironment.
      */

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
@@ -51,7 +51,7 @@ public class TargetObsCompCB extends AbstractObsComponentCB {
         // Patch for a problem in 2009B.1.1.1.  The "telescope:Base:name" param
         // was missing, which caused the FITS OBJECT keyword to be incorrect.
         // TODO:ASTERISM: how do we handle multiples? For now just use an arbitrary target's name.
-        String baseName = env.getArbitraryTargetFromAsterism().getName();
+        String baseName = env.getPrimaryTargetFromAsterism().getName();
         if ((baseName != null) && !"".equals(baseName)) {
             DefaultConfigParameter cp = DefaultConfigParameter.getInstance("Base");
             ISysConfig sc = (ISysConfig) cp.getValue();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetObsCompCB.java
@@ -51,7 +51,7 @@ public class TargetObsCompCB extends AbstractObsComponentCB {
         // Patch for a problem in 2009B.1.1.1.  The "telescope:Base:name" param
         // was missing, which caused the FITS OBJECT keyword to be incorrect.
         // TODO:ASTERISM: how do we handle multiples? For now just use an arbitrary target's name.
-        String baseName = env.getPrimaryTargetFromAsterism().getName();
+        String baseName = env.getSlewPositionObjectFromAsterism().getName();
         if ((baseName != null) && !"".equals(baseName)) {
             DefaultConfigParameter cp = DefaultConfigParameter.getInstance("Base");
             ISysConfig sc = (ISysConfig) cp.getValue();

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPCoordinates.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPCoordinates.scala
@@ -98,9 +98,15 @@ final class SPCoordinates(var coordinates: Coordinates) extends SPSkyObject {
 
   override def getDecString(time: GOLong): GOption[String] =
     Some(coordinates.dec.toAngle.formatHMS).asGeminiOpt
+
+  override val getName: String = SPCoordinates.Name
+
+  override def setName(name: String): Unit =
+    throw new UnsupportedOperationException("Cannot set name of coordinates")
 }
 
 object SPCoordinates {
   val ParamSetName = "spCoordinates"
   val CoordinatesName   = "coordinates"
+  val Name = "Sky Position"
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPCoordinates.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPCoordinates.scala
@@ -100,13 +100,10 @@ final class SPCoordinates(var coordinates: Coordinates) extends SPSkyObject {
     Some(coordinates.dec.toAngle.formatHMS).asGeminiOpt
 
   override val getName: String = SPCoordinates.Name
-
-  override def setName(name: String): Unit =
-    throw new UnsupportedOperationException("Cannot set name of coordinates")
 }
 
 object SPCoordinates {
   val ParamSetName = "spCoordinates"
   val CoordinatesName   = "coordinates"
-  val Name = "Sky Position"
+  val Name = "Sky"
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPSkyObject.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPSkyObject.scala
@@ -34,4 +34,8 @@ abstract class SPSkyObject extends WatchablePos {
   def getDecDegrees(time: GOLong): GODouble
 
   def getDecString(time: GOLong): GOption[String]
+
+  def getName: String
+
+  def setName(name: String): Unit
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPSkyObject.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPSkyObject.scala
@@ -36,6 +36,4 @@ abstract class SPSkyObject extends WatchablePos {
   def getDecString(time: GOLong): GOption[String]
 
   def getName: String
-
-  def setName(name: String): Unit
 }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GMOSSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GMOSSupport.java
@@ -18,7 +18,7 @@ public final class GMOSSupport implements ITccInstrumentSupport {
     }
 
     /**
-     * Factory for creating a new TReCS Instrument Support.
+     * Factory for creating a new GMOS Instrument Support.
      *
      * @param oe The current ObservationEnvironment
      * @return A new instance

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GNIRSSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GNIRSSupport.java
@@ -22,7 +22,7 @@ public class GNIRSSupport implements ITccInstrumentSupport {
     }
 
     /**
-     * Factory for creating a new TReCS Instrument Support.
+     * Factory for creating a new GNIRS Instrument Support.
      *
      * @param oe The current ObservationEnvironment
      * @return A new instance

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
@@ -12,6 +12,13 @@ public class GhostSupport implements ITccInstrumentSupport {
         this.oe = oe;
     }
 
+    /**
+     * Factor for creating a new GHOST Instrument Support.
+     *
+     * @param oe The current ObservationEnvironment
+     * @return A new instance
+     * @throws NullPointerException returned if the ObservationEnvironment is null.
+     */
     static public ITccInstrumentSupport create(final ObservationEnvironment oe) throws NullPointerException {
         return new GhostSupport(oe);
     }
@@ -34,7 +41,7 @@ public class GhostSupport implements ITccInstrumentSupport {
 
     @Override
     public String getTccConfigInstrumentOrigin() {
-        return null;
+        return "ghost";
     }
 
     @Override

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
@@ -9,6 +9,8 @@ final public class GhostSupport implements ITccInstrumentSupport {
 
     private GhostSupport(final ObservationEnvironment oe) {
         Objects.requireNonNull(oe, "Observation environment can not be null");
+        if (!(oe.getInstrument() instanceof Ghost))
+            throw new RuntimeException("Incompatible instrument in ObservationEnvironment.");
         this.oe = oe;
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
@@ -4,8 +4,8 @@ import edu.gemini.spModel.gemini.ghost.Ghost;
 
 import java.util.Objects;
 
-public class GhostSupport implements ITccInstrumentSupport {
-    private ObservationEnvironment oe;
+final public class GhostSupport implements ITccInstrumentSupport {
+    final private ObservationEnvironment oe;
 
     private GhostSupport(final ObservationEnvironment oe) {
         Objects.requireNonNull(oe, "Observation environment can not be null");

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
@@ -1,0 +1,54 @@
+package edu.gemini.wdba.tcc;
+
+import edu.gemini.spModel.gemini.ghost.Ghost;
+
+import java.util.Objects;
+
+public class GhostSupport implements ITccInstrumentSupport {
+    private ObservationEnvironment oe;
+
+    private GhostSupport(final ObservationEnvironment oe) {
+        Objects.requireNonNull(oe, "Observation environment can not be null");
+        this.oe = oe;
+    }
+
+    static public ITccInstrumentSupport create(final ObservationEnvironment oe) throws NullPointerException {
+        return new GhostSupport(oe);
+    }
+
+    @Override
+    public String getWavelength() {
+        return null;
+    }
+
+    @Override
+    public String getPositionAngle() {
+        Ghost inst = (Ghost) oe.getInstrument();
+        return inst.getPosAngleDegreesStr();
+    }
+
+    @Override
+    public String getTccConfigInstrument() {
+        return "GHOST";
+    }
+
+    @Override
+    public String getTccConfigInstrumentOrigin() {
+        return null;
+    }
+
+    @Override
+    public String getFixedRotatorConfigName() {
+        return null;
+    }
+
+    @Override
+    public String getChopState() {
+        return TccNames.NOCHOP;
+    }
+
+    @Override
+    public void addGuideDetails(final ParamSet p) {
+
+    }
+}

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/NICISupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/NICISupport.java
@@ -23,7 +23,7 @@ public class NICISupport implements ITccInstrumentSupport {
     }
 
     /**
-     * Factory for creating a new TReCS Instrument Support.
+     * Factory for creating a new NICI Instrument Support.
      *
      * @param oe The current ObservationEnvironment
      * @return A new instance

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/NIFSSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/NIFSSupport.java
@@ -21,7 +21,7 @@ public class NIFSSupport implements ITccInstrumentSupport {
     }
 
     /**
-     * Factory for creating a new TReCS Instrument Support.
+     * Factory for creating a new NIFS Instrument Support.
      *
      * @param oe The current ObservationEnvironment
      * @return A new instance

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/NIRISupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/NIRISupport.java
@@ -30,7 +30,7 @@ public class NIRISupport implements ITccInstrumentSupport {
     }
 
     /**
-     * Factory for creating a new TReCS Instrument Support.
+     * Factory for creating a new NIRI Instrument Support.
      *
      * @param oe The current ObservationEnvironment
      * @return A new instance

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -140,7 +140,7 @@ public final class ObservationEnvironment {
             }
         }
 
-        return _targetEnv.getPrimaryTargetFromAsterism().getName();
+        return _targetEnv.getSlewPositionObjectFromAsterism().getName();
     }
 
     public boolean isNorth() {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -129,17 +129,17 @@ public final class ObservationEnvironment {
     }
 
     public String getBasePositionName() {
-        final Asterism a = _targetEnv.getAsterism();
-
-        // A dual asterism always has a sky position, and an asterism with an
-        // overridden base has a sky position.
-        if (a instanceof GhostAsterism) {
-            if (a instanceof GhostAsterism.DualTarget
-                || ((GhostAsterism)a).base().isDefined()) {
-                return SPCoordinates.Name();
-            }
-        }
-
+//        final Asterism a = _targetEnv.getAsterism();
+//
+//        // A dual asterism always has a sky position, and an asterism with an
+//        // overridden base has a sky position.
+//        if (a instanceof GhostAsterism) {
+//            if (a instanceof GhostAsterism.DualTarget
+//                || ((GhostAsterism)a).base().isDefined()) {
+//                return SPCoordinates.Name();
+//            }
+//        }
+        System.out.println("*** ObservationEnvironment.getBasePositionName: " + _targetEnv.getSlewPositionObjectFromAsterism().getName());
         return _targetEnv.getSlewPositionObjectFromAsterism().getName();
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -129,17 +129,6 @@ public final class ObservationEnvironment {
     }
 
     public String getBasePositionName() {
-//        final Asterism a = _targetEnv.getAsterism();
-//
-//        // A dual asterism always has a sky position, and an asterism with an
-//        // overridden base has a sky position.
-//        if (a instanceof GhostAsterism) {
-//            if (a instanceof GhostAsterism.DualTarget
-//                || ((GhostAsterism)a).base().isDefined()) {
-//                return SPCoordinates.Name();
-//            }
-//        }
-        System.out.println("*** ObservationEnvironment.getBasePositionName: " + _targetEnv.getSlewPositionObjectFromAsterism().getName());
         return _targetEnv.getSlewPositionObjectFromAsterism().getName();
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/ObservationEnvironment.java
@@ -10,10 +10,13 @@ import edu.gemini.spModel.ext.*;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.altair.InstAltair;
 import edu.gemini.spModel.gemini.gems.Gems;
+import edu.gemini.spModel.gemini.ghost.GhostAsterism;
 import edu.gemini.spModel.gemini.seqcomp.SeqRepeatOffsetBase;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeUtil;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
+import edu.gemini.spModel.target.SPCoordinates;
+import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.wdba.glue.api.WdbaGlueException;
@@ -126,7 +129,18 @@ public final class ObservationEnvironment {
     }
 
     public String getBasePositionName() {
-        return _targetEnv.getArbitraryTargetFromAsterism().getName();
+        final Asterism a = _targetEnv.getAsterism();
+
+        // A dual asterism always has a sky position, and an asterism with an
+        // overridden base has a sky position.
+        if (a instanceof GhostAsterism) {
+            if (a instanceof GhostAsterism.DualTarget
+                || ((GhostAsterism)a).base().isDefined()) {
+                return SPCoordinates.Name();
+            }
+        }
+
+        return _targetEnv.getPrimaryTargetFromAsterism().getName();
     }
 
     public boolean isNorth() {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/PhoenixSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/PhoenixSupport.java
@@ -18,7 +18,7 @@ public class PhoenixSupport implements ITccInstrumentSupport {
     }
 
     /**
-     * Factory for creating a new TReCS Instrument Support.
+     * Factory for creating a new Phoenix Instrument Support.
      *
      * @param oe The current ObservationEnvironment
      * @return A new instance

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -50,7 +50,7 @@ public final class TargetConfig extends ParamSet {
 
     public TargetConfig(final SPCoordinates spc, final String tag) throws WdbaGlueException {
         super(spc.getName());
-
+        System.out.println("*** Creating SPCoordinates TargetConfig with name=" + spc.getName() + ", tag=" + tag);
         // The coordinates are fixed.
         final Coordinates cs = spc.coordinates();
         addAttribute(TYPE, "hmsdegTarget");
@@ -64,6 +64,7 @@ public final class TargetConfig extends ParamSet {
 
     public TargetConfig(final SPTarget spt, final String tag) throws WdbaGlueException {
         super(spt.getName());
+        System.out.println("*** Creating SPTarget TargetConfig with name=" + spt.getName() + ", tag=" + tag);
         final Target t = spt.getTarget();
 
         // Get coordinates right now

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -2,6 +2,7 @@ package edu.gemini.wdba.tcc;
 
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.core.*;
+import edu.gemini.spModel.target.SPCoordinates;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw;
@@ -45,6 +46,20 @@ public final class TargetConfig extends ParamSet {
 
     public static String formatName(final String tag, final int position) {
         return String.format("%s (%d)", tag, position);
+    }
+
+    public TargetConfig(final SPCoordinates spc, final String tag) throws WdbaGlueException {
+        super(spc.getName());
+
+        // The coordinates are fixed.
+        final Coordinates cs = spc.coordinates();
+        addAttribute(TYPE, "hmsdegTarget");
+        putParameter(TccNames.OBJNAME,     spc.getName());
+        putParameter(TccNames.BRIGHTNESS, "");
+        putParameter(TccNames.TAG,         tag);
+        putParameter(TccNames.SYSTEM,     "J2000");
+        putParameter(TccNames.C1,          cs.ra().toAngle().formatHMS());
+        putParameter(TccNames.C2,          cs.dec().formatDMS());
     }
 
     public TargetConfig(final SPTarget spt, final String tag) throws WdbaGlueException {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetConfig.java
@@ -50,7 +50,7 @@ public final class TargetConfig extends ParamSet {
 
     public TargetConfig(final SPCoordinates spc, final String tag) throws WdbaGlueException {
         super(spc.getName());
-        System.out.println("*** Creating SPCoordinates TargetConfig with name=" + spc.getName() + ", tag=" + tag);
+
         // The coordinates are fixed.
         final Coordinates cs = spc.coordinates();
         addAttribute(TYPE, "hmsdegTarget");
@@ -64,7 +64,6 @@ public final class TargetConfig extends ParamSet {
 
     public TargetConfig(final SPTarget spt, final String tag) throws WdbaGlueException {
         super(spt.getName());
-        System.out.println("*** Creating SPTarget TargetConfig with name=" + spt.getName() + ", tag=" + tag);
         final Target t = spt.getTarget();
 
         // Get coordinates right now

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
@@ -25,7 +25,7 @@ public final class TargetGroupConfig extends ParamSet {
         final ImList<SPTarget> scienceTargets = env.getAsterism().allSpTargetsJava();
         final ImList<SPTarget> userTargets    = env.getUserTargets().map(u -> u.target);
         final ImList<SPTarget> targets        = scienceTargets.append(userTargets);
-        return new TargetGroupConfig(TccNames.BASE, targets, ImOption.apply(env.getPrimaryTargetFromAsterism()));
+        return new TargetGroupConfig(TccNames.BASE, targets, ImOption.apply(env.getSlewPositionObjectFromAsterism()));
     }
 
     public static TargetGroupConfig createGuideGroup(final GuideProbeTargets gt) {
@@ -41,7 +41,7 @@ public final class TargetGroupConfig extends ParamSet {
         addAttribute(TYPE, TYPE_VALUE);
 
         primaryTarget.map(SPSkyObject::getName)
-                .filter(n -> !n.isEmpty())
+                .filter(n -> !"".equals(n))
                 .foreach(n -> putParameter(TccNames.PRIMARY, n));
 
         final List<String> targetNames = targets.toList().stream().map(SPSkyObject::getName).collect(Collectors.toList());

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
@@ -1,7 +1,3 @@
-//
-// $
-//
-
 package edu.gemini.wdba.tcc;
 
 import edu.gemini.shared.util.immutable.ImList;
@@ -22,23 +18,20 @@ public final class TargetGroupConfig extends ParamSet {
     public static final String TYPE_VALUE="targetgroup";
 
     public static TargetGroupConfig createBaseGroup(final TargetEnvironment env) {
-        System.out.println("*** In TargetGroupConfig.createBaseGroup");
-        final ImList<SPTarget> scienceTargets = env.getAsterism().allSpTargetsJava();
-        final ImList<SPTarget> userTargets    = env.getUserTargets().map(u -> u.target);
-        final ImList<SPTarget> targets        = scienceTargets.append(userTargets);
-        System.out.println("*** Adding targets: " + targets.size());
-        System.out.println("*** Leaving TargetGroupConfig.createBaseGroup");
+        final SPSkyObject base = env.getSlewPositionObjectFromAsterism();
+        final ImList<SPSkyObject> userTargets    = env.getUserTargets().map(u -> u.target);
+        final ImList<SPSkyObject> targets        = userTargets.cons(base);
         return new TargetGroupConfig(TccNames.BASE, targets, ImOption.apply(env.getSlewPositionObjectFromAsterism()));
     }
 
     public static TargetGroupConfig createGuideGroup(final GuideProbeTargets gt) {
         final String tag = TargetConfig.getTag(gt.getGuider());
-        final ImList<SPTarget> targets = gt.getTargets();
+        final ImList<SPSkyObject> targets = gt.getTargets().map(o -> (SPSkyObject)o);
         final Option<SPSkyObject> primaryOpt = gt.getPrimary().map(t -> (SPSkyObject) t);
         return new TargetGroupConfig(tag, targets, primaryOpt);
     }
 
-    private TargetGroupConfig(final String name, final ImList<SPTarget> targets, final Option<SPSkyObject> primaryTarget) {
+    private TargetGroupConfig(final String name, final ImList<SPSkyObject> targets, final Option<SPSkyObject> primaryTarget) {
         super(name);
 
         addAttribute(TYPE, TYPE_VALUE);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TargetGroupConfig.java
@@ -22,9 +22,12 @@ public final class TargetGroupConfig extends ParamSet {
     public static final String TYPE_VALUE="targetgroup";
 
     public static TargetGroupConfig createBaseGroup(final TargetEnvironment env) {
+        System.out.println("*** In TargetGroupConfig.createBaseGroup");
         final ImList<SPTarget> scienceTargets = env.getAsterism().allSpTargetsJava();
         final ImList<SPTarget> userTargets    = env.getUserTargets().map(u -> u.target);
         final ImList<SPTarget> targets        = scienceTargets.append(userTargets);
+        System.out.println("*** Adding targets: " + targets.size());
+        System.out.println("*** Leaving TargetGroupConfig.createBaseGroup");
         return new TargetGroupConfig(TccNames.BASE, targets, ImOption.apply(env.getSlewPositionObjectFromAsterism()));
     }
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -99,8 +99,7 @@ public class TccFieldConfig extends ParamSet {
     }
 
     private void addBaseGroup(TargetEnvironment env) throws WdbaGlueException {
-        System.out.println("*** In TccFieldConfig.addBaseGroup");
-        // Add the base target itself.
+        // Add the base target / position.
         final SPSkyObject so = env.getSlewPositionObjectFromAsterism();
 
         if (so instanceof SPTarget) {
@@ -108,9 +107,7 @@ public class TccFieldConfig extends ParamSet {
             if (isEmpty(spt.getName()))
                 spt.setName(TccNames.BASE);
             add(new TargetConfig(spt, TccNames.BASE));
-        }
-
-        if (so instanceof SPCoordinates) {
+        } else if (so instanceof SPCoordinates) {
             add(new TargetConfig((SPCoordinates)so, TccNames.BASE));
         }
 
@@ -127,7 +124,6 @@ public class TccFieldConfig extends ParamSet {
 
         // Add the "group" for the base position.
         add(TargetGroupConfig.createBaseGroup(env));
-        System.out.println("*** Leaving TccFieldConfig.addBaseGroup");
     }
 
     private void addGuideGroup(GuideProbeTargets gt) throws WdbaGlueException {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -100,9 +100,9 @@ public class TccFieldConfig extends ParamSet {
 
     private void addBaseGroup(TargetEnvironment env) throws WdbaGlueException {
         // Add the target itself.
-        SPSkyObject so = env.getPrimaryTargetFromAsterism();
+        SPSkyObject so = env.getSlewPositionObjectFromAsterism();
 
-        if (so instanceof  SPTarget) {
+        if (so instanceof SPTarget) {
             final SPTarget spt = (SPTarget) so;
             if (isEmpty(spt.getName()))
                 spt.setName(TccNames.BASE);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -99,8 +99,9 @@ public class TccFieldConfig extends ParamSet {
     }
 
     private void addBaseGroup(TargetEnvironment env) throws WdbaGlueException {
-        // Add the target itself.
-        SPSkyObject so = env.getSlewPositionObjectFromAsterism();
+        System.out.println("*** In TccFieldConfig.addBaseGroup");
+        // Add the base target itself.
+        final SPSkyObject so = env.getSlewPositionObjectFromAsterism();
 
         if (so instanceof SPTarget) {
             final SPTarget spt = (SPTarget) so;
@@ -126,6 +127,7 @@ public class TccFieldConfig extends ParamSet {
 
         // Add the "group" for the base position.
         add(TargetGroupConfig.createBaseGroup(env));
+        System.out.println("*** Leaving TccFieldConfig.addBaseGroup");
     }
 
     private void addGuideGroup(GuideProbeTargets gt) throws WdbaGlueException {

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -2,6 +2,8 @@ package edu.gemini.wdba.tcc;
 
 import edu.gemini.pot.sp.SPObservationID;
 import edu.gemini.shared.util.immutable.*;
+import edu.gemini.spModel.target.SPCoordinates;
+import edu.gemini.spModel.target.SPSkyObject;
 import edu.gemini.spModel.target.SPTarget;
 import edu.gemini.spModel.target.env.GuideProbeTargets;
 import edu.gemini.spModel.target.env.TargetEnvironment;
@@ -98,11 +100,18 @@ public class TccFieldConfig extends ParamSet {
 
     private void addBaseGroup(TargetEnvironment env) throws WdbaGlueException {
         // Add the target itself.
-        SPTarget base = env.getArbitraryTargetFromAsterism();
-        if (isEmpty(base.getName())) {
-            base.setName(TccNames.BASE);
+        SPSkyObject so = env.getPrimaryTargetFromAsterism();
+
+        if (so instanceof  SPTarget) {
+            final SPTarget spt = (SPTarget) so;
+            if (isEmpty(spt.getName()))
+                spt.setName(TccNames.BASE);
+            add(new TargetConfig(spt, TccNames.BASE));
         }
-        add(new TargetConfig(base, TccNames.BASE));
+
+        if (so instanceof SPCoordinates) {
+            add(new TargetConfig((SPCoordinates)so, TccNames.BASE));
+        }
 
         // Add the user targets.
         int pos = 1;
@@ -146,7 +155,7 @@ public class TccFieldConfig extends ParamSet {
     // private method to log and throw and exception
     private void _logAbort(String message, Exception ex) throws WdbaGlueException {
         //LOG.error(message);
-        throw new WdbaGlueException(message, (ex != null) ? ex : null);
+        throw new WdbaGlueException(message, ex);
     }
 
 }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccHandler.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccHandler.java
@@ -12,6 +12,7 @@ import edu.gemini.spModel.ext.ObservationNodeFunctor;
 import edu.gemini.spModel.gemini.acqcam.InstAcqCam;
 import edu.gemini.spModel.gemini.bhros.InstBHROS;
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2;
+import edu.gemini.spModel.gemini.ghost.Ghost;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
 import edu.gemini.spModel.gemini.gnirs.InstGNIRS;
@@ -109,6 +110,8 @@ public final class TccHandler implements ITccXmlRpc {
         supportMap.put(Gsaoi.SP_TYPE, "edu.gemini.wdba.tcc.GsaoiSupport");
         // Add Gpi Support
         supportMap.put(Gpi.SP_TYPE, "edu.gemini.wdba.tcc.GpiSupport");
+        // Add GHOST Support
+        supportMap.put(Ghost.SP_TYPE, "edu.gemini.wdba.tcc.GhostSupport");
         // Add Visitor Instrument Support
         supportMap.put(VisitorInstrument.SP_TYPE, "edu.gemini.wdba.tcc.VisitorInstrumentSupport");
 

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TexesSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TexesSupport.java
@@ -17,7 +17,7 @@ public class TexesSupport implements ITccInstrumentSupport {
     }
 
     /**
-     * Factory for creating a new TReCS Instrument Support.
+     * Factory for creating a new Texes Instrument Support.
      *
      * @param oe The current ObservationEnvironment
      * @return A new instance


### PR DESCRIPTION
This implements the code to let the TCC load GHOST observations from the session queue, as well as fix some minor comment issues and cleanup along the way.

Here are two screenshots of GHOST observations in the TCC.

The first is a single target standard resolution GHOST observation of M62:
![screen shot 2018-06-20 at 3 45 26 pm](https://user-images.githubusercontent.com/8795653/41681315-407bd036-74a2-11e8-9e70-3f73741f17bd.png)

The second is a dual target observation, in which case, the base position is not a named target, and thus we call it `Sky Position`:
![screen shot 2018-06-20 at 3 45 49 pm](https://user-images.githubusercontent.com/8795653/41681344-59a9624e-74a2-11e8-9a27-ef788d9719eb.png)
