### PR TITLE
REL-1714: patch release update

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
@@ -11,11 +11,9 @@ import edu.gemini.qpt.shared.sp.MiniModel;
 import edu.gemini.qpt.shared.util.EnumPio;
 import edu.gemini.qpt.shared.util.PioSerializable;
 import edu.gemini.qpt.shared.util.TimeUtils;
-import edu.gemini.skycalc.TwilightBoundType;
 import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.spModel.core.ProgramId;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.data.PreImagingType;
 import edu.gemini.spModel.ictd.Availability;
@@ -66,9 +64,6 @@ public final class Schedule extends BaseMutableBean implements PioSerializable, 
     public static final String PROP_EXTRA_SEMESTERS = "extraSemesters";
     public static final String PROP_MINI_MODEL = "miniModel";
     public static final String PROP_ICTD = "ictd";
-
-    // Constants for internal use (probably will move)
-    private static final TwilightBoundType TYPE = TwilightBoundType.NAUTICAL;
 
     // Persistent Members
     private final BlockUnion blocks;
@@ -522,7 +517,7 @@ public final class Schedule extends BaseMutableBean implements PioSerializable, 
 
     public void addObservingNights(long start, long end) {
         for (long i = start; i <= end; i += MS_PER_DAY) {
-            TwilightBoundedNight night = new TwilightBoundedNight(TYPE, i, miniModel.getSite());
+            final TwilightBoundedNight night = Twilight.startingOnDate(i, miniModel.getSite());
             addBlock(night.getStartTime(), night.getEndTime());
         }
     }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -25,8 +25,6 @@ import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obscomp.SPGroup.GroupType;
 
