### PR TITLE
REL-1714: publish plan with selected timezone

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Marker.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Marker.java
@@ -10,7 +10,7 @@ import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.Site;
 
 /**
- * Represents a problem or annotation associated with a model object. 
+ * Represents a problem or annotation associated with a model object.
  * @author rnorris
  */
 public class Marker implements Comparable<Marker> {
@@ -18,14 +18,14 @@ public class Marker implements Comparable<Marker> {
 	public enum Severity {
 		Error, Warning, Notice, Info
 	}
-	
+
 	private final Object owner;
 	private final Object[] path;
 	private final String text;
 	private final Severity severity;
 	private final boolean qcOnly;
 	private final Option<Union<Interval>> union;
-	
+
 	public Marker(boolean qcOnly, Object owner, Severity severity, String text, Option<Union<Interval>> union, Object... path) {
 		this.qcOnly = qcOnly;
 		this.owner = owner;
@@ -42,7 +42,7 @@ public class Marker implements Comparable<Marker> {
 	public boolean isQcOnly() {
 		return qcOnly;
 	}
-	
+
 	public Object getOwner() {
 		return owner;
 	}
@@ -54,20 +54,24 @@ public class Marker implements Comparable<Marker> {
 	public Object getTarget() {
 		return path[path.length - 1];
 	}
-	
+
 	public String getText() {
 		return text;
 	}
 
-	private static final String formatInterval(Site site, Interval interval) {
+	private static final String formatInterval(Site site, Interval interval, TimePreference p) {
 		return String.format(
 				"%s - %s",
-				TimePreference.format(site, interval.getStart(), "HH:mm"),
-				TimePreference.format(site, interval.getEnd(), "HH:mm")
+				p.format(site, interval.getStart(), "HH:mm"),
+				p.format(site, interval.getEnd(), "HH:mm")
 		);
 	}
 
-    public String getUnionText(Site site) {
+	public String getUnionText(Site site) {
+		return getUnionText(site, TimePreference.BOX.get());
+	}
+
+    public String getUnionText(Site site, TimePreference p) {
 
 		final Union<Interval> intervals = this.getUnion().getOrElse(new Union<>());
 
@@ -75,7 +79,7 @@ public class Marker implements Comparable<Marker> {
 
 		String msg;
 		if (is.nonEmpty()) {
-			final String m = is.map(i -> formatInterval(site, i)).mkString(" ", ", ", ".");
+			final String m = is.map(i -> formatInterval(site, i, p)).mkString(" ", ", ", ".");
 			msg = this.getText() + m;
 		} else {
 			msg = this.getText();
@@ -83,8 +87,8 @@ public class Marker implements Comparable<Marker> {
 		return msg;
 	}
 
-	public String getFilteredUnionText(Site site) {
-		return this.getUnionText(site).replace("\u00B0", "&deg;");
+	public String getFilteredUnionText(Site site, TimePreference p) {
+		return this.getUnionText(site, p).replace("\u00B0", "&deg;");
 	}
 
     public Severity getSeverity() {
@@ -100,22 +104,22 @@ public class Marker implements Comparable<Marker> {
 
 	@SuppressWarnings("unchecked")
 	public int compareTo(Marker o) {
-		
+
 		// Sort first on severity
 		int diff = severity.compareTo(o.severity);
 		if (diff != 0) return diff;
-		
+
 		// Next sort by target, if they are the same type and
 		// are comparable.
 		Object t1 = getTarget();
 		Object t2 = o.getTarget();
 		if (t1 instanceof Comparable && t1.getClass().isInstance(t2) && !t1.equals(t2))
 			return ((Comparable) t1).compareTo(t2);
-			
+
 		// Otherwise order predictably but arbitrarily, grouping by target.
 		diff = t1.toString().compareTo(t2.toString());
 		return (diff == 0) ? System.identityHashCode(this) - System.identityHashCode(o) : diff;
-		
+
 	}
-		
+
 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/ScheduleDocument.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/ScheduleDocument.java
@@ -246,6 +246,10 @@ public class ScheduleDocument {
         return TimeUtils.msToHHMM(ms);
     }
 
+    public TimePreference getTimePreference() {
+        return (utc) ? TimePreference.UNIVERSAL : TimePreference.LOCAL;
+    }
+
     public String getColor(Severity sev) {
         if (sev != null) {
             switch (sev) {

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/util/TimePreference.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/util/TimePreference.java
@@ -13,15 +13,14 @@ public enum TimePreference {
 	LOCAL,
 	UNIVERSAL,
 	SIDEREAL
-	
 	;
-	
+
 	public static EnumBox<TimePreference> BOX = new EnumBox<TimePreference>(LOCAL);
 
-    public static String format(Site site, Long timestamp, String pattern) {
+    public String format(Site site, Long timestamp, String pattern) {
 		final String timeString;
 		final DateTimeFormatter f = DateTimeFormatter.ofPattern(pattern);
-		switch (TimePreference.BOX.get()) {
+		switch (this) {
 			case LOCAL:
 				timeString = f.withZone(site.timezone().toZoneId()).format(Instant.ofEpochMilli(timestamp));
 				break;

--- a/bundle/edu.gemini.qpt.client/src/main/resources/edu/gemini/qpt/ui/html/template.vm
+++ b/bundle/edu.gemini.qpt.client/src/main/resources/edu/gemini/qpt/ui/html/template.vm
@@ -29,9 +29,9 @@
 	#if(!$doc.isEmpty($doc.Schedule.Comment))
 	<div class="comment">$doc.Schedule.Comment</div>
 	#end
-	
+
 	<!--
-	
+
 	<h2>Sky Almanac</h2>
 
 	<table>
@@ -43,7 +43,7 @@
 	-->
 
 	<h2>Resource Summary</h2>
-	
+
 	<table align="center">
 		<tr>
 		#foreach ($variant in $doc.Schedule.Variants)
@@ -62,11 +62,11 @@
 		</tr>
 	</table>
 
-	
+
 	#foreach ($variant in $doc.Schedule.Variants)
-	
+
 		#if(!$doc.isEmpty($variant.Comment) || !$variant.isEmpty())
-	
+
 		<h2 class="visit" style="page-break-before:always;margin-bottom:0pt;"><a name="$variant.Conditions.toShortString()">$variant</a><br><span style="font-size:9pt; font-weight: normal">$variant.Conditions</span></h2>
 		#if(!$doc.isEmpty($variant.Comment))
 		<div class="comment" style="margin-top:0pt">$variant.Comment</div>
@@ -95,14 +95,14 @@
 				<th>Trans</th>
 				<th>Set</th>
 			</tr>
-			
+
 			#foreach($a in $doc.getEvents($variant))
 
 				#set($style=$doc.getStyle($a))
-			
+
 				#if($doc.isAlloc($a))
 					#set($conds=$a.Obs.Conditions)
-					
+
 					<!--
 					#if($doc.isGroupStart($a))
 					<tr style="color:#999999">
@@ -111,7 +111,7 @@
 					</tr>
 					#end
 					-->
-					
+
 					<tr style="xbackground-color:#f0f0f0">
 						<td nowrap style="$style">$doc.formatDate("HH:mm", $a.Start)</td>
 						<td nowrap>$doc.formatHHMMSS($a.Length)</td>
@@ -126,9 +126,9 @@
 						<td align="center" nowrap>$doc.getCond($conds.CC)</td>
 						<td align="center" nowrap>$doc.getCond($conds.WV)</td>
 						<td align="center" nowrap>$doc.getCond($conds.SB)</td>
-						
+
 						#set($rts=$doc.getRTS($a))
-						
+
 						<td nowrap>$doc.formatDate("HH:mm", $rts.Rise)</td>
 						<td nowrap>$doc.formatDate("HH:mm", $rts.Transit)</td>
 						<td nowrap>$doc.formatDate("HH:mm", $rts.Set)</td>
@@ -139,11 +139,11 @@
 						<tr>
 							<td class="comment" style="$style">&nbsp;</td>
 							<td colspan="16" class="comment">
-							
+
 							$!a.Comment
-							
+
 							#foreach($m in $markers)
-								<div style="margin:0px;color:$doc.getColor($m.Severity)">$m.Severity: $m.getFilteredUnionText($doc.getSchedule().getSite())</div>
+								<div style="margin:0px;color:$doc.getColor($m.Severity)">$m.Severity: $m.getFilteredUnionText($doc.getSchedule().getSite(), $doc.getTimePreference())</div>
 							#end
 
                             #foreach($w in $clearanceWindows)
@@ -151,20 +151,20 @@
                             #end
 
 							</td>
-						</tr>			
-					#end	
-				
+						</tr>
+					#end
+
 				#else
-				
+
 				<tr style="color:#999999">
 					<td nowrap style="$style">$doc.formatDate("HH:mm", $a.Time)</td>
 					<td nowrap colspan="15">$a.Text</td>
 				</tr>
-				
+
 				#end
-			
+
 			#end
-			
+
 		</table>
 
 		#end
@@ -172,6 +172,6 @@
 		#end
 
 	#end
-  
+
 </body>
 </html>


### PR DESCRIPTION
This PR addresses an issue with formatting marker message time intervals in the QPT's published plan.  Danny and I worked on this together.  We realized that we could get the time preference from the `ScheduleDocument` and use that to format the messages with a few tweaks here and there.