### PR TITLE
REL-1714: Change night boundaries to civil twilight

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
@@ -11,11 +11,9 @@ import edu.gemini.qpt.shared.sp.MiniModel;
 import edu.gemini.qpt.shared.util.EnumPio;
 import edu.gemini.qpt.shared.util.PioSerializable;
 import edu.gemini.qpt.shared.util.TimeUtils;
-import edu.gemini.skycalc.TwilightBoundType;
 import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.spModel.core.ProgramId;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.data.PreImagingType;
 import edu.gemini.spModel.ictd.Availability;
@@ -66,9 +64,6 @@ public final class Schedule extends BaseMutableBean implements PioSerializable, 
     public static final String PROP_EXTRA_SEMESTERS = "extraSemesters";
     public static final String PROP_MINI_MODEL = "miniModel";
     public static final String PROP_ICTD = "ictd";
-
-    // Constants for internal use (probably will move)
-    private static final TwilightBoundType TYPE = TwilightBoundType.NAUTICAL;
 
     // Persistent Members
     private final BlockUnion blocks;
@@ -522,7 +517,7 @@ public final class Schedule extends BaseMutableBean implements PioSerializable, 
 
     public void addObservingNights(long start, long end) {
         for (long i = start; i <= end; i += MS_PER_DAY) {
-            TwilightBoundedNight night = new TwilightBoundedNight(TYPE, i, miniModel.getSite());
+            final TwilightBoundedNight night = Twilight.startingOnDate(i, miniModel.getSite());
             addBlock(night.getStartTime(), night.getEndTime());
         }
     }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -25,8 +25,6 @@ import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obscomp.SPGroup.GroupType;
 
-import static edu.gemini.skycalc.TwilightBoundType.NAUTICAL;
-
 /**
  * Generates Alloc markers.
  * @author rnorris
@@ -101,8 +99,9 @@ public class LimitsListener extends MarkerModelListener<Variant> {
                 mm.addMarker(false, this, Severity.Warning, msg, v, a);
             }
 
-            final TwilightBoundedNight tbn = TwilightBoundedNight.forTime(NAUTICAL, a.getStart(), v.getSchedule().getSite());
-            final Supplier<Union<Interval>> wholeNight = () -> new Union<>(new Interval(tbn.getStartTime(), tbn.getEndTime()));
+            final TwilightBoundedNight tbn = Twilight.forTime(a.getStart(), v.getSchedule().getSite());
+            final Interval nightInterval   = new Interval(tbn.getStartTime(), tbn.getEndTime());
+            final Supplier<Union<Interval>> wholeNight = () -> new Union<>(nightInterval);
 
             final Predicate<String> contributes =
                 (cacheName) -> {

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/Twilight.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/Twilight.java
@@ -1,0 +1,38 @@
+package edu.gemini.qpt.core.util;
+
+import edu.gemini.spModel.core.Site;
+import edu.gemini.skycalc.TwilightBoundedNight;
+import edu.gemini.skycalc.TwilightBoundType;
+
+/**
+ * Twilight night bound calculations used throughout the QPT.
+ */
+public final class Twilight {
+    private Twilight() {}
+
+    /** Definition of twilight in use for the QPT. */
+    public static final TwilightBoundType TYPE = TwilightBoundType.CIVIL;
+
+    /**
+     * Computes the twilight bounds for the night starting on the date of the
+     * given time.  For example, at midnight October 8 that would be the night
+     * October 8/9, whereas for 11:59:59 October 7 it would be the night of
+     * October 7/8.
+     */
+    public static TwilightBoundedNight startingOnDate(long time, Site site) {
+        return new TwilightBoundedNight(TYPE, time, site);
+    }
+
+    /**
+     * Computes the twilight bounds corresponding to the given time.  If the
+     * time falls within twilight bounds, the same night is returned.  On the
+     * other hand if the time falls during daytime, it returns the coming night.
+     *
+     * For example, at midnight October 8, this will return the night of
+     * October 7/8 (the same for 11:59:59 October 7).
+     */
+    public static TwilightBoundedNight forTime(long time, Site site) {
+        return TwilightBoundedNight.forTime(TYPE, time, site);
+    }
+
+}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/MergeAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/MergeAction.java
@@ -10,7 +10,7 @@ import javax.swing.JOptionPane;
 import edu.gemini.ags.api.AgsMagnitude;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.Variant;
-import edu.gemini.skycalc.TwilightBoundType;
+import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.ui.workspace.IShell;
 import edu.gemini.util.security.auth.keychain.KeyChain;
@@ -69,8 +69,8 @@ public class MergeAction extends AbstractOpenAction implements PropertyChangeLis
                 }
 
                 // Can't merge plans from different nights (yet)
