### PR TITLE
REL-1714: change airmass limits

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -15,6 +15,7 @@ import edu.gemini.qpt.core.Marker.Severity;
 import edu.gemini.qpt.core.Variant.Flag;
 import edu.gemini.qpt.core.util.*;
 import edu.gemini.qpt.shared.sp.Group;
+import edu.gemini.qpt.core.util.AirmassLimit;
 import edu.gemini.qpt.core.util.LttsServicesClient;
 import edu.gemini.qpt.core.util.MarkerManager;
 import edu.gemini.qpt.shared.sp.Obs;
@@ -165,10 +166,10 @@ public class LimitsListener extends MarkerModelListener<Variant> {
 
                 } else {
 
-                    // Legacy behavior; airmass 2.0 limit
-                    if (maxAirmass > 2.0) {
+                    // Legacy behavior; airmass limit
+                    if (maxAirmass > AirmassLimit.ERROR.airmass) {
                         mm.addMarker(false, this, Severity.Error, String.format("Observation reaches airmass %1.2f.", maxAirmass), v, a);
-                    } else if (maxAirmass > 1.75) {
+                    } else if (maxAirmass > AirmassLimit.WARNING.airmass) {
                         mm.addMarker(false, this, Severity.Warning, String.format("Observation reaches airmass %1.2f.", maxAirmass), v, a);
                     }
                 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/AirmassLimit.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/AirmassLimit.java
@@ -1,0 +1,24 @@
+package edu.gemini.qpt.core.util;
+
+import edu.gemini.spModel.core.Angle;
+import edu.gemini.spModel.core.Angle$;
+
+/**
+ * Airmass limits used throughout the QPT.
+ */
+public enum AirmassLimit {
+    WARNING(2.0, 30.000),
+    ERROR  (2.3, 25.625),
+    ;
+
+    /** Airmass limit above which the warning or error is triggered. */
+    public final double airmass;
+
+    /** Corresponding elevation angle. */
+    public final Angle elevation;
+
+    private AirmassLimit(double airmass, double elevationDeg) {
+        this.airmass   = airmass;
+        this.elevation = Angle$.MODULE$.fromDegrees(elevationDeg);
+    }
+}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/ElevationConstraintSolver.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/ElevationConstraintSolver.java
@@ -13,11 +13,11 @@ public abstract class ElevationConstraintSolver extends Solver {
 
     @SuppressWarnings("unused")
     private static final Logger LOGGER = Logger.getLogger(ElevationConstraintSolver.class.getName());
-    
+
     protected final ImprovedSkyCalc calc;
     protected final Function<Long, WorldCoords> coords;
     protected final double min, max;
-    
+
     protected ElevationConstraintSolver(Site site, Function<Long, WorldCoords> coords, double min, double max) {
         super(TimeUtils.MS_PER_HOUR / 4, TimeUtils.MS_PER_MINUTE);
         this.coords = coords;
@@ -30,12 +30,12 @@ public abstract class ElevationConstraintSolver extends Solver {
         switch (obs.getElevationConstraintType()) {
         case AIRMASS:    return new AirmassSolver(site, obs);
         case HOUR_ANGLE: return new HourAngleSolver(site, obs);
-        case NONE:       return new AirmassSolver(site, obs, 1.0, 2.0);
+        case NONE:       return new AirmassSolver(site, obs, 1.0, AirmassLimit.ERROR.airmass);
         default:
             throw new Error("Unknown ElevationConstraintType: " + obs.getElevationConstraintType());
-        }        
+        }
     }
-    
+
     static class AirmassSolver extends ElevationConstraintSolver {
 
         protected AirmassSolver(Site site, Obs obs) {
@@ -56,7 +56,7 @@ public abstract class ElevationConstraintSolver extends Solver {
     }
 
     static class HourAngleSolver extends ElevationConstraintSolver {
-        
+
         protected HourAngleSolver(Site site, Obs obs) {
             super(site, obs::getCoords, obs.getElevationConstraintMin(), obs.getElevationConstraintMax());
         }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/RiseTransitSet.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/RiseTransitSet.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import edu.gemini.spModel.core.Site;
 import jsky.coords.WorldCoords;
+import edu.gemini.qpt.core.util.AirmassLimit;
 import edu.gemini.qpt.core.util.ImprovedSkyCalc;
 import edu.gemini.qpt.core.util.Interval;
 import edu.gemini.qpt.core.util.Solver;
@@ -12,10 +13,10 @@ import edu.gemini.qpt.shared.util.TimeUtils;
 
 /**
  * Value type that calculates the rise, transit, and set times for a given object, given a reference
- * time. If the object is above airmass 2.0 at the reference time, the current transit is calculated. 
- * Otherwise the next one will be calculated. If the target doesn't rise/set with respect to the
- * airmass 2 boundary within +/- 24 hrs of the reference time, rise and set will be null. If it 
- * doesn't rise/set with respect to the horizon, transit will be null. 
+ * time. If the object is above the airmass error limit at the reference time, the current transit
+ * is calculated. Otherwise the next one will be calculated. If the target doesn't rise/set with
+ * respect to the airmass boundary within +/- 24 hrs of the reference time, rise and set will be null.
+ * If it doesn't rise/set with respect to the horizon, transit will be null.
  * @author rnorris
  */
 public class RiseTransitSet {
@@ -23,17 +24,17 @@ public class RiseTransitSet {
     private final ImprovedSkyCalc calc;
     private final Function<Long, WorldCoords> coords;
     private final Long rise, transit, set;
-    
+
     private static final long MARGIN = TimeUtils.MS_PER_MINUTE / 4; // 15 sec
-    
+
     public RiseTransitSet(Site site, Function<Long, WorldCoords> coords, long start) {
         this.coords = coords;
         this.calc = new ImprovedSkyCalc(site);
-        
+
         Solver solver = new Solver(TimeUtils.MS_PER_HOUR, MARGIN) {
             @Override
             protected boolean f(long t) {
-                return airmass(t) < 2.0;
+                return airmass(t) < AirmassLimit.ERROR.airmass;
             }
         };
 
@@ -45,10 +46,10 @@ public class RiseTransitSet {
             rise = domain.getStart();
             set = domain.getEnd();
             transit = (rise + set) / 2;
-            
+
         } else {
 
-            // [QPT-184] Target never gets above 2.0, so rise and set are undefined.            
+            // [QPT-184] Target never gets above airmass error limit, so rise and set are undefined.
             rise = null;
             set = null;
 
@@ -64,15 +65,15 @@ public class RiseTransitSet {
 
             // If there is a solution we can define transit. Otheriwse it's null too.
             transit = (domain == null) ? null : ((domain.getStart() + domain.getEnd()) / 2);
-                                            
-        } 
-        
+
+        }
+
     }
-    
+
     private double airmass(long time) {
         calc.calculate(coords.apply(time), new Date(time), false);
         double ret = calc.getAirmass();
-        // WACK: skycalc returns 0 for targets below the horizon        
+        // WACK: skycalc returns 0 for targets below the horizon
         return (ret < 1.0) ? Double.MAX_VALUE : ret;
     }
 
@@ -87,5 +88,5 @@ public class RiseTransitSet {
     public Long getTransit() {
         return transit;
     }
-        
+
 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/Visualizer.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/Visualizer.java
@@ -5,6 +5,7 @@ import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Shape;
+import java.awt.Stroke;
 import java.awt.TexturePaint;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -40,6 +41,7 @@ import edu.gemini.qpt.shared.sp.Obs;
 import edu.gemini.qpt.core.util.ImprovedSkyCalc;
 import edu.gemini.qpt.core.util.Interval;
 import edu.gemini.qpt.shared.util.TimeUtils;
+import edu.gemini.qpt.core.util.AirmassLimit;
 import edu.gemini.qpt.core.util.TimingWindowSolver;
 import edu.gemini.qpt.ui.util.BooleanViewPreference;
 import edu.gemini.qpt.ui.util.ColorWheel;
@@ -395,6 +397,11 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
         }
     }
 
+    private Shape elevationLine(double elevation) {
+        return alt2Y.createTransformedShape(
+            new Line2D.Double(0, elevation, getSize().getWidth(), elevation)
+        );
+    }
 
     private void paintElevationLines(Graphics2D g2d) {
         Graphics2DAttributes g2da = new Graphics2DAttributes(g2d);
@@ -403,14 +410,12 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
         switch (ElevationPreference.BOX.get()) {
         case AIRMASS:
 
-            // Draw airmass lines every so often from 0 - 90 deg. The one at 30 is special
-            // because it represents airmass 2.0 (more or less), so we use a different style.
+            // Draw airmass lines every so often from 0 - 90 deg.
             for (int elevation = 10 * ((int) MIN_DEG / 10); elevation < MAX_DEG; elevation += 10) {
 
                 // Create and draw the line.
-                Shape line = new Line2D.Double(0, elevation, getSize().getWidth(), elevation);
-                line = alt2Y.createTransformedShape(line);
-                g2d.setStroke(elevation == 30 ? SOLID_STROKE_LIGHT : DOTTED_STROKE_LIGHT);
+                final Shape line = elevationLine(elevation);
+                g2d.setStroke(DOTTED_STROKE_LIGHT);
                 g2d.draw(line);
 
                 // And the label, off to the left. Don't need one at zero.
@@ -426,19 +431,25 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
                 }
 
             }
+
+            // Draw a special airmass line at the error limit.
+            {
+                final Shape line = elevationLine(AirmassLimit.ERROR.elevation.toDegrees());
+                g2d.setStroke(SOLID_STROKE_LIGHT);
+                g2d.draw(line);
+            }
+
             break;
 
 
         case ELEVATION:
 
-            // Draw elevation lines every so often from 0 - 90 deg. The one at 30 is special
-            // because it represents airmass 2.0 (more or less), so we use a different style.
+            // Draw elevation lines every so often from 0 - 90 deg.
             for (int elevation = 10 * ((int) MIN_DEG / 10); elevation < MAX_DEG; elevation += 10) {
 
                 // Create and draw the line.
-                Shape line = new Line2D.Double(0, elevation, getSize().getWidth(), elevation);
-                line = alt2Y.createTransformedShape(line);
-                g2d.setStroke(elevation == 30 ? SOLID_STROKE_LIGHT : DOTTED_STROKE_LIGHT);
+                final Shape line = elevationLine(elevation);
+                g2d.setStroke(DOTTED_STROKE_LIGHT);
                 g2d.draw(line);
 
                 // And the label, off to the left. Don't need one at zero.
@@ -449,6 +460,14 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
                 }
 
             }
+
+            // Draw a special airmass line at the error limit.
+            {
+                final Shape line = elevationLine(AirmassLimit.ERROR.elevation.toDegrees());
+                g2d.setStroke(SOLID_STROKE_LIGHT);
+                g2d.draw(line);
+            }
+
             break;
 
         }


### PR DESCRIPTION
This PR updates the default error and warning airmass limits used throughout the QPT as requested.  Previously the limits were defined in a couple of places.  They have now have been collected in an `AirmassLimit` enum.

I believe this is correct, but perhaps @tpolecat could take a look as well.  I definitely could have missed some of them.