### PR TITLE
REL-3453: Made Altair LGS unavailable for 2019A

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/AltairNode.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/AltairNode.scala
@@ -2,18 +2,16 @@ package edu.gemini.model.p1.dtree.inst
 
 import edu.gemini.model.p1.immutable._
 
-/**
- *
- */
-
 trait AltairNode {
   val allGuideStarTypes: Boolean
   val title       = "Adaptive Optics"
   val description = "Please select an adaptive optics option."
 
-  def choices     = if (allGuideStarTypes) {
-      List(AltairNone, AltairLGS(pwfs1 = false, aowfs = true), AltairLGS(pwfs1 = true), AltairLGS(pwfs1 = false, oiwfs = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
-    } else {
-      List(AltairNone, AltairLGS(pwfs1 = false), AltairLGS(pwfs1 = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
-    }
+  // REL-3453: Altair LGS not available for 2019A.
+//  def choices     = if (allGuideStarTypes) {
+//      List(AltairNone, AltairLGS(pwfs1 = false, aowfs = true), AltairLGS(pwfs1 = true), AltairLGS(pwfs1 = false, oiwfs = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
+//    } else {
+//      List(AltairNone, AltairLGS(pwfs1 = false), AltairLGS(pwfs1 = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
+//    }
+  def choices = List(AltairNone, AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -145,7 +145,12 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
  * This converter will upgrade to 2019A.
  */
 case object SemesterConverter2018BTo2019A extends SemesterConverter {
-  override val transformers = Nil
+  // REL-3453: Altair LGS not available for 2019A.
+  val altairLgsNotAvailable: TransformFunction = {
+    case a @ <altair>{ns@_*}</altair> if (a \\ "lgs").nonEmpty =>
+      StepResult(s"Altair Laser Guidestar is currently not offered", a).successNel
+  }
+  override val transformers = List(altairLgsNotAvailable)
 }
 
 /**
@@ -154,21 +159,21 @@ case object SemesterConverter2018BTo2019A extends SemesterConverter {
 case object SemesterConverter2018ATo2018B extends SemesterConverter {
   // REL-3363: No GMOS-N + Altair offered for 2018B. Remove Altair from component.
   // The name of the instrument is auto-generated from its properties, so we don't worry about the <name>...</name> tag.
-  private lazy val gmosnAltairLGSRE  = " Altair Laser Guidestar( w/ (PWFS1|OIWFS))?"
-  private lazy val gmosnAltairNGSRE  = " Altair Natural Guidestar( w/ Field Lens)?"
-  lazy val gmosnAltairRemoverMessage = "GMOS-N does not offer Altair in 2018B. Altair component removed."
-  val gmosnAltairRemover: TransformFunction = {
-    case p @ <gmosN>{ns @ _*}</gmosN> if (p \\ "altair" \ "lgs").nonEmpty || (p \\ "altair" \\ "ngs").nonEmpty =>
-      object GmosNAltairRemover extends BasicTransformer {
-        override def transform(n: xml.Node): xml.NodeSeq = n match {
-          case <altair>{_ @ _*}</altair> => <altair><none/></altair>
-          case <name>{name}</name>       => <name>{name.text.replaceFirst(gmosnAltairLGSRE, "").replaceFirst(gmosnAltairNGSRE, "")}</name>
-          case elem: xml.Elem            => elem.copy(child = elem.child.flatMap(transform))
-          case _                         => n
-        }
-      }
-      StepResult(gmosnAltairRemoverMessage, <gmosN>{GmosNAltairRemover.transform(ns)}</gmosN>).successNel
-  }
+//  private lazy val gmosnAltairLGSRE  = " Altair Laser Guidestar( w/ (PWFS1|OIWFS))?"
+//  private lazy val gmosnAltairNGSRE  = " Altair Natural Guidestar( w/ Field Lens)?"
+//  lazy val gmosnAltairRemoverMessage = "GMOS-N does not offer Altair in 2018B. Altair component removed."
+//  val gmosnAltairRemover: TransformFunction = {
+//    case p @ <gmosN>{ns @ _*}</gmosN> if (p \\ "altair" \ "lgs").nonEmpty || (p \\ "altair" \\ "ngs").nonEmpty =>
+//      object GmosNAltairRemover extends BasicTransformer {
+//        override def transform(n: xml.Node): xml.NodeSeq = n match {
+//          case <altair>{_ @ _*}</altair> => <altair><none/></altair>
+//          case <name>{name}</name>       => <name>{name.text.replaceFirst(gmosnAltairLGSRE, "").replaceFirst(gmosnAltairNGSRE, "")}</name>
+//          case elem: xml.Elem            => elem.copy(child = elem.child.flatMap(transform))
+//          case _                         => n
+//        }
+//      }
+//      StepResult(gmosnAltairRemoverMessage, <gmosN>{GmosNAltairRemover.transform(ns)}</gmosN>).successNel
+//  }
 
   lazy val dssiGNToAlopekeMessage: String = "DSSI Gemini North proposal has been migrated to ʻAlopeke instead."
   val dssiGNToAlopeke: TransformFunction = {
@@ -206,7 +211,7 @@ case object SemesterConverter2018ATo2018B extends SemesterConverter {
 
   val (texesRemover, texesRemoverMessage) = removeBlueprint("texes", "Texes")
 
-  override val transformers = List(gmosnAltairRemover, dssiGNToAlopeke, phoenixSite, texesRemover)
+  override val transformers = List(dssiGNToAlopeke, phoenixSite, texesRemover)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -559,25 +559,13 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           (result \\ "gmosN") must \\("name") \>~ ".*1.0 arcsec slit.*"
       }
     }
-    "proposal with GmosN with Altair mode must have it set to AltairNone for 2018B, REL-3363" in {
-      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gmosn_altair_lgs.xml")))
-
-      val converted = UpConverter.convert(xml)
-      converted must beSuccessful.like {
-        case StepResult(changes, result) =>
-          changes must contain(SemesterConverter2018ATo2018B.gmosnAltairRemoverMessage)
-          (result \\ "gmosN" \\ "altair") must \\("none")
-          (result \\ "gmosN") must \\("name") \> "GMOS-N Imaging z (925 nm)"
-      }
-
-    }
     "proposal with Gnirs that doesn't have a central wavelength, REL-1254" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gnirs_no_centralwavelength.xml")))
 
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           changes must contain("GNIRS observation doesn't have a central wavelength range, assigning to '< 2.5um'")
           // Check that the centralWavelength node is added
           result must \\("centralWavelength") \> "< 2.5um"
@@ -755,7 +743,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 5
+          changes must have length 6
           result \\ "niri" must \\("filter") \> "HeI (1.083 um)"
           result \\ "niri" must not(\\("filter") \> "J-continuum (1.122 um)")
           result \\ "niri" must not(\\("filter") \> "Jcont (1.065 um)")

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -82,7 +82,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           TacProblems(p, s).all ++
           Semester2018BProblems(p, s).all ++
           List(incompleteInvestigator, missingObsElementCheck, emptyTargetCheck,
-            emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck,
+            emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck, altairLgsCheck,
             badGuiding, cwfsCorrectionsIssue, badVisibility, iffyVisibility, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsIQ70Check, lgsGemsIQ85Check,
             lgsCC50Check, texesCCCheck, texesWVCheck, gmosWVCheck, gmosR600Check, band3IQ, band3LGS, band3RapidToO, sbIrObservation).flatten
       ps.sorted
@@ -196,6 +196,12 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
         s"""Ephemeris for target "$n" is undefined between ${dateFormat.format(Instant.ofEpochMilli(firstDay))} and ${dateFormat.format(Instant.ofEpochMilli(p.semester.lastDay))} UTC."""
       }
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
+
+    // REL-3453: Altair LGS not available for 2019A.
+    private lazy val altairLgsCheck = for {
+      o <- p.observations
+      b <- o.blueprint if bpIsLgs(b) && !bpIsGemsLgs(b)
+    } yield new Problem(Severity.Error, "Altair Laser Guidestar is currently not offered.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
 
     def aoPerspectiveIsLgs(ao: AoPerspective): Boolean = ao match {
       case AoLgs => true


### PR DESCRIPTION
The laser at GN is not working and thus will not be available for 2019A proposals.

This PR:

1. Removes the LGS options from Altair;

2. Issues a warning if upconverting with an observation requiring Altair LGS; and

3. Produces an error (that disallows submission) if the proposal contains an observation with Altair LGS.

Here is a screenshot that shows the Altair node in the resource selection:
![screen shot 2018-07-31 at 3 48 54 pm](https://user-images.githubusercontent.com/8795653/43483495-d48b9a02-94d9-11e8-90c5-2b4a9fc3412f.png)
