### PR TITLE
REL-3452: parse mask name and use it as lookup key

### DIFF
--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/CustomMaskKey.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/CustomMaskKey.scala
@@ -11,17 +11,45 @@ import Scalaz._
 
 /** The custom mask key identifies a custom mask.
   *
-  * @param id   program id; ICTD only tracks ids that conform to the
-  *             ProgramId.Science pattern
-  * @param name name of the custom mask definition file, which should match the
-  *             value in the MOS ICTD table (sans the "_ODF.fits" suffix).
+  * @param id    program id; ICTD only tracks ids that conform to the
+  *              ProgramId.Science pattern
+  * @param index running index, which must be positive
   */
-final case class CustomMaskKey(id: ProgramId.Science, name: String)
+sealed abstract case class CustomMaskKey(id: ProgramId.Science, index: Int) {
+
+  assert(index >= 0, s"Invariant violated. $index is negative.")
+
+  def format: String =
+    f"${id.siteVal.abbreviation}${id.semesterVal.format}${id.ptypeVal.abbreviation}${id.index}-$index%02d"
+
+}
 
 object CustomMaskKey {
 
+  def fromIdAndIndex(id: ProgramId.Science, index: Int): Option[CustomMaskKey] =
+    (index >= 0) option new CustomMaskKey(id, index) {}
+
+  def unsafeFromIdAndIndex(id: ProgramId.Science, index: Int): CustomMaskKey =
+    fromIdAndIndex(id, index).getOrElse(sys.error(s"Cannot create CustomMaskKey with negative index: id=$id, index=$index"))
+
+  private val MaskDef = """(G[NS])(\d\d\d\d)([AB])([A-Z]+)(\d+)-(\d+)""".r
+
+  def parse(s: String): Option[CustomMaskKey] =
+    s match {
+      case MaskDef(site, year, ab, t, pidx, midx) =>
+        for {
+          pid <- ProgramId.parseScienceId(s"$site-$year$ab-$t-$pidx")
+          key <- CustomMaskKey.fromIdAndIndex(pid, midx.toInt)
+        } yield key
+      case _                                      =>
+        None
+    }
+
+  def unsafeParse(s: String): CustomMaskKey =
+    parse(s).getOrElse(sys.error(s"Could not parse $s as a CustomMaskKey"))
+
   implicit val OrderingCustomMaskKey: scala.math.Ordering[CustomMaskKey] =
-    scala.math.Ordering.by(k => (k.id.siteVal, k.id.semesterVal, k.id.ptypeVal, k.id.index, k.name))
+    scala.math.Ordering.by(k => (k.id.siteVal, k.id.semesterVal, k.id.ptypeVal, k.id.index, k.index))
 
   implicit val OrderCustomMaskKey: Order[CustomMaskKey] =
     Order.fromScalaOrdering

--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/dao/CustomMaskDao.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/dao/CustomMaskDao.scala
@@ -22,7 +22,7 @@ object CustomMaskDao {
     */
   final case class Mos(
     pid:        ProgramId.Science,
-    name:       String,
+    index:      Int,
     location:   Location
   ) {
 
@@ -31,7 +31,7 @@ object CustomMaskDao {
       * mask name itself without the _ODF.fits suffix.
       */
     def toKey: CustomMaskKey =
-      CustomMaskKey(pid, name.stripSuffix("_ODF.fits").stripSuffix(".fits"))
+      CustomMaskKey.unsafeFromIdAndIndex(pid, index)
 
     def toMapEntry: (CustomMaskKey, Availability) =
       (toKey, location.availability)
@@ -65,7 +65,7 @@ object CustomMaskDao {
                m.Semester,
                m.ProgramType,
                m.ProgramNo,
-               m.ODF,
+               m.RunningNo,
                c.Location
           FROM MOS m
                LEFT OUTER JOIN Component c

--- a/bundle/edu.gemini.ictd/src/test/scala/edu/gemini/ictd/CustomMaskKeySpec.scala
+++ b/bundle/edu.gemini.ictd/src/test/scala/edu/gemini/ictd/CustomMaskKeySpec.scala
@@ -1,0 +1,54 @@
+package edu.gemini.ictd
+
+import edu.gemini.spModel.core.{ProgramType, Site, ProgramId, ProgramIdGen}
+
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop.forAll
+
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+import scalaz._
+import Scalaz._
+
+
+object CustomMaskKeySpec extends Specification with ScalaCheck {
+
+  implicit val arbSciencePid: Arbitrary[ProgramId.Science] =
+    Arbitrary {
+      ProgramIdGen.genScienceId.map { pid =>
+        ProgramId.parse(pid.stringValue) match {
+          case s: ProgramId.Science => s
+          case _                    => sys.error("should only generate science pids")
+        }
+      }
+    }
+
+  implicit val arbCustomMaskKey: Arbitrary[CustomMaskKey] =
+    Arbitrary {
+      for {
+        pid <- arbitrary[ProgramId.Science]
+        run <- Gen.posNum[Int]
+      } yield CustomMaskKey.unsafeFromIdAndIndex(pid, run)
+    }
+
+  "CustomMaskKey" should {
+
+    "roundtrip" in {
+      forAll { (key: CustomMaskKey) =>
+        CustomMaskKey.parse(key.format) shouldEqual Some(key)
+      }
+    }
+
+    "disallow negative running numbers" in {
+      forAll { (pid: ProgramId.Science, index: Int) =>
+        CustomMaskKey.fromIdAndIndex(pid, index) match {
+          case Some(key) => index should be_>=(0)
+          case None      => index should be_<(0)
+        }
+      }
+    }
+
+  }
+}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
@@ -256,12 +256,9 @@ public final class Schedule extends BaseMutableBean implements PioSerializable, 
      * Determines the availability of the indicated custom mask.  Note, if there
      * is no ICTD data, we assume that the mask is available.
      */
-    public Availability maskAvailability(ProgramId.Science pid, String name) {
-        final CustomMaskKey k = new CustomMaskKey(pid, name);
-
-        // Assume Installed if there is no ICTD data whatsoever.
-        return getIctd().map(i -> i.maskAvailability.getOrDefault(k, Availability.Missing))
-                        .getOrElse(Availability.Installed);
+    public Availability maskAvailability(CustomMaskKey key) {
+        return getIctd().map(i -> i.maskAvailability.getOrDefault(key, Availability.Missing))
+                        .getOrElse(Availability.Installed); // no ICTD => assume installed
     }
 
     public void moveAllocs(long offset) {

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
@@ -29,7 +29,7 @@ public final class MaskController implements GTableController<Schedule, Map.Entr
     @Override
     public Object getSubElement(Map.Entry<CustomMaskKey, Availability> element, MaskAttribute subElement) {
         switch (subElement) {
-            case Name:         return element.getKey().name();
+            case Name:         return element.getKey().format();
             case Availability: return element.getValue();
             default:           throw new IllegalArgumentException(subElement.name());
         }
@@ -72,7 +72,7 @@ public final class MaskController implements GTableController<Schedule, Map.Entr
         Arrays.sort(entries, new Comparator<Map.Entry<CustomMaskKey, Availability>>() {
             @Override
             public int compare(Map.Entry<CustomMaskKey, Availability> e1, Map.Entry<CustomMaskKey, Availability> e2) {
-                return e1.getKey().name().compareTo(e2.getKey().name());
+                return CustomMaskKey.OrderingCustomMaskKey().compare(e1.getKey(), e2.getKey());
             }
         });
     }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramId.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramId.scala
@@ -59,8 +59,11 @@ object ProgramId {
 
     lazy val toSp: SPProgramID     = SPProgramID.toProgramID(toString)
 
-    override def toString: String =
+    def format: String =
       s"${siteVal.abbreviation}-${semesterVal.toString}-${ptypeVal.abbreviation}-$index"
+
+    override def toString: String =
+      format
   }
 
   case class Daily(siteVal: Site, ptypeVal: ProgramType, year: Int, month: Int, day: Int) extends StandardProgramId {
@@ -137,6 +140,12 @@ object ProgramId {
     parse(s) match {
       case s: StandardProgramId => Some(s)
       case _                    => None
+    }
+
+  def parseScienceId(s: String): Option[Science] =
+    parse(s) match {
+      case pid: Science => Some(pid)
+      case _            => None
     }
 }
 

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -58,7 +58,7 @@ trait OcsBundle {
     project.in(file("bundle/edu.gemini.ictd")).dependsOn(
       bundle_edu_gemini_pot,
       bundle_edu_gemini_shared_util,
-      bundle_edu_gemini_spModel_core,
+      bundle_edu_gemini_spModel_core % "test->test;compile->compile",
       bundle_edu_gemini_spModel_pio
     )
 


### PR DESCRIPTION
In the initial QPT+ICTD release I misinterpreted the columns of the ICTD `MOS` table.  I had thought that an observation's custom mask name should be matched to the `MOS` table's `ODF` field to find the mask's availability.  In reality the `ODF` field turns out to be informational and the `MOS` table should instead by keyed by its corresponding program id + `RunningNo` columns.

This PR updates the code to ignore the `MOS` table `ODF` column altogether.  Instead it parses a GMOS observation's custom mask field to obtain a `CustomMaskKey`, identifying the program id and running number for the mask entry in the `MOS` table. 