### PR TITLE
REL-1714: show nautical twilight and airmass 2 limits

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/Twilight.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/Twilight.java
@@ -5,7 +5,9 @@ import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.skycalc.TwilightBoundType;
 
 /**
- * Twilight night bound calculations used throughout the QPT.
+ * Twilight night bound calculations used for block limits. Note, we display
+ * nautical twilight bounds in the visualizer and property sheet, but the
+ * twilight calculations are based on civil twilight.
  */
 public final class Twilight {
     private Twilight() {}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/ScheduleDocument.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/ScheduleDocument.java
@@ -34,7 +34,6 @@ import edu.gemini.qpt.core.Alloc.Grouping;
 import edu.gemini.qpt.core.Marker.Severity;
 import edu.gemini.qpt.core.util.ImprovedSkyCalc;
 import edu.gemini.qpt.core.util.Interval;
-import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.qpt.shared.util.TimeUtils;
 import edu.gemini.qpt.ui.util.CancelledException;
 import edu.gemini.qpt.ui.util.ColorWheel;
@@ -327,15 +326,14 @@ public class ScheduleDocument {
         ret.add(new SimpleEvent(allocs.last().getEnd(), "End of plan variant."));
 
         // Add twilight info.
-        final TwilightBoundedNight twilight = Twilight.startingOnDate(schedule.getStart(), schedule.getSite());
+        final TwilightBoundedNight nautical = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, schedule.getStart(), schedule.getSite());
         final TimeZone timezone = utc ? TimeZone.getTimeZone("UTC") : schedule.getSite().timezone();
-        final int hAngle = (int) Twilight.TYPE.getHorizonAngle();
-        ret.add(new SimpleEvent(twilight.getStartTimeRounded(timezone), String.format("Evening %d&deg; Twilight", hAngle)));
-        ret.add(new SimpleEvent(twilight.getEndTimeRounded(timezone), String.format("Morning %d&deg; Twilight", hAngle)));
+        ret.add(new SimpleEvent(nautical.getStartTimeRounded(timezone), "Evening 12&deg; Twilight"));
+        ret.add(new SimpleEvent(nautical.getEndTimeRounded(timezone),   "Morning 12&deg; Twilight"));
 
         // Find illuminated fraction
         Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(twilight.getEndTime());
+        cal.setTimeInMillis(nautical.getEndTime());
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/VariantAdapter.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/VariantAdapter.java
@@ -2,7 +2,6 @@ package edu.gemini.qpt.ui.view.property.adapter;
 
 import edu.gemini.spModel.core.Site;
 import edu.gemini.qpt.core.Variant;
-import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.qpt.ui.view.property.PropertyTable;
 import edu.gemini.qpt.ui.view.property.PropertyTable.Adapter;
 import edu.gemini.skycalc.TwilightBoundType;
@@ -24,15 +23,15 @@ public class VariantAdapter implements Adapter<Variant> {
         DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm")
                 .withZone(zone.toZoneId());
 
-        final TwilightBoundedNight night    = new TwilightBoundedNight(TwilightBoundType.OFFICIAL, start, site);
-        final TwilightBoundedNight twilight = Twilight.startingOnDate(start, site);
+        final TwilightBoundedNight official = new TwilightBoundedNight(TwilightBoundType.OFFICIAL, start, site);
+        final TwilightBoundedNight nautical = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, start, site);
 
         table.put(PROP_TYPE,        "Plan Variant");
         table.put(PROP_TITLE,       target.getName());
-        table.put(PROP_SUNSET,      dateFormat.format(Instant.ofEpochMilli(night.getStartTimeRounded(zone))));
-        table.put(PROP_DUSK,        dateFormat.format(Instant.ofEpochMilli(twilight.getStartTimeRounded(zone))));
-        table.put(PROP_DAWN,        dateFormat.format(Instant.ofEpochMilli(twilight.getEndTimeRounded(zone))));
-        table.put(PROP_SUNRISE,     dateFormat.format(Instant.ofEpochMilli(night.getEndTimeRounded(zone))));
+        table.put(PROP_SUNSET,      dateFormat.format(Instant.ofEpochMilli(official.getStartTimeRounded(zone))));
+        table.put(PROP_DUSK,        dateFormat.format(Instant.ofEpochMilli(nautical.getStartTimeRounded(zone))));
+        table.put(PROP_DAWN,        dateFormat.format(Instant.ofEpochMilli(nautical.getEndTimeRounded(zone))));
+        table.put(PROP_SUNRISE,     dateFormat.format(Instant.ofEpochMilli(official.getEndTimeRounded(zone))));
         table.put(PROP_CONSTRAINTS, target.getConditions());
 
         if (target.getWindConstraint() != null)

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/Visualizer.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/Visualizer.java
@@ -165,9 +165,9 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
             g2d.setRenderingHints(RENDERING_HINTS);
 
             // Background stuff: night, blocks, sun, moon, elevation lines
-            paintNight(g2d);
-            for (Block b: blocks) paintBlock(g2d, b);
-             paintSun(g2d);
+            paintOfficialNight(g2d);
+            paintNauticalNight(g2d);
+            paintSun(g2d);
             paintMoon(g2d);
             paintElevationLines(g2d);
 
@@ -432,9 +432,9 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
 
             }
 
