### PR TITLE
REL-3290: Implemented empty observation in PIT.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -94,6 +94,7 @@ class Observation private (val blueprint:Option[BlueprintBase],
   }
 
   def isEmpty = blueprint.isEmpty && condition.isEmpty && target.isEmpty && calculatedTimes.isEmpty
+  def nonEmpty = !isEmpty
 
   override def equals(a:Any) = a match {
     case o:Observation => kernel == o.kernel

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_disabled_observations.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_disabled_observations.xml
@@ -21,9 +21,18 @@
     </investigators>
     <targets/>
     <conditions/>
-    <blueprints/>
+    <blueprints>
+        <visitor>
+            <visitor id="blueprint-0">
+                <name>Visitor - Gemini South - Visitor Instrument</name>
+                <visitor>true</visitor>
+                <site>Gemini South</site>
+                <custom-name>Visitor Instrument</custom-name>
+            </visitor>
+        </visitor>
+    </blueprints>
     <observations>
-        <observation enabled="false" band="Band 1/2"/>
+        <observation blueprint="blueprint-0" enabled="false" band="Band 1/2"/>
     </observations>
     <proposalClass>
         <queue tooOption="None"/>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ObservationSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ObservationSpec.scala
@@ -10,8 +10,7 @@ import org.specs2.scalaz.ValidationMatchers._
 class ObservationSpec extends Specification with SemesterProperties with XmlMatchers {
   "The Observation class" should {
     "support the enable attribute and set it to true by default, REL-658" in {
-      val observationEnabled = Observation(None, None, None, Band.BAND_1_2, None)
-      val proposal = Proposal.empty.copy(observations = observationEnabled :: Nil)
+      val proposal = Proposal.empty.copy(observations = ObservationSpec.observation :: Nil)
 
       val xml = XML.loadString(ProposalIo.writeToString(proposal))
 
@@ -19,14 +18,12 @@ class ObservationSpec extends Specification with SemesterProperties with XmlMatc
       xml must \\("observation", "enabled" -> "true")
     }
     "support the enable attribute as false, REL-658" in {
-      val observationEnabled = Observation(None, None, None, Band.BAND_1_2, None)
-      val proposal = Proposal.empty.copy(observations = observationEnabled.copy(enabled = false) :: Nil)
+      val proposal = Proposal.empty.copy(observations = ObservationSpec.observation.copy(enabled = false) :: Nil)
 
       val xml = XML.loadString(ProposalIo.writeToString(proposal))
 
       // verify the exported value
       xml must \\("observation", "enabled" -> "false")
-      true must beTrue
     }
     "preserve the enable attribute as false, REL-658" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_disabled_observations.xml")))
@@ -37,4 +34,9 @@ class ObservationSpec extends Specification with SemesterProperties with XmlMatc
       xml must \\("observation", "enabled" -> "false")
     }
   }
+}
+
+object ObservationSpec {
+  // A non-empty observation. Empty observations are ignored, and not submittable to ITAC.
+  val observation = Observation(Some(VisitorBlueprint(Site.GS, "Visitor Instrument")), None, None, Band.BAND_1_2, None)
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -6,9 +6,8 @@ import edu.gemini.model.p1.immutable._
 import edu.gemini.pit.ui.editor.Institutions
 import edu.gemini.pit.util.PDF
 import edu.gemini.pit.catalog._
-
 import edu.gemini.spModel.core.MagnitudeBand
-import view.obs.ObsListGrouping
+import view.obs.{ObsListGrouping, ObsListView}
 import edu.gemini.model.p1.visibility.TargetVisibilityCalc
 import edu.gemini.pit.ui.view.tac.TacView
 import java.time.{Instant, ZoneId}
@@ -19,7 +18,7 @@ import edu.gemini.pit.model.{AppPreferences, Model}
 import edu.gemini.pit.catalog.NotFound
 import edu.gemini.pit.catalog.Error
 
-import scalaz.{ Band => _, _ }
+import scalaz.{Band => _, _}
 import Scalaz._
 
 object ProblemRobot {
@@ -413,21 +412,17 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     }
 
     private lazy val missingObsElementCheck = {
-      def fix[A](b: Band, g: ObsListGrouping[A]) {
-        s.inObsListView(b, _.Fixes.fixEmpty(g))
-      }
-
-      def check[A](s: String, g: ObsListGrouping[A]) =
-        p.observations.filter(g.lens.get(_).isEmpty) match {
+      def check[A](msg: String, g: ObsListGrouping[A], adder: ObsListView => Unit) =
+        p.observations.filter(o => g.lens.get(o).isEmpty) match {
           case Nil => None
-          case h :: Nil => Some(new Problem(Severity.Error, s"One observation has no $s.", "Observations", fix(h.band, g)))
-          case h :: tail => Some(new Problem(Severity.Error, s"${1 + tail.length} observations have no $s.", "Observations", fix(h.band, g)))
+          case o :: Nil => Some(new Problem(Severity.Error, s"One observation has no $msg.", "Observations", s.inObsListView(o.band, adder)))
+          case o :: tail => Some(new Problem(Severity.Error, s"${1 + tail.length} observations have no $msg.", "Observations", s.inObsListView(o.band, adder)))
         }
 
       List(
-        check("instrument configuration", ObsListGrouping.Blueprint),
-        check("target", ObsListGrouping.Target),
-        check("observing conditions", ObsListGrouping.Condition)).flatten
+        check("instrument configuration", ObsListGrouping.Blueprint, _.Fixes.addBlueprint()),
+        check("target", ObsListGrouping.Target, _.Fixes.addTarget()),
+        check("observing conditions", ObsListGrouping.Condition, _.Fixes.addConditions())).flatten
     }
 
     private def indicateObservation(o: Observation) {
@@ -435,7 +430,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     }
 
     private lazy val missingObsDetailsCheck =
-      p.observations.filter(_.calculatedTimes.isEmpty) match {
+      p.observations.filter(o => o.nonEmpty && o.calculatedTimes.isEmpty) match {
         case Nil => None
         case h :: Nil => Some(new Problem(Severity.Error, "One observation has no observation time.", "Observations", indicateObservation(h)))
         case h :: tail => Some(new Problem(Severity.Error, s"${1 + tail.length} observations have no observation times.", "Observations", indicateObservation(h)))
@@ -583,7 +578,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       })
     }
 
-    private lazy val noObs = when (p.observations.isEmpty) {
+    private lazy val noObs = when (!p.hasNonEmptyObservations) {
       new Problem(Severity.Todo, "Please create observations with conditions, targets, and resources.", "Observations", ())
     }
 


### PR DESCRIPTION
This redoes some work that was originally intended to be in the 2018B PIT, but that we felt hadn't had adequate testing to ensure it was working exactly as expected.

The idea here is that normally, when the PIT is launched, the Observations section contains no entries.

Science requested in REL-3290 that this be changed, and the Observations section begin with an "empty observation" to serve as a guide for users so that they better understood how to create the necessary data.

Here is a before picture:
![pit_original](https://user-images.githubusercontent.com/8795653/43471743-ba4e3b60-94b9-11e8-9148-9a54b89169fd.png)

Here is an after picture. As you can see, there is now an empty observation:
![screen shot 2018-07-31 at 11 58 55 am](https://user-images.githubusercontent.com/8795653/43471757-c7c49a14-94b9-11e8-9146-056518f9ed36.png)
