### PR TITLE
REL-1714: Use Nautical twilight for QPT intersection messages

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -20,8 +20,11 @@ import edu.gemini.qpt.core.util.MarkerManager;
 import edu.gemini.qpt.shared.sp.Obs;
 import edu.gemini.qpt.shared.util.TimeUtils;
 import edu.gemini.shared.util.immutable.*;
+import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obscomp.SPGroup.GroupType;
+
+import static edu.gemini.skycalc.TwilightBoundType.NAUTICAL;
 
 /**
  * Generates Alloc markers.
@@ -97,7 +100,8 @@ public class LimitsListener extends MarkerModelListener<Variant> {
                 mm.addMarker(false, this, Severity.Warning, msg, v, a);
             }
 
-            final Supplier<Union<Interval>> wholeNight = () -> new Union<>(new Interval(v.getSchedule().getStart(), v.getSchedule().getEnd()));
+            final TwilightBoundedNight tbn = TwilightBoundedNight.forTime(NAUTICAL, a.getStart(), v.getSchedule().getSite());
+            final Supplier<Union<Interval>> wholeNight = () -> new Union<>(new Interval(tbn.getStartTime(), tbn.getEndTime()));
 
             final Predicate<String> contributes =
                 (cacheName) -> {


### PR DESCRIPTION
This is a follow up to the new intersection messages in the QPT. There was a glitch when dragging an allocation around close to the night border that this commit should fix.

This was reported initially as an error when *opening a queue from the web* but it might be this issue in disguise instead.