-            // Draw a special airmass line at the error limit.
+            // Draw a special airmass line at the warning limit.
             {
-                final Shape line = elevationLine(AirmassLimit.ERROR.elevation.toDegrees());
+                final Shape line = elevationLine(AirmassLimit.WARNING.elevation.toDegrees());
                 g2d.setStroke(SOLID_STROKE_LIGHT);
                 g2d.draw(line);
             }
@@ -461,9 +461,9 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
 
             }
 
-            // Draw a special airmass line at the error limit.
+            // Draw a special airmass line at the warning limit.
             {
-                final Shape line = elevationLine(AirmassLimit.ERROR.elevation.toDegrees());
+                final Shape line = elevationLine(AirmassLimit.WARNING.elevation.toDegrees());
                 g2d.setStroke(SOLID_STROKE_LIGHT);
                 g2d.draw(line);
             }
@@ -524,35 +524,28 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
         g2da.restore();
     }
 
-    private void paintNight(Graphics2D g2d) {
+    private void paintNight(Graphics2D g2d, TwilightBoundType boundType, Color color) {
+        final Site site = model.getSchedule().getSite();
 
-        Site site = model.getSchedule().getSite();
+        final TwilightBoundedNight night = new TwilightBoundedNight(boundType, model.getSchedule().getStart(), site);
 
-        TwilightBoundedNight night = new TwilightBoundedNight(TwilightBoundType.OFFICIAL, model.getSchedule().getStart(), site);
-
-        Graphics2DAttributes g2da = new Graphics2DAttributes(g2d);
+        final Graphics2DAttributes g2da = new Graphics2DAttributes(g2d);
 
         // Night is just a colored rectangle.
-        Rectangle2D.Double rect = new Rectangle2D.Double(night.getStartTime(), 0, night.getTotalTime(), getSize().getHeight());
-        Shape rect2 = time2X.createTransformedShape(rect);
-        g2d.setColor(NIGHT_COLOR);
+        final Rectangle2D.Double rect = new Rectangle2D.Double(night.getStartTime(), 0, night.getTotalTime(), getSize().getHeight());
+        final Shape rect2 = time2X.createTransformedShape(rect);
+        g2d.setColor(color);
         g2d.fill(rect2);
 
         g2da.restore();
-
-
     }
 
-    private void paintBlock(Graphics2D g2d, Block b) {
-        Graphics2DAttributes g2da = new Graphics2DAttributes(g2d);
+    private void paintOfficialNight(Graphics2D g2d) {
+        paintNight(g2d, TwilightBoundType.OFFICIAL, NIGHT_COLOR);
+    }
 
-        // Blocks are just colored rectangles.
-        Rectangle2D.Double rect = new Rectangle2D.Double(b.getStart(), 0, b.getLength(), getSize().getHeight());
-        Shape rect2 = time2X.createTransformedShape(rect);
-        g2d.setColor(BLOCK_COLOR);
-        g2d.fill(rect2);
-
-        g2da.restore();
+    private void paintNauticalNight(Graphics2D g2d) {
+        paintNight(g2d, TwilightBoundType.NAUTICAL, BLOCK_COLOR);
     }
 
     private void paintShutteringWindows(Graphics2D g2d, Alloc a, boolean selected) {


### PR DESCRIPTION
Airmass limits and twilight bounds were adjusted as requested in #1534 and #1535 respectively.  I had incorrectly assumed that the QPT should display the new reality accordingly.  Instead the old limits and boundaries should in fact still be displayed and yet the calculations need to be based on the new limits.  This PR updates the visualizer, property sheets and schedule document accordingly.