### PR TITLE
REL-3465: Modify GNIRS exposure time at which read mode is set to "Very Bright"

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -962,7 +962,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     }
 
     public static ReadMode selectReadMode(double exposure) {
-        if (exposure <= 1.0) {
+        if (exposure < 0.6) {
             return ReadMode.VERY_BRIGHT;
         } else if (exposure <= 20.0) {
             return ReadMode.BRIGHT;


### PR DESCRIPTION
This is a straight-forward change of the exposure time at which the OT will automatically select "Very Bright" (high-noise) read mode.

The ITC tests all (surprisingly) pass.