-                TwilightBoundedNight prevNight = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, current.getStart(), current.getSite());
-                TwilightBoundedNight nextNight = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, other.getStart(), other.getSite());
+                final TwilightBoundedNight prevNight = Twilight.startingOnDate(current.getStart(), current.getSite());
+                final TwilightBoundedNight nextNight = Twilight.startingOnDate(other.getStart(), other.getSite());
                 if (prevNight.getStartTime() != nextNight.getStartTime()) {
                     JOptionPane.showMessageDialog(shell.getPeer(), ERR_NIGHT, "Cannot Merge", JOptionPane.ERROR_MESSAGE);
                     return;

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/OpenFromWebAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/OpenFromWebAction.java
@@ -34,6 +34,7 @@ import edu.gemini.ags.api.AgsMagnitude;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.ScheduleIO;
 import edu.gemini.qpt.core.util.LttsServicesClient;
+import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.qpt.ui.util.AbstractAsyncAction;
 import edu.gemini.qpt.ui.util.CalendarPanel;
 import edu.gemini.qpt.ui.util.ConfigErrorDialog;
@@ -273,7 +274,7 @@ class OpenFromWebDialog extends JDialog {
     public URL getURL() {
 
         // Get the night for the selected day
-        TwilightBoundedNight night = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, calendarPanel.getStartDate(), site);
+        final TwilightBoundedNight night = Twilight.startingOnDate(calendarPanel.getStartDate(), site);
 
         // Get yy mmm dd
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/VariantAdapter.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/VariantAdapter.java
@@ -1,6 +1,8 @@
 package edu.gemini.qpt.ui.view.property.adapter;
 
+import edu.gemini.spModel.core.Site;
 import edu.gemini.qpt.core.Variant;
+import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.qpt.ui.view.property.PropertyTable;
 import edu.gemini.qpt.ui.view.property.PropertyTable.Adapter;
 import edu.gemini.skycalc.TwilightBoundType;
@@ -15,30 +17,24 @@ public class VariantAdapter implements Adapter<Variant> {
 
     public void setProperties(Variant variant, Variant target, PropertyTable table) {
 
-        final TimeZone zone = target.getSchedule().getSite().timezone();
+        final long    start = target.getSchedule().getStart();
+        final Site     site = target.getSchedule().getSite();
+        final TimeZone zone = site.timezone();
 
         DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm")
                 .withZone(zone.toZoneId());
 
-        TwilightBoundedNight night = new TwilightBoundedNight(
-                TwilightBoundType.OFFICIAL,
-                target.getSchedule().getStart(),
-                target.getSchedule().getSite()
-        );
+        final TwilightBoundedNight night    = new TwilightBoundedNight(TwilightBoundType.OFFICIAL, start, site);
+        final TwilightBoundedNight twilight = Twilight.startingOnDate(start, site);
 
-        TwilightBoundedNight nautical = new TwilightBoundedNight(
-                TwilightBoundType.NAUTICAL,
-                target.getSchedule().getStart(),
-                target.getSchedule().getSite()
-        );
-
-        table.put(PROP_TYPE, "Plan Variant");
-        table.put(PROP_TITLE, target.getName());
-        table.put(PROP_SUNSET, dateFormat.format(Instant.ofEpochMilli(night.getStartTimeRounded(zone))));
-        table.put(PROP_DUSK, dateFormat.format(Instant.ofEpochMilli(nautical.getStartTimeRounded(zone))));
-        table.put(PROP_DAWN, dateFormat.format(Instant.ofEpochMilli(nautical.getEndTimeRounded(zone))));
-        table.put(PROP_SUNRISE, dateFormat.format(Instant.ofEpochMilli(night.getEndTimeRounded(zone))));
+        table.put(PROP_TYPE,        "Plan Variant");
+        table.put(PROP_TITLE,       target.getName());
+        table.put(PROP_SUNSET,      dateFormat.format(Instant.ofEpochMilli(night.getStartTimeRounded(zone))));
+        table.put(PROP_DUSK,        dateFormat.format(Instant.ofEpochMilli(twilight.getStartTimeRounded(zone))));
+        table.put(PROP_DAWN,        dateFormat.format(Instant.ofEpochMilli(twilight.getEndTimeRounded(zone))));
+        table.put(PROP_SUNRISE,     dateFormat.format(Instant.ofEpochMilli(night.getEndTimeRounded(zone))));
         table.put(PROP_CONSTRAINTS, target.getConditions());
+
         if (target.getWindConstraint() != null)
             table.put(PROP_WIND, target.getWindConstraint());
         else


### PR DESCRIPTION
This PR changes the QPT twilight boundaries to the civil, 6 degree definition.  This allows `SBAny` observations to be scheduled earlier in the night without impacting other sky background constraints. 

To ensure consistency, I centralized the twilight bound computation in a single place.  I'm not particularly pleased with how it came out though.