### PR TITLE
REL-1714: Support for migrating pre-civil twilight schedules

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/ScheduleIO.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/ScheduleIO.java
@@ -40,7 +40,8 @@ public class ScheduleIO {
     static final int VERSION_104 = 104;   // 1.0.4
     static final int VERSION_1030 = 1030; // 1.0.30 (new infrastructure, Dec 2013)
     static final int VERSION_1031 = 1031; // 1.0.31 (additional facilities (enums) as part of QV, Jan 2014)
-    static final int VERSION_CURRENT = VERSION_1031;
+    static final int VERSION_1032 = 1032; // 18B.1.1.5 (switch to civil twilight)
+    static final int VERSION_CURRENT = VERSION_1032;
 
     public static void write(Schedule sched, File file) throws IOException {
         try {

--- a/bundle/edu.gemini.qpt.client/src/test/resources/edu/gemini/qpt/core/v1031-unexpected.qpt
+++ b/bundle/edu.gemini.qpt.client/src/test/resources/edu/gemini/qpt/core/v1031-unexpected.qpt
@@ -1,0 +1,2198 @@
+
+<paramset name="qpt-archive">
+  <param name="version" value="1031"/>
+  <param name="site" value="GS"/>
+  <param name="timestamp" value="1533224602574"/>
+  <param name="digest" value="d74b70997a70ae8f225db8c4d81147e"/>
+  <paramset name="schedule">
+    <paramset name="facilities">
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="PA_BETA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="PINHOLE_ARRAY"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="BLOCK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="NONE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H1S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="DIFFUSER1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_8"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosCommonType$UseNS"/>
+        <param name="name" value="TRUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H2_2_1_S_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H1L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="K_F32"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Disperser"/>
+        <param name="name" value="R3000"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Camera"/>
+        <param name="name" value="SHORT_BLUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="HK_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H4S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="CH4_LONG"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="CLEAR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.texes.TexesParams$Disperser"/>
+        <param name="name" value="D_75_LMM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw"/>
+        <param name="name" value="odgw1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="H2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="OD_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="Z"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H_CONTINUUM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K_CONTINUUM2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gems.Canopus$Wfs$3"/>
+        <param name="name" value="cwfs3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K_PRIME"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_10"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="H_F32"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="PINHOLE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="F1063"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K_SHORT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H2_1_0_S_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="K2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="BLOCKED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask$1"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Camera"/>
+        <param name="name" value="F14"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_8"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_IMAGING_W"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="PINHOLE_MASK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="Z"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="K1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_IMAGING"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="H2_plus_ND100X"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="K_RED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Disperser"/>
+        <param name="name" value="WOLLASTON"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="JH_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="K_LONG"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="PWFS"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_11"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="PAH"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Camera"/>
+        <param name="name" value="F6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw"/>
+        <param name="name" value="odgw2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Camera"/>
+        <param name="name" value="SHORT_RED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="Y"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="HEI"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW$1"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H1L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Camera"/>
+        <param name="name" value="LONG_BLUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="BLOCKED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="CANOPUS"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="PINHOLE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="KG5_ND_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="JH"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.texes.TexesParams$Disperser"/>
+        <param name="name" value="D_32_LMM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="BLOCKED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K_CONTINUUM1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="BLOCK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.texes.TexesParams$Disperser"/>
+        <param name="name" value="E_D_32_LMM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Camera"/>
+        <param name="name" value="LONG_RED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.texes.TexesParams$Disperser"/>
+        <param name="name" value="E_D_75_LMM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gems.Canopus$Wfs$2"/>
+        <param name="name" value="cwfs2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$CrossDispersed"/>
+        <param name="name" value="LXD"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="J_CONTINUUM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.target.obsComp.PwfsGuideProbe$1"/>
+        <param name="name" value="pwfs1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H1SP"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW$2"/>
+        <param name="name" value="BR_GAMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="K_BLUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="Y"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="H_plus_ND100X"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="SUBPIX_PINHOLE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.target.obsComp.PwfsGuideProbe$2"/>
+        <param name="name" value="pwfs2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="LOW_RES_20"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="H_K_DICHROIC"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H4L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="K_CONT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="OCCULTING_BAR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="HK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="X_DISPERSED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="GSAOI"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H4S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="F1056"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="H5050_BEAMSPLITTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="ACQUISITION_CAMERA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="RONCHE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="J_LOW"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="PA_GAMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H20_ICE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H1S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw"/>
+        <param name="name" value="odgw4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2OiwfsGuideProbe"/>
+        <param name="name" value="instance"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="SAME_AS_DISPERSER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Camera"/>
+        <param name="name" value="F32"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosCommonType$UseNS"/>
+        <param name="name" value="FALSE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="HEI_2P2S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="NICI"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="CH4_H_DICHROIC"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw"/>
+        <param name="name" value="odgw3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Disperser"/>
+        <param name="name" value="R1200JH"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="FE_II"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="GMOS_SOUTH"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="CH4_SHORT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_9"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW$1"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="GRID"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="CO"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_7"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="FPU_NONE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="ZJ_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.data.PreImagingType"/>
+        <param name="name" value="FALSE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H65S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="OD_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="WOLLASTON"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="FE_II"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_IMAGING"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter$1"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="K_SHORT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gems.Canopus$Wfs$1"/>
+        <param name="name" value="cwfs1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="HIGH_RES_REF_MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="H210S1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="OD_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Disperser"/>
+        <param name="name" value="R1200HK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="LOW_RES_REF_MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="USER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="Y"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW$2"/>
+        <param name="name" value="H20"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H1SP"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="HIGH_RES"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter$2"/>
+        <param name="name" value="DARK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="K_PRIMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="J_F32"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="BLOCK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H4L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="KS"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="FLAMINGOS2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="BR_GAMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$CrossDispersed"/>
+        <param name="name" value="SXD"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="L_PRIMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Disperser"/>
+        <param name="name" value="NONE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="M"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="SLIT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.altair.AltairAowfsGuider"/>
+        <param name="name" value="instance"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="KG3_ND_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_7"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="LOW_RES_10"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H65L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="H20"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.data.PreImagingType"/>
+        <param name="name" value="TRUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="BR_GAMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Camera"/>
+        <param name="name" value="F32_PV"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="K_CH4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="M_PRIMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Disperser"/>
+        <param name="name" value="PRISM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="CLEAR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="K_LONG"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$CrossDispersed"/>
+        <param name="name" value="NO"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="DIFFUSER2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="CUSTOM_MASK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="K_SHORT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="K_CH4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="WIRE_GRID"/>
+      </paramset>
+    </paramset>
+    <paramset name="blocks">
+      <paramset name="block">
+        <param name="start" value="1533164653760"/>
+        <param name="end" value="1533206039227"/>
+      </paramset>
+    </paramset>
+    <paramset name="variants">
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="20"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="50"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Super Seeing, Dry"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="20"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="100"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Super Seeing, Wet"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="70"/>
+          <param name="iq" value="20"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Thin Cirrus, Super Seeing"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="70"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="50"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Good Seeing, Dry"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="70"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="100"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Good Seeing, Wet"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="70"/>
+          <param name="iq" value="70"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Thin Cirrus, Good Seeing"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="85"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="50"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Poor Seeing, Dry"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="85"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="100"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Poor Seeing, Wet"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="70"/>
+          <param name="iq" value="85"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Thin Cirrus, Poor Seeing"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="0"/>
+          <param name="iq" value="100"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Terrible Seeing"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="100"/>
+          <param name="iq" value="0"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Thick Clouds"/>
+        <param name="comment" value=""/>
+      </paramset>
+    </paramset>
+    <paramset name="extraSemesters"/>
+    <paramset name="ictd">
+      <paramset name="feature">
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter$1"/>
+          <param name="name" value="OPEN"/>
+          <param name="avail" value="Unavailable"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_2"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="NONE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="K_RED"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_N_B"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OVI_G0347"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="H"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="J_LOW"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="r_G0326_RG610_G0331"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="i_G0327_CaT_G0333"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_3"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="J"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="z_G0328"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="SII_G0335"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter$2"/>
+          <param name="name" value="DARK"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_5"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="BHROS"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="Ha_G0336"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="R831_G5322"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_1"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HeIIC_G0341"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_4"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_3"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="R150_G5326"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="Z_G0343"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="B600_G5323"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="g_G0325_OG515_G0330"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="R600_G5324"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="FPU_NONE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="RG780_G0334"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="z_G0328_CaT_G0333"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HaC_G0337"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="JH"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_7"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="Y_G0344"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_2"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_3"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_N"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HartmannB_G0338_r_G0326"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HeII_G0340"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OG515_G0330"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="R400_G5325"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HartmannA_G0337_r_G0326"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_3"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_6"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="B1200_G5321"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="K_BLUE"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="FPU_NONE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="Lya395_G0342"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="i_G0327"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="CUSTOM_MASK"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_2"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="Y"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_4"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="PINHOLE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OVIC_G0348"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="SUBPIX_PINHOLE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="F1063"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="MIRROR"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OIII_G0338"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_4"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_6"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_N_R"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_5"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_2"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OIIIC_G0339"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="u_G0332"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_1"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth$1"/>
+          <param name="name" value="IFU_1"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="RG610_G0331"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="CaT_G0333"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="HK"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="i_G0327_RG780_G0334"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="GG455_G0329"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_8"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="K_LONG"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_1"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="F1056"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="CUSTOM_MASK"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="g_G0325"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="g_G0325_GG455_G0329"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="K_SHORT"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="r_G0326"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+      </paramset>
+      <paramset name="mask">
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-227"/>
+          <param name="name" value="GS2018AQ227-02"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-59"/>
+          <param name="name" value="GS2017BQ059-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-317"/>
+          <param name="name" value="GS2018AQ317-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-07"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-23"/>
+          <param name="name" value="GS2014BQ023-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-15"/>
+          <param name="name" value="GS2017BLP015-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-32"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-86"/>
+          <param name="name" value="GS2016AQ086-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-46"/>
+          <param name="name" value="GS2017BQ046-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-19"/>
+          <param name="name" value="GS2017BQ019-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-07"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-12"/>
+          <param name="name" value="GS2014BQ012-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-LP-5"/>
+          <param name="name" value="GS2017ALP005-47"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-83"/>
+          <param name="name" value="GS2017BQ083-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-05"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-227"/>
+          <param name="name" value="GS2018AQ227-01"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-11"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-11"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-08"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-15"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-08"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-17"/>
+          <param name="name" value="GS2016BQ017-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-57"/>
+          <param name="name" value="GS2017BQ057-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-Q-80"/>
+          <param name="name" value="GS2017AQ080-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-23"/>
+          <param name="name" value="GS2014BQ023-11"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-FT-14"/>
+          <param name="name" value="GS2017BFT014-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-86"/>
+          <param name="name" value="GS2016AQ086-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2015B-LP-5"/>
+          <param name="name" value="GS2015BLP005-30"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-09"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-09"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-224"/>
+          <param name="name" value="GS2018AQ224-01"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-71"/>
+          <param name="name" value="GS2017BQ071-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-FT-20"/>
+          <param name="name" value="GS2017AFT020-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-FT-204"/>
+          <param name="name" value="GS2018AFT204-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-125"/>
+          <param name="name" value="GS2018AQ125-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-23"/>
+          <param name="name" value="GS2014BQ023-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-57"/>
+          <param name="name" value="GS2017BQ057-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-15"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-09"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-206"/>
+          <param name="name" value="GS2018BQ206-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-LP-5"/>
+          <param name="name" value="GS2017ALP005-46"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-1"/>
+          <param name="name" value="GS2017BC001-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-52"/>
+          <param name="name" value="GS2017BQ052-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-LP-1"/>
+          <param name="name" value="GS2018ALP001-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-1"/>
+          <param name="name" value="GS2017BC001-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-16"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-7"/>
+          <param name="name" value="GS2017BQ007-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-LP-1"/>
+          <param name="name" value="GS2018ALP001-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-83"/>
+          <param name="name" value="GS2017BQ083-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-11"/>
+          <param name="name" value="GS2016BQ011-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-49"/>
+          <param name="name" value="GS2016BQ049-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-19"/>
+          <param name="name" value="GS2017BQ019-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-52"/>
+          <param name="name" value="GS2017BQ052-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-14"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-07"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-16"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-317"/>
+          <param name="name" value="GS2018AQ317-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-7"/>
+          <param name="name" value="GS2017BQ007-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-125"/>
+          <param name="name" value="GS2018AQ125-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-31"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-15"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-FT-19"/>
+          <param name="name" value="GS2017AFT019-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-64"/>
+          <param name="name" value="GS2014BQ064-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-59"/>
+          <param name="name" value="GS2017BQ059-02"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-49"/>
+          <param name="name" value="GS2016BQ049-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-FT-20"/>
+          <param name="name" value="GS2017AFT020-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-49"/>
+          <param name="name" value="GS2016BQ049-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-09"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-43"/>
+          <param name="name" value="GS2017BQ043-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-26"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-19"/>
+          <param name="name" value="GS2017BQ019-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-23"/>
+          <param name="name" value="GS2017BQ023-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-LP-1"/>
+          <param name="name" value="GS2017ALP001-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-25"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-46"/>
+          <param name="name" value="GS2017BQ046-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-11"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-19"/>
+          <param name="name" value="GS2017BQ019-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-14"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-LP-1"/>
+          <param name="name" value="GS2017ALP001-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-Q-36"/>
+          <param name="name" value="GS2017AQ036-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-08"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-128"/>
+          <param name="name" value="GS2018AQ128-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-FT-14"/>
+          <param name="name" value="GS2017BFT014-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-Q-39"/>
+          <param name="name" value="GS2017AQ039-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-DD-2"/>
+          <param name="name" value="GS2017ADD002-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-08"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-FT-204"/>
+          <param name="name" value="GS2018AFT204-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-46"/>
+          <param name="name" value="GS2017BQ046-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+      </paramset>
+    </paramset>
+    <param name="comment" value=""/>
+  </paramset>
+</paramset>

--- a/bundle/edu.gemini.qpt.client/src/test/resources/edu/gemini/qpt/core/v1031.qpt
+++ b/bundle/edu.gemini.qpt.client/src/test/resources/edu/gemini/qpt/core/v1031.qpt
@@ -1,0 +1,2198 @@
+
+<paramset name="qpt-archive">
+  <param name="version" value="1031"/>
+  <param name="site" value="GS"/>
+  <param name="timestamp" value="1533224602574"/>
+  <param name="digest" value="d74b70997a70ae8f225db8c4d81147e"/>
+  <paramset name="schedule">
+    <paramset name="facilities">
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="PA_BETA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="PINHOLE_ARRAY"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="BLOCK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="NONE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H1S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="DIFFUSER1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_8"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosCommonType$UseNS"/>
+        <param name="name" value="TRUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H2_2_1_S_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H1L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="K_F32"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Disperser"/>
+        <param name="name" value="R3000"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Camera"/>
+        <param name="name" value="SHORT_BLUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="HK_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H4S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="CH4_LONG"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="CLEAR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.texes.TexesParams$Disperser"/>
+        <param name="name" value="D_75_LMM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw"/>
+        <param name="name" value="odgw1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="H2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="OD_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="Z"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H_CONTINUUM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K_CONTINUUM2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gems.Canopus$Wfs$3"/>
+        <param name="name" value="cwfs3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K_PRIME"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_10"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="H_F32"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="PINHOLE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="F1063"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K_SHORT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H2_1_0_S_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="K2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="BLOCKED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask$1"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Camera"/>
+        <param name="name" value="F14"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_8"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_IMAGING_W"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="PINHOLE_MASK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="Z"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="K1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_IMAGING"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="H2_plus_ND100X"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="K_RED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Disperser"/>
+        <param name="name" value="WOLLASTON"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="JH_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="K_LONG"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="PWFS"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_11"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="PAH"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Camera"/>
+        <param name="name" value="F6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw"/>
+        <param name="name" value="odgw2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Camera"/>
+        <param name="name" value="SHORT_RED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="Y"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="HEI"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW$1"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H1L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Camera"/>
+        <param name="name" value="LONG_BLUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="BLOCKED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="CANOPUS"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="PINHOLE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="KG5_ND_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="JH"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.texes.TexesParams$Disperser"/>
+        <param name="name" value="D_32_LMM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="BLOCKED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K_CONTINUUM1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="BLOCK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.texes.TexesParams$Disperser"/>
+        <param name="name" value="E_D_32_LMM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Camera"/>
+        <param name="name" value="LONG_RED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.texes.TexesParams$Disperser"/>
+        <param name="name" value="E_D_75_LMM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gems.Canopus$Wfs$2"/>
+        <param name="name" value="cwfs2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$CrossDispersed"/>
+        <param name="name" value="LXD"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="J_CONTINUUM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.target.obsComp.PwfsGuideProbe$1"/>
+        <param name="name" value="pwfs1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H1SP"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW$2"/>
+        <param name="name" value="BR_GAMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="K_BLUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="Y"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="H_plus_ND100X"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="SUBPIX_PINHOLE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.target.obsComp.PwfsGuideProbe$2"/>
+        <param name="name" value="pwfs2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="LOW_RES_20"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="H_K_DICHROIC"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H4L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="K_CONT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="OCCULTING_BAR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="HK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="X_DISPERSED"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="GSAOI"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H4S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="F1056"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="H5050_BEAMSPLITTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="ACQUISITION_CAMERA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="RONCHE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="J_LOW"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="PA_GAMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="H20_ICE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H1S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw"/>
+        <param name="name" value="odgw4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2OiwfsGuideProbe"/>
+        <param name="name" value="instance"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="SAME_AS_DISPERSER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Camera"/>
+        <param name="name" value="F32"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosCommonType$UseNS"/>
+        <param name="name" value="FALSE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="HEI_2P2S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="NICI"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="CH4_H_DICHROIC"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.GsaoiOdgw"/>
+        <param name="name" value="odgw3"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Disperser"/>
+        <param name="name" value="R1200JH"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="FE_II"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="GMOS_SOUTH"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="CH4_SHORT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_9"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW$1"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="GRID"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="CO"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_7"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="FPU_NONE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="ZJ_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.data.PreImagingType"/>
+        <param name="name" value="FALSE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="CH4H65S"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="OD_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="WOLLASTON"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="FE_II"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_IMAGING"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$Filter"/>
+        <param name="name" value="ORDER_6"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter$1"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Disperser"/>
+        <param name="name" value="K_SHORT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gems.Canopus$Wfs$1"/>
+        <param name="name" value="cwfs1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="HIGH_RES_REF_MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="H210S1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="OD_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Disperser"/>
+        <param name="name" value="R1200HK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="J"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="LOW_RES_REF_MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="USER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$DichroicWheel"/>
+        <param name="name" value="OPEN"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="Y"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW$2"/>
+        <param name="name" value="H20"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H1SP"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="HIGH_RES"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Filter"/>
+        <param name="name" value="H"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter$2"/>
+        <param name="name" value="DARK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="K_PRIMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="J_F32"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Mask"/>
+        <param name="name" value="MASK_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="BLOCK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H4L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="KS"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.qpt.shared.sp.Inst"/>
+        <param name="name" value="FLAMINGOS2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="BR_GAMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$FocalPlaneMask"/>
+        <param name="name" value="MASK_1"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$CrossDispersed"/>
+        <param name="name" value="SXD"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="L_PRIMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Disperser"/>
+        <param name="name" value="NONE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="M"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="SLIT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.altair.AltairAowfsGuider"/>
+        <param name="name" value="instance"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="KG3_ND_FILTER"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_7"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="LOW_RES_10"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="CH4H65L"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="H20"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="LONGSLIT_4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.data.PreImagingType"/>
+        <param name="name" value="TRUE"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="BR_GAMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Camera"/>
+        <param name="name" value="F32_PV"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel2FW"/>
+        <param name="name" value="K_CH4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="M_PRIMMA"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gpi.Gpi$Disperser"/>
+        <param name="name" value="PRISM"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Mask"/>
+        <param name="name" value="CLEAR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="K_LONG"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gnirs.GNIRSParams$CrossDispersed"/>
+        <param name="name" value="NO"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.gsaoi.Gsaoi$Filter"/>
+        <param name="name" value="DIFFUSER2"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+        <param name="name" value="CUSTOM_MASK"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Mask"/>
+        <param name="name" value="MASK_5"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+        <param name="name" value="K_SHORT"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.trecs.TReCSParams$Disperser"/>
+        <param name="name" value="MIRROR"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nici.NICIParams$Channel1FW"/>
+        <param name="name" value="K_CH4"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.niri.Niri$Disperser"/>
+        <param name="name" value="K"/>
+      </paramset>
+      <paramset name="member">
+        <param name="class" value="edu.gemini.spModel.gemini.nifs.NIFSParams$Filter"/>
+        <param name="name" value="WIRE_GRID"/>
+      </paramset>
+    </paramset>
+    <paramset name="blocks">
+      <paramset name="block">
+        <param name="start" value="1533164653759"/>
+        <param name="end" value="1533206039226"/>
+      </paramset>
+    </paramset>
+    <paramset name="variants">
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="20"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="50"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Super Seeing, Dry"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="20"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="100"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Super Seeing, Wet"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="70"/>
+          <param name="iq" value="20"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Thin Cirrus, Super Seeing"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="70"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="50"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Good Seeing, Dry"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="70"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="100"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Good Seeing, Wet"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="70"/>
+          <param name="iq" value="70"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Thin Cirrus, Good Seeing"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="85"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="50"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Poor Seeing, Dry"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="50"/>
+          <param name="iq" value="85"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="100"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Photometric, Poor Seeing, Wet"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="70"/>
+          <param name="iq" value="85"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Thin Cirrus, Poor Seeing"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="0"/>
+          <param name="iq" value="100"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Terrible Seeing"/>
+        <param name="comment" value=""/>
+      </paramset>
+      <paramset name="variant">
+        <paramset name="visits"/>
+        <paramset name="siteConditions">
+          <param name="cc" value="100"/>
+          <param name="iq" value="0"/>
+          <param name="sb" value="0"/>
+          <param name="wv" value="0"/>
+        </paramset>
+        <param name="lgsConstraint" value="false"/>
+        <param name="name" value="Thick Clouds"/>
+        <param name="comment" value=""/>
+      </paramset>
+    </paramset>
+    <paramset name="extraSemesters"/>
+    <paramset name="ictd">
+      <paramset name="feature">
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter$1"/>
+          <param name="name" value="OPEN"/>
+          <param name="avail" value="Unavailable"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_2"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="NONE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="K_RED"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_N_B"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OVI_G0347"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="H"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="J_LOW"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="r_G0326_RG610_G0331"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="i_G0327_CaT_G0333"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_3"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="J"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="z_G0328"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="SII_G0335"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter$2"/>
+          <param name="name" value="DARK"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_5"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="BHROS"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="Ha_G0336"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="R831_G5322"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_1"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HeIIC_G0341"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_4"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_3"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="R150_G5326"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="Z_G0343"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="B600_G5323"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="g_G0325_OG515_G0330"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="R600_G5324"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="FPU_NONE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="RG780_G0334"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="z_G0328_CaT_G0333"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HaC_G0337"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="JH"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_7"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="Y_G0344"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_2"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_3"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_N"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HartmannB_G0338_r_G0326"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HeII_G0340"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OG515_G0330"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="R400_G5325"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="HartmannA_G0337_r_G0326"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_3"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_6"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="B1200_G5321"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="K_BLUE"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="FPU_NONE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="Lya395_G0342"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="i_G0327"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="CUSTOM_MASK"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_2"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="Y"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_4"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="PINHOLE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OVIC_G0348"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="SUBPIX_PINHOLE"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="F1063"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$DisperserSouth"/>
+          <param name="name" value="MIRROR"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OIII_G0338"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_4"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="LONGSLIT_6"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="IFU_N_R"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_5"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_2"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="OIIIC_G0339"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="u_G0332"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_1"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth$1"/>
+          <param name="name" value="IFU_1"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="RG610_G0331"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="CaT_G0333"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="HK"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="i_G0327_RG780_G0334"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="GG455_G0329"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="LONGSLIT_8"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="K_LONG"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FPUnitSouth"/>
+          <param name="name" value="NS_1"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="F1056"/>
+          <param name="avail" value="Missing"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$FPUnit"/>
+          <param name="name" value="CUSTOM_MASK"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="g_G0325"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="g_G0325_GG455_G0329"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.flamingos2.Flamingos2$Filter"/>
+          <param name="name" value="K_SHORT"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="class" value="edu.gemini.spModel.gemini.gmos.GmosSouthType$FilterSouth"/>
+          <param name="name" value="r_G0326"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+      </paramset>
+      <paramset name="mask">
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-227"/>
+          <param name="name" value="GS2018AQ227-02"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-59"/>
+          <param name="name" value="GS2017BQ059-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-317"/>
+          <param name="name" value="GS2018AQ317-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-07"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-23"/>
+          <param name="name" value="GS2014BQ023-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-15"/>
+          <param name="name" value="GS2017BLP015-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-32"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-86"/>
+          <param name="name" value="GS2016AQ086-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-46"/>
+          <param name="name" value="GS2017BQ046-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-19"/>
+          <param name="name" value="GS2017BQ019-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-07"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-12"/>
+          <param name="name" value="GS2014BQ012-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-LP-5"/>
+          <param name="name" value="GS2017ALP005-47"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-83"/>
+          <param name="name" value="GS2017BQ083-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-05"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-227"/>
+          <param name="name" value="GS2018AQ227-01"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-11"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-11"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-08"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-15"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-08"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-17"/>
+          <param name="name" value="GS2016BQ017-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-57"/>
+          <param name="name" value="GS2017BQ057-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-Q-80"/>
+          <param name="name" value="GS2017AQ080-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-23"/>
+          <param name="name" value="GS2014BQ023-11"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-FT-14"/>
+          <param name="name" value="GS2017BFT014-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-86"/>
+          <param name="name" value="GS2016AQ086-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2015B-LP-5"/>
+          <param name="name" value="GS2015BLP005-30"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-09"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-09"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-224"/>
+          <param name="name" value="GS2018AQ224-01"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-71"/>
+          <param name="name" value="GS2017BQ071-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-FT-20"/>
+          <param name="name" value="GS2017AFT020-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-FT-204"/>
+          <param name="name" value="GS2018AFT204-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-125"/>
+          <param name="name" value="GS2018AQ125-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-23"/>
+          <param name="name" value="GS2014BQ023-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-57"/>
+          <param name="name" value="GS2017BQ057-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-15"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-09"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-206"/>
+          <param name="name" value="GS2018BQ206-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-LP-5"/>
+          <param name="name" value="GS2017ALP005-46"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-1"/>
+          <param name="name" value="GS2017BC001-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-52"/>
+          <param name="name" value="GS2017BQ052-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-LP-1"/>
+          <param name="name" value="GS2018ALP001-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-1"/>
+          <param name="name" value="GS2017BC001-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-16"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-7"/>
+          <param name="name" value="GS2017BQ007-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-LP-1"/>
+          <param name="name" value="GS2018ALP001-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-83"/>
+          <param name="name" value="GS2017BQ083-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-11"/>
+          <param name="name" value="GS2016BQ011-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-49"/>
+          <param name="name" value="GS2016BQ049-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-19"/>
+          <param name="name" value="GS2017BQ019-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-52"/>
+          <param name="name" value="GS2017BQ052-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-14"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-07"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-16"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-317"/>
+          <param name="name" value="GS2018AQ317-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-7"/>
+          <param name="name" value="GS2017BQ007-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-125"/>
+          <param name="name" value="GS2018AQ125-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-31"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-15"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-FT-19"/>
+          <param name="name" value="GS2017AFT019-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016A-Q-7"/>
+          <param name="name" value="GS2016AQ007-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2014B-Q-64"/>
+          <param name="name" value="GS2014BQ064-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-59"/>
+          <param name="name" value="GS2017BQ059-02"/>
+          <param name="avail" value="Installed"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-49"/>
+          <param name="name" value="GS2016BQ049-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-FT-20"/>
+          <param name="name" value="GS2017AFT020-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2016B-Q-49"/>
+          <param name="name" value="GS2016BQ049-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-09"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-43"/>
+          <param name="name" value="GS2017BQ043-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-26"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-19"/>
+          <param name="name" value="GS2017BQ019-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-23"/>
+          <param name="name" value="GS2017BQ023-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-13"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-LP-1"/>
+          <param name="name" value="GS2017ALP001-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-25"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-46"/>
+          <param name="name" value="GS2017BQ046-03"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-11"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-C-3"/>
+          <param name="name" value="GS2017BC003-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-19"/>
+          <param name="name" value="GS2017BQ019-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-14"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-76"/>
+          <param name="name" value="GS2017BQ076-05"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-LP-1"/>
+          <param name="name" value="GS2017ALP001-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-10"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-Q-36"/>
+          <param name="name" value="GS2017AQ036-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-LP-1"/>
+          <param name="name" value="GS2017BLP001-08"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-36"/>
+          <param name="name" value="GS2017BQ036-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-128"/>
+          <param name="name" value="GS2018AQ128-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-FT-14"/>
+          <param name="name" value="GS2017BFT014-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018B-Q-233"/>
+          <param name="name" value="GS2018BQ233-12"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-Q-39"/>
+          <param name="name" value="GS2017AQ039-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-Q-219"/>
+          <param name="name" value="GS2018AQ219-04"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017A-DD-2"/>
+          <param name="name" value="GS2017ADD002-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-39"/>
+          <param name="name" value="GS2017BQ039-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-77"/>
+          <param name="name" value="GS2017BQ077-06"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-82"/>
+          <param name="name" value="GS2017BQ082-08"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2018A-FT-204"/>
+          <param name="name" value="GS2018AFT204-01"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+        <paramset name="entry">
+          <param name="pid" value="GS-2017B-Q-46"/>
+          <param name="name" value="GS2017BQ046-02"/>
+          <param name="avail" value="SummitCabinet"/>
+        </paramset>
+      </paramset>
+    </paramset>
+    <param name="comment" value=""/>
+  </paramset>
+</paramset>

--- a/bundle/edu.gemini.qpt.client/src/test/scala/edu/gemini/qpt/core/MigrationSpec.scala
+++ b/bundle/edu.gemini.qpt.client/src/test/scala/edu/gemini/qpt/core/MigrationSpec.scala
@@ -1,0 +1,78 @@
+package edu.gemini.qpt.core
+
+import edu.gemini.qpt.core.util.Interval
+import edu.gemini.qpt.shared.sp.MiniModel
+import edu.gemini.skycalc.TwilightBoundedNight
+import edu.gemini.skycalc.TwilightBoundType.CIVIL
+import edu.gemini.spModel.core.Site
+import edu.gemini.spModel.pio.ParamSet
+import edu.gemini.spModel.pio.xml.PioXmlUtil
+
+import org.specs2.mutable._
+
+import java.io.{ BufferedReader, InputStreamReader, Reader }
+
+import scala.collection.JavaConverters._
+
+/**
+ * Schedule doc migration spec
+ */
+final class MigrationSpec extends Specification {
+
+  private def closing[A](fileName: String)(test: ParamSet => A): A = {
+
+    val is = new BufferedReader(new InputStreamReader(getClass.getResourceAsStream(fileName)))
+
+    try {
+
+      PioXmlUtil.read(is) match {
+        case ps: ParamSet => test(ps.getParamSet("schedule"))
+        case _            => sys.error(s"expected a paramset in file '$fileName'")
+      }
+
+    } finally {
+      is.close
+    }
+
+  }
+
+  val site: Site = Site.GS
+
+  "Schedule import" should {
+
+    "update normal block to civil twilight" in {
+
+      closing("v1031.qpt") { ps =>
+
+        val s = new Schedule(MiniModel.empty(site), ps, 1031)
+        s.getBlocks.asScala.toList match {
+          case b :: nil =>
+            val n = TwilightBoundedNight.forTime(CIVIL, b.getStart, site)
+            val e = new Interval(n.getStartTime, n.getEndTime)
+            e shouldEqual b.getInterval
+          case _        =>
+            sys.error("expected a single block")
+        }
+      }
+
+    }
+
+    "leave unusual block times alone" in {
+
+      closing("v1031-unexpected.qpt") { ps =>
+
+        val s = new Schedule(MiniModel.empty(site), ps, 1031)
+        s.getBlocks.asScala.toList match {
+          case b :: nil =>
+            b.getStart shouldEqual 1533164653760l
+            b.getEnd   shouldEqual 1533206039227l
+          case _        =>
+            sys.error("expected a single block")
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/MiniModel.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/MiniModel.java
@@ -68,6 +68,17 @@ public class MiniModel {
         for (Obs obs: allObservations) obsMap.put(obs.getObsId(), obs);
     }
 
+    public static MiniModel empty(Site site) {
+        return new MiniModel(
+                site,
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptySortedSet(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+        );
+    }
+
     public SortedSet<Prog> getPrograms() {
         return programs;
     }


### PR DESCRIPTION
When opening an old schedule document, the block interval is set to nautical twilight.  Because the block interval trims all the cache results (such as the `VISIBLE_UNION_CACHE`) we mistakenly report availability ranges limited by nautical twilight.

This PR adjusts block boundaries to civil twilight upon import if they were set to nautical twilight.