-import static edu.gemini.skycalc.TwilightBoundType.NAUTICAL;
-
 /**
  * Generates Alloc markers.
  * @author rnorris
@@ -101,8 +99,9 @@ public class LimitsListener extends MarkerModelListener<Variant> {
                 mm.addMarker(false, this, Severity.Warning, msg, v, a);
             }
 
-            final TwilightBoundedNight tbn = TwilightBoundedNight.forTime(NAUTICAL, a.getStart(), v.getSchedule().getSite());
-            final Supplier<Union<Interval>> wholeNight = () -> new Union<>(new Interval(tbn.getStartTime(), tbn.getEndTime()));
+            final TwilightBoundedNight tbn = Twilight.forTime(a.getStart(), v.getSchedule().getSite());
+            final Interval nightInterval   = new Interval(tbn.getStartTime(), tbn.getEndTime());
+            final Supplier<Union<Interval>> wholeNight = () -> new Union<>(nightInterval);
 
             final Predicate<String> contributes =
                 (cacheName) -> {

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -3,7 +3,6 @@ package edu.gemini.qpt.core.listeners;
 import java.beans.PropertyChangeEvent;
 import java.util.*;
 import java.util.function.*;
-import java.util.TimeZone;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -44,8 +43,6 @@ public class LimitsListener extends MarkerModelListener<Variant> {
         Variant v = (Variant) evt.getSource();
         MarkerManager mm = v.getSchedule().getMarkerManager();
         mm.clearMarkers(this, v);
-
-        final TimeZone zone = v.getSchedule().getSite().timezone();
 
         for (Alloc a: v.getAllocs()) {
 
@@ -103,19 +100,39 @@ public class LimitsListener extends MarkerModelListener<Variant> {
             final Interval nightInterval   = new Interval(tbn.getStartTime(), tbn.getEndTime());
             final Supplier<Union<Interval>> wholeNight = () -> new Union<>(nightInterval);
 
-            final Predicate<String> contributes =
-                (cacheName) -> {
-                    final Map<Obs, Union<Interval>> c = v.getSchedule().getCache(cacheName);
-                    final Union<Interval> u = c.getOrDefault(a.getObs(), new Union<>());
+            final BiFunction<Function<Interval, Long>, String, Predicate<Long>> matchWith =
+                (f, cacheName) ->
+                    ts -> {
+                        final Map<Obs, Union<Interval>> c = v.getSchedule().getCache(cacheName);
+                        final Union<Interval> u = c.getOrDefault(a.getObs(), new Union<>());
 
-                    final Union<Interval> r = wholeNight.get();
-                    r.remove(u);
-                    return !r.isEmpty();
+                        return u.getIntervals().stream().anyMatch(i -> f.apply(i) == ts);
+                    };
+
+            final BiFunction<Function<Interval, Long>, Interval, Option<String>> explainLimit =
+                (f, i) -> {
+                    if (matchWith.apply(f, Variant.VISIBLE_UNION_CACHE).test(f.apply(i))) {
+                        switch (a.getObs().getElevationConstraintType()) {
+                            case HOUR_ANGLE:
+                                new Some<>("%t(H)");
+                                break;
+                            default:
+                                new Some<>("%t(A)");
+                                break;
+                        }
+                        return new Some<>("%t(A)");
+                    } else if (matchWith.apply(f, Variant.DARK_UNION_CACHE).test(f.apply(i))) {
+                        return new Some<>("%t(B)");
+                    } else if (matchWith.apply(f, Variant.TIMING_UNION_CACHE).test(f.apply(i))) {
+                        return new Some<>("%t(T)");
+                    } else {
+                        return None.instance();
+                    }
                 };
 
             // Function to create markers that report solver intervals.
-            final Function<String, Option<Marker>> createSolverMarker =
-                (prefix) -> {
+            final Supplier<Option<Marker>> createSolverMarker =
+                () -> {
                     final Map<Obs, Union<Interval>> c = v.getSchedule().getCache(Variant.CONSTRAINED_UNION_CACHE);
                     final Union<Interval>       valid = c.getOrDefault(a.getObs(), new Union<>());
                     final Union<Interval>     invalid = wholeNight.get();
@@ -125,21 +142,34 @@ public class LimitsListener extends MarkerModelListener<Variant> {
                     if (is.isEmpty() || invalid.isEmpty()) {
                         return None.instance();
                     } else {
-                        final List<String> attrs = new ArrayList<>();
-                        if (contributes.test(Variant.VISIBLE_UNION_CACHE)) { attrs.add("airmass"); }
-                        if (contributes.test(Variant.DARK_UNION_CACHE))    { attrs.add("background"); }
-                        if (contributes.test(Variant.TIMING_UNION_CACHE))  { attrs.add("timing window"); }
 
-                        final String s = attrs.isEmpty() ?
-                            "" : DefaultImList.create(attrs).mkString(" (", ", ", ")");
+                        final ImList<Long> timestamps =
+                            DefaultImList.create(valid.getIntervals()).flatMap(
+                                i -> DefaultImList.create(i.getStart(), i.getEnd())
+                            );
 
-                        return new Some<>(new Marker(false, this, Severity.Notice, prefix + s, new Some<>(valid), v, a));
+                        final String m = is.map(i -> {
+                           final String start = explainLimit.apply(Interval::getStart, i).getOrElse("%t(sunset)");
+                           final String end   = explainLimit.apply(Interval::getEnd, i).getOrElse("%t(sunrise)");
+                           return start + '-' + end;
+                        }).mkString("Must be observed between ", ", ", ".");
+
+                    return new Some<>(
+                        new Marker(
+                            false,
+                            this,
+                            Severity.Notice,
+                            m,
+                            timestamps,
+                            v,
+                            a
+                        )
+                    );
                     }
-                };
+            };
 
             // Report intersection of constraints.
-            createSolverMarker.apply("Must be observed between").foreach(m -> mm.addMarker(m));
-
+            createSolverMarker.get().foreach(m -> mm.addMarker(m));
 
             // Elevation Constraint
             final Double maxAirmass = a.getMax(Circumstance.AIRMASS, false);

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -15,6 +15,7 @@ import edu.gemini.qpt.core.Marker.Severity;
 import edu.gemini.qpt.core.Variant.Flag;
 import edu.gemini.qpt.core.util.*;
 import edu.gemini.qpt.shared.sp.Group;
+import edu.gemini.qpt.core.util.AirmassLimit;
 import edu.gemini.qpt.core.util.LttsServicesClient;
 import edu.gemini.qpt.core.util.MarkerManager;
 import edu.gemini.qpt.shared.sp.Obs;
@@ -165,10 +166,10 @@ public class LimitsListener extends MarkerModelListener<Variant> {
 
                 } else {
 
-                    // Legacy behavior; airmass 2.0 limit
-                    if (maxAirmass > 2.0) {
+                    // Legacy behavior; airmass limit
+                    if (maxAirmass > AirmassLimit.ERROR.airmass) {
                         mm.addMarker(false, this, Severity.Error, String.format("Observation reaches airmass %1.2f.", maxAirmass), v, a);
-                    } else if (maxAirmass > 1.75) {
+                    } else if (maxAirmass > AirmassLimit.WARNING.airmass) {
                         mm.addMarker(false, this, Severity.Warning, String.format("Observation reaches airmass %1.2f.", maxAirmass), v, a);
                     }
                 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/AirmassLimit.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/AirmassLimit.java
@@ -1,0 +1,24 @@
+package edu.gemini.qpt.core.util;
+
+import edu.gemini.spModel.core.Angle;
+import edu.gemini.spModel.core.Angle$;
+
+/**
+ * Airmass limits used throughout the QPT.
+ */
+public enum AirmassLimit {
+    WARNING(2.0, 30.000),
+    ERROR  (2.3, 25.625),
+    ;
+
+    /** Airmass limit above which the warning or error is triggered. */
+    public final double airmass;
+
+    /** Corresponding elevation angle. */
+    public final Angle elevation;
+
+    private AirmassLimit(double airmass, double elevationDeg) {
+        this.airmass   = airmass;
+        this.elevation = Angle$.MODULE$.fromDegrees(elevationDeg);
+    }
+}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/ElevationConstraintSolver.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/ElevationConstraintSolver.java
@@ -13,11 +13,11 @@ public abstract class ElevationConstraintSolver extends Solver {
 
     @SuppressWarnings("unused")
     private static final Logger LOGGER = Logger.getLogger(ElevationConstraintSolver.class.getName());
-    
+
     protected final ImprovedSkyCalc calc;
     protected final Function<Long, WorldCoords> coords;
     protected final double min, max;
-    
+
     protected ElevationConstraintSolver(Site site, Function<Long, WorldCoords> coords, double min, double max) {
         super(TimeUtils.MS_PER_HOUR / 4, TimeUtils.MS_PER_MINUTE);
         this.coords = coords;
@@ -30,12 +30,12 @@ public abstract class ElevationConstraintSolver extends Solver {
         switch (obs.getElevationConstraintType()) {
         case AIRMASS:    return new AirmassSolver(site, obs);
         case HOUR_ANGLE: return new HourAngleSolver(site, obs);
-        case NONE:       return new AirmassSolver(site, obs, 1.0, 2.0);
+        case NONE:       return new AirmassSolver(site, obs, 1.0, AirmassLimit.ERROR.airmass);
         default:
             throw new Error("Unknown ElevationConstraintType: " + obs.getElevationConstraintType());
-        }        
+        }
     }
-    
+
     static class AirmassSolver extends ElevationConstraintSolver {
 
         protected AirmassSolver(Site site, Obs obs) {
@@ -56,7 +56,7 @@ public abstract class ElevationConstraintSolver extends Solver {
     }
 
     static class HourAngleSolver extends ElevationConstraintSolver {
-        
+
         protected HourAngleSolver(Site site, Obs obs) {
             super(site, obs::getCoords, obs.getElevationConstraintMin(), obs.getElevationConstraintMax());
         }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/Twilight.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/Twilight.java
@@ -5,7 +5,9 @@ import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.skycalc.TwilightBoundType;
 
 /**
- * Twilight night bound calculations used throughout the QPT.
+ * Twilight night bound calculations used for block limits. Note, we display
+ * nautical twilight bounds in the visualizer and property sheet, but the
+ * twilight calculations are based on civil twilight.
  */
 public final class Twilight {
     private Twilight() {}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/Twilight.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/Twilight.java
@@ -1,0 +1,38 @@
+package edu.gemini.qpt.core.util;
+
+import edu.gemini.spModel.core.Site;
+import edu.gemini.skycalc.TwilightBoundedNight;
+import edu.gemini.skycalc.TwilightBoundType;
+
+/**
+ * Twilight night bound calculations used throughout the QPT.
+ */
+public final class Twilight {
+    private Twilight() {}
+
+    /** Definition of twilight in use for the QPT. */
+    public static final TwilightBoundType TYPE = TwilightBoundType.CIVIL;
+
+    /**
+     * Computes the twilight bounds for the night starting on the date of the
+     * given time.  For example, at midnight October 8 that would be the night
+     * October 8/9, whereas for 11:59:59 October 7 it would be the night of
+     * October 7/8.
+     */
+    public static TwilightBoundedNight startingOnDate(long time, Site site) {
+        return new TwilightBoundedNight(TYPE, time, site);
+    }
+
+    /**
+     * Computes the twilight bounds corresponding to the given time.  If the
+     * time falls within twilight bounds, the same night is returned.  On the
+     * other hand if the time falls during daytime, it returns the coming night.
+     *
+     * For example, at midnight October 8, this will return the night of
+     * October 7/8 (the same for 11:59:59 October 7).
+     */
+    public static TwilightBoundedNight forTime(long time, Site site) {
+        return TwilightBoundedNight.forTime(TYPE, time, site);
+    }
+
+}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/MergeAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/MergeAction.java
@@ -10,7 +10,7 @@ import javax.swing.JOptionPane;
 import edu.gemini.ags.api.AgsMagnitude;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.Variant;
-import edu.gemini.skycalc.TwilightBoundType;
+import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.ui.workspace.IShell;
 import edu.gemini.util.security.auth.keychain.KeyChain;
@@ -69,8 +69,8 @@ public class MergeAction extends AbstractOpenAction implements PropertyChangeLis
                 }
 
                 // Can't merge plans from different nights (yet)
-                TwilightBoundedNight prevNight = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, current.getStart(), current.getSite());
-                TwilightBoundedNight nextNight = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, other.getStart(), other.getSite());
+                final TwilightBoundedNight prevNight = Twilight.startingOnDate(current.getStart(), current.getSite());
+                final TwilightBoundedNight nextNight = Twilight.startingOnDate(other.getStart(), other.getSite());
                 if (prevNight.getStartTime() != nextNight.getStartTime()) {
                     JOptionPane.showMessageDialog(shell.getPeer(), ERR_NIGHT, "Cannot Merge", JOptionPane.ERROR_MESSAGE);
                     return;

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/OpenFromWebAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/OpenFromWebAction.java
@@ -34,6 +34,7 @@ import edu.gemini.ags.api.AgsMagnitude;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.ScheduleIO;
 import edu.gemini.qpt.core.util.LttsServicesClient;
+import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.qpt.ui.util.AbstractAsyncAction;
 import edu.gemini.qpt.ui.util.CalendarPanel;
 import edu.gemini.qpt.ui.util.ConfigErrorDialog;
@@ -273,7 +274,7 @@ class OpenFromWebDialog extends JDialog {
     public URL getURL() {
 
         // Get the night for the selected day
-        TwilightBoundedNight night = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, calendarPanel.getStartDate(), site);
+        final TwilightBoundedNight night = Twilight.startingOnDate(calendarPanel.getStartDate(), site);
 
         // Get yy mmm dd
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/RiseTransitSet.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/RiseTransitSet.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import edu.gemini.spModel.core.Site;
 import jsky.coords.WorldCoords;
+import edu.gemini.qpt.core.util.AirmassLimit;
 import edu.gemini.qpt.core.util.ImprovedSkyCalc;
 import edu.gemini.qpt.core.util.Interval;
 import edu.gemini.qpt.core.util.Solver;
@@ -12,10 +13,10 @@ import edu.gemini.qpt.shared.util.TimeUtils;
 
 /**
  * Value type that calculates the rise, transit, and set times for a given object, given a reference
- * time. If the object is above airmass 2.0 at the reference time, the current transit is calculated. 
- * Otherwise the next one will be calculated. If the target doesn't rise/set with respect to the
- * airmass 2 boundary within +/- 24 hrs of the reference time, rise and set will be null. If it 
- * doesn't rise/set with respect to the horizon, transit will be null. 
+ * time. If the object is above the airmass error limit at the reference time, the current transit
+ * is calculated. Otherwise the next one will be calculated. If the target doesn't rise/set with
+ * respect to the airmass boundary within +/- 24 hrs of the reference time, rise and set will be null.
+ * If it doesn't rise/set with respect to the horizon, transit will be null.
  * @author rnorris
  */
 public class RiseTransitSet {
@@ -23,17 +24,17 @@ public class RiseTransitSet {
     private final ImprovedSkyCalc calc;
     private final Function<Long, WorldCoords> coords;
     private final Long rise, transit, set;
-    
+
     private static final long MARGIN = TimeUtils.MS_PER_MINUTE / 4; // 15 sec
-    
+
     public RiseTransitSet(Site site, Function<Long, WorldCoords> coords, long start) {
         this.coords = coords;
         this.calc = new ImprovedSkyCalc(site);
-        
+
         Solver solver = new Solver(TimeUtils.MS_PER_HOUR, MARGIN) {
             @Override
             protected boolean f(long t) {
-                return airmass(t) < 2.0;
+                return airmass(t) < AirmassLimit.ERROR.airmass;
             }
         };
 
@@ -45,10 +46,10 @@ public class RiseTransitSet {
             rise = domain.getStart();
             set = domain.getEnd();
             transit = (rise + set) / 2;
-            
+
         } else {
 
-            // [QPT-184] Target never gets above 2.0, so rise and set are undefined.            
+            // [QPT-184] Target never gets above airmass error limit, so rise and set are undefined.
             rise = null;
             set = null;
 
@@ -64,15 +65,15 @@ public class RiseTransitSet {
 
             // If there is a solution we can define transit. Otheriwse it's null too.
             transit = (domain == null) ? null : ((domain.getStart() + domain.getEnd()) / 2);
-                                            
-        } 
-        
+
+        }
+
     }
-    
+
     private double airmass(long time) {
         calc.calculate(coords.apply(time), new Date(time), false);
         double ret = calc.getAirmass();
-        // WACK: skycalc returns 0 for targets below the horizon        
+        // WACK: skycalc returns 0 for targets below the horizon
         return (ret < 1.0) ? Double.MAX_VALUE : ret;
     }
 
@@ -87,5 +88,5 @@ public class RiseTransitSet {
     public Long getTransit() {
         return transit;
     }
-        
+
 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/ScheduleDocument.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/ScheduleDocument.java
@@ -34,7 +34,6 @@ import edu.gemini.qpt.core.Alloc.Grouping;
 import edu.gemini.qpt.core.Marker.Severity;
 import edu.gemini.qpt.core.util.ImprovedSkyCalc;
 import edu.gemini.qpt.core.util.Interval;
-import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.qpt.shared.util.TimeUtils;
 import edu.gemini.qpt.ui.util.CancelledException;
 import edu.gemini.qpt.ui.util.ColorWheel;
@@ -327,15 +326,14 @@ public class ScheduleDocument {
         ret.add(new SimpleEvent(allocs.last().getEnd(), "End of plan variant."));
 
         // Add twilight info.
-        final TwilightBoundedNight twilight = Twilight.startingOnDate(schedule.getStart(), schedule.getSite());
+        final TwilightBoundedNight nautical = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, schedule.getStart(), schedule.getSite());
         final TimeZone timezone = utc ? TimeZone.getTimeZone("UTC") : schedule.getSite().timezone();
-        final int hAngle = (int) Twilight.TYPE.getHorizonAngle();
-        ret.add(new SimpleEvent(twilight.getStartTimeRounded(timezone), String.format("Evening %d&deg; Twilight", hAngle)));
-        ret.add(new SimpleEvent(twilight.getEndTimeRounded(timezone), String.format("Morning %d&deg; Twilight", hAngle)));
+        ret.add(new SimpleEvent(nautical.getStartTimeRounded(timezone), "Evening 12&deg; Twilight"));
+        ret.add(new SimpleEvent(nautical.getEndTimeRounded(timezone),   "Morning 12&deg; Twilight"));
 
         // Find illuminated fraction
         Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(twilight.getEndTime());
+        cal.setTimeInMillis(nautical.getEndTime());
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/VariantAdapter.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/VariantAdapter.java
@@ -1,6 +1,8 @@
 package edu.gemini.qpt.ui.view.property.adapter;
 
+import edu.gemini.spModel.core.Site;
 import edu.gemini.qpt.core.Variant;
+import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.qpt.ui.view.property.PropertyTable;
 import edu.gemini.qpt.ui.view.property.PropertyTable.Adapter;
 import edu.gemini.skycalc.TwilightBoundType;
@@ -15,30 +17,24 @@ public class VariantAdapter implements Adapter<Variant> {
 
     public void setProperties(Variant variant, Variant target, PropertyTable table) {
 
-        final TimeZone zone = target.getSchedule().getSite().timezone();
+        final long    start = target.getSchedule().getStart();
+        final Site     site = target.getSchedule().getSite();
+        final TimeZone zone = site.timezone();
 
         DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm")
                 .withZone(zone.toZoneId());
 
-        TwilightBoundedNight night = new TwilightBoundedNight(
-                TwilightBoundType.OFFICIAL,
-                target.getSchedule().getStart(),
-                target.getSchedule().getSite()
-        );
+        final TwilightBoundedNight night    = new TwilightBoundedNight(TwilightBoundType.OFFICIAL, start, site);
+        final TwilightBoundedNight twilight = Twilight.startingOnDate(start, site);
 
-        TwilightBoundedNight nautical = new TwilightBoundedNight(
-                TwilightBoundType.NAUTICAL,
-                target.getSchedule().getStart(),
-                target.getSchedule().getSite()
-        );
-
-        table.put(PROP_TYPE, "Plan Variant");
-        table.put(PROP_TITLE, target.getName());
-        table.put(PROP_SUNSET, dateFormat.format(Instant.ofEpochMilli(night.getStartTimeRounded(zone))));
-        table.put(PROP_DUSK, dateFormat.format(Instant.ofEpochMilli(nautical.getStartTimeRounded(zone))));
-        table.put(PROP_DAWN, dateFormat.format(Instant.ofEpochMilli(nautical.getEndTimeRounded(zone))));
-        table.put(PROP_SUNRISE, dateFormat.format(Instant.ofEpochMilli(night.getEndTimeRounded(zone))));
+        table.put(PROP_TYPE,        "Plan Variant");
+        table.put(PROP_TITLE,       target.getName());
+        table.put(PROP_SUNSET,      dateFormat.format(Instant.ofEpochMilli(night.getStartTimeRounded(zone))));
+        table.put(PROP_DUSK,        dateFormat.format(Instant.ofEpochMilli(twilight.getStartTimeRounded(zone))));
+        table.put(PROP_DAWN,        dateFormat.format(Instant.ofEpochMilli(twilight.getEndTimeRounded(zone))));
+        table.put(PROP_SUNRISE,     dateFormat.format(Instant.ofEpochMilli(night.getEndTimeRounded(zone))));
         table.put(PROP_CONSTRAINTS, target.getConditions());
+
         if (target.getWindConstraint() != null)
             table.put(PROP_WIND, target.getWindConstraint());
         else

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/VariantAdapter.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/property/adapter/VariantAdapter.java
@@ -2,7 +2,6 @@ package edu.gemini.qpt.ui.view.property.adapter;
 
 import edu.gemini.spModel.core.Site;
 import edu.gemini.qpt.core.Variant;
-import edu.gemini.qpt.core.util.Twilight;
 import edu.gemini.qpt.ui.view.property.PropertyTable;
 import edu.gemini.qpt.ui.view.property.PropertyTable.Adapter;
 import edu.gemini.skycalc.TwilightBoundType;
@@ -24,15 +23,15 @@ public class VariantAdapter implements Adapter<Variant> {
         DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm")
                 .withZone(zone.toZoneId());
 
-        final TwilightBoundedNight night    = new TwilightBoundedNight(TwilightBoundType.OFFICIAL, start, site);
-        final TwilightBoundedNight twilight = Twilight.startingOnDate(start, site);
+        final TwilightBoundedNight official = new TwilightBoundedNight(TwilightBoundType.OFFICIAL, start, site);
+        final TwilightBoundedNight nautical = new TwilightBoundedNight(TwilightBoundType.NAUTICAL, start, site);
 
         table.put(PROP_TYPE,        "Plan Variant");
         table.put(PROP_TITLE,       target.getName());
-        table.put(PROP_SUNSET,      dateFormat.format(Instant.ofEpochMilli(night.getStartTimeRounded(zone))));
-        table.put(PROP_DUSK,        dateFormat.format(Instant.ofEpochMilli(twilight.getStartTimeRounded(zone))));
-        table.put(PROP_DAWN,        dateFormat.format(Instant.ofEpochMilli(twilight.getEndTimeRounded(zone))));
-        table.put(PROP_SUNRISE,     dateFormat.format(Instant.ofEpochMilli(night.getEndTimeRounded(zone))));
+        table.put(PROP_SUNSET,      dateFormat.format(Instant.ofEpochMilli(official.getStartTimeRounded(zone))));
+        table.put(PROP_DUSK,        dateFormat.format(Instant.ofEpochMilli(nautical.getStartTimeRounded(zone))));
+        table.put(PROP_DAWN,        dateFormat.format(Instant.ofEpochMilli(nautical.getEndTimeRounded(zone))));
+        table.put(PROP_SUNRISE,     dateFormat.format(Instant.ofEpochMilli(official.getEndTimeRounded(zone))));
         table.put(PROP_CONSTRAINTS, target.getConditions());
 
         if (target.getWindConstraint() != null)

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/Visualizer.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/Visualizer.java
@@ -165,9 +165,9 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
             g2d.setRenderingHints(RENDERING_HINTS);
 
             // Background stuff: night, blocks, sun, moon, elevation lines
-            paintNight(g2d);
-            for (Block b: blocks) paintBlock(g2d, b);
-             paintSun(g2d);
+            paintOfficialNight(g2d);
+            paintNauticalNight(g2d);
+            paintSun(g2d);
             paintMoon(g2d);
             paintElevationLines(g2d);
 
@@ -432,9 +432,9 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
 
             }
 
-            // Draw a special airmass line at the error limit.
+            // Draw a special airmass line at the warning limit.
             {
-                final Shape line = elevationLine(AirmassLimit.ERROR.elevation.toDegrees());
+                final Shape line = elevationLine(AirmassLimit.WARNING.elevation.toDegrees());
                 g2d.setStroke(SOLID_STROKE_LIGHT);
                 g2d.draw(line);
             }
@@ -461,9 +461,9 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
 
             }
 
-            // Draw a special airmass line at the error limit.
+            // Draw a special airmass line at the warning limit.
             {
-                final Shape line = elevationLine(AirmassLimit.ERROR.elevation.toDegrees());
+                final Shape line = elevationLine(AirmassLimit.WARNING.elevation.toDegrees());
                 g2d.setStroke(SOLID_STROKE_LIGHT);
                 g2d.draw(line);
             }
@@ -524,35 +524,28 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
         g2da.restore();
     }
 
-    private void paintNight(Graphics2D g2d) {
+    private void paintNight(Graphics2D g2d, TwilightBoundType boundType, Color color) {
+        final Site site = model.getSchedule().getSite();
 
-        Site site = model.getSchedule().getSite();
+        final TwilightBoundedNight night = new TwilightBoundedNight(boundType, model.getSchedule().getStart(), site);
 
-        TwilightBoundedNight night = new TwilightBoundedNight(TwilightBoundType.OFFICIAL, model.getSchedule().getStart(), site);
-
-        Graphics2DAttributes g2da = new Graphics2DAttributes(g2d);
+        final Graphics2DAttributes g2da = new Graphics2DAttributes(g2d);
 
         // Night is just a colored rectangle.
-        Rectangle2D.Double rect = new Rectangle2D.Double(night.getStartTime(), 0, night.getTotalTime(), getSize().getHeight());
-        Shape rect2 = time2X.createTransformedShape(rect);
-        g2d.setColor(NIGHT_COLOR);
+        final Rectangle2D.Double rect = new Rectangle2D.Double(night.getStartTime(), 0, night.getTotalTime(), getSize().getHeight());
+        final Shape rect2 = time2X.createTransformedShape(rect);
+        g2d.setColor(color);
         g2d.fill(rect2);
 
         g2da.restore();
-
-
     }
 
-    private void paintBlock(Graphics2D g2d, Block b) {
-        Graphics2DAttributes g2da = new Graphics2DAttributes(g2d);
+    private void paintOfficialNight(Graphics2D g2d) {
+        paintNight(g2d, TwilightBoundType.OFFICIAL, NIGHT_COLOR);
+    }
 
-        // Blocks are just colored rectangles.
-        Rectangle2D.Double rect = new Rectangle2D.Double(b.getStart(), 0, b.getLength(), getSize().getHeight());
-        Shape rect2 = time2X.createTransformedShape(rect);
-        g2d.setColor(BLOCK_COLOR);
-        g2d.fill(rect2);
-
-        g2da.restore();
+    private void paintNauticalNight(Graphics2D g2d) {
+        paintNight(g2d, TwilightBoundType.NAUTICAL, BLOCK_COLOR);
     }
 
     private void paintShutteringWindows(Graphics2D g2d, Alloc a, boolean selected) {

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/Visualizer.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visualizer/Visualizer.java
@@ -5,6 +5,7 @@ import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Shape;
+import java.awt.Stroke;
 import java.awt.TexturePaint;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -40,6 +41,7 @@ import edu.gemini.qpt.shared.sp.Obs;
 import edu.gemini.qpt.core.util.ImprovedSkyCalc;
 import edu.gemini.qpt.core.util.Interval;
 import edu.gemini.qpt.shared.util.TimeUtils;
+import edu.gemini.qpt.core.util.AirmassLimit;
 import edu.gemini.qpt.core.util.TimingWindowSolver;
 import edu.gemini.qpt.ui.util.BooleanViewPreference;
 import edu.gemini.qpt.ui.util.ColorWheel;
@@ -395,6 +397,11 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
         }
     }
 
+    private Shape elevationLine(double elevation) {
+        return alt2Y.createTransformedShape(
+            new Line2D.Double(0, elevation, getSize().getWidth(), elevation)
+        );
+    }
 
     private void paintElevationLines(Graphics2D g2d) {
         Graphics2DAttributes g2da = new Graphics2DAttributes(g2d);
@@ -403,14 +410,12 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
         switch (ElevationPreference.BOX.get()) {
         case AIRMASS:
 
-            // Draw airmass lines every so often from 0 - 90 deg. The one at 30 is special
-            // because it represents airmass 2.0 (more or less), so we use a different style.
+            // Draw airmass lines every so often from 0 - 90 deg.
             for (int elevation = 10 * ((int) MIN_DEG / 10); elevation < MAX_DEG; elevation += 10) {
 
                 // Create and draw the line.
-                Shape line = new Line2D.Double(0, elevation, getSize().getWidth(), elevation);
-                line = alt2Y.createTransformedShape(line);
-                g2d.setStroke(elevation == 30 ? SOLID_STROKE_LIGHT : DOTTED_STROKE_LIGHT);
+                final Shape line = elevationLine(elevation);
+                g2d.setStroke(DOTTED_STROKE_LIGHT);
                 g2d.draw(line);
 
                 // And the label, off to the left. Don't need one at zero.
@@ -426,19 +431,25 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
                 }
 
             }
+
+            // Draw a special airmass line at the error limit.
+            {
+                final Shape line = elevationLine(AirmassLimit.ERROR.elevation.toDegrees());
+                g2d.setStroke(SOLID_STROKE_LIGHT);
+                g2d.draw(line);
+            }
+
             break;
 
 
         case ELEVATION:
 
-            // Draw elevation lines every so often from 0 - 90 deg. The one at 30 is special
-            // because it represents airmass 2.0 (more or less), so we use a different style.
+            // Draw elevation lines every so often from 0 - 90 deg.
             for (int elevation = 10 * ((int) MIN_DEG / 10); elevation < MAX_DEG; elevation += 10) {
 
                 // Create and draw the line.
-                Shape line = new Line2D.Double(0, elevation, getSize().getWidth(), elevation);
-                line = alt2Y.createTransformedShape(line);
-                g2d.setStroke(elevation == 30 ? SOLID_STROKE_LIGHT : DOTTED_STROKE_LIGHT);
+                final Shape line = elevationLine(elevation);
+                g2d.setStroke(DOTTED_STROKE_LIGHT);
                 g2d.draw(line);
 
                 // And the label, off to the left. Don't need one at zero.
@@ -449,6 +460,14 @@ public final class Visualizer extends VisualizerBase implements VisualizerConsta
                 }
 
             }
+
+            // Draw a special airmass line at the error limit.
+            {
+                final Shape line = elevationLine(AirmassLimit.ERROR.elevation.toDegrees());
+                g2d.setStroke(SOLID_STROKE_LIGHT);
+                g2d.draw(line);
+            }
+
             break;
 
         }


### PR DESCRIPTION
This PR brings the latest spate of QPT changes to address the final REL-1714 request over to the release branch.

> The QCs decided to change the default airmass constraints to give a warning if airmass > 2.0 and give an error if airmass > 2.3.  It was also agreed that BG-Any observations may be scheduled between civil (6-deg) twilights.  It was requested to add a letters to the time ranges to indicate the origin of the constraints: (T)iming window, (A)irmass, (B)ackground, and (H)our angle.  For example: "Notice: Must be observed between: 19:55(A) - 22:18(T)."