### PR TITLE
REL-3447: Upping max memory allocation.

### DIFF
--- a/app/itc/build.sbt
+++ b/app/itc/build.sbt
@@ -103,7 +103,6 @@ def itc(version: Version) = AppConfig(
   distribution = List(TestDistro),
   vmargs = List(
     "-Xmx1024M",
-    "-XX:MaxPermSize=196M",
     "-Dedu.gemini.site=north"
   ),
   props = Map.empty

--- a/app/ot/build.sbt
+++ b/app/ot/build.sbt
@@ -40,8 +40,7 @@ ocsAppManifest := {
 def common(version: Version) = AppConfig(
   id = "common",
   vmargs = List(
-    "-Xmx1024M",
-    "-XX:MaxPermSize=196M",
+    "-Xmx2048M",
     "-Duser.language=en",
     "-Duser.country=US"
   ),

--- a/app/qpt/build.sbt
+++ b/app/qpt/build.sbt
@@ -34,7 +34,7 @@ ocsAppManifest := {
 def common(version: Version) = AppConfig(
   id = "common",
   vmargs = List(
-    "-Xmx1024M",
+    "-Xmx2048M",
     "-Duser.language=en",
     "-Duser.country=US"
   ),


### PR DESCRIPTION
Increasing the max memory allocation for the QPT and OT as the garbage collector generated an `OutOfMemoryError` for the program GS-2018A-Q-419.