### PR TITLE
REL-3413: Update GPI magnitude checks in PIT

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -38,6 +38,7 @@ package object immutable {
   type CloudCover = M.CloudCover
   object CloudCover extends EnumObject[M.CloudCover] {
     val BEST = M.CloudCover.cc50
+    val CC70 = M.CloudCover.cc70
     val CC80 = M.CloudCover.cc80
     val ANY  = M.CloudCover.cc100
   }
@@ -366,6 +367,7 @@ package object immutable {
     val BEST = M.ImageQuality.iq20
     val IQ70 = M.ImageQuality.iq70
     val IQ85 = M.ImageQuality.iq85
+    val IQANY = M.ImageQuality.iq100
   }
 
   type InvestigatorStatus = M.InvestigatorStatus

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -361,20 +361,37 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
         ~(((requiredBands & observationBands) =/= requiredBands) option {List((Severity.Error, "The magnitude information in the GPI target component should include the bandpasses I, Y, J, H, and K."))})
       }
 
-      def gpiIChecks(target: SiderealTarget, cond: Condition):List[(Severity.Value, String)] = for {
+      def magAdjust(cond: Condition): Double = {
+        val ccAdjust = cond.cc match {
+          case CloudCover.BEST                  =>  0.0
+          case CloudCover.CC70                  =>  1.5
+          case CloudCover.CC80 | CloudCover.ANY => 10.0
+        }
+        val iqAdjust = cond.iq match {
+          case ImageQuality.BEST | ImageQuality.IQ70 =>  0.0
+          case ImageQuality.IQ85                     =>  1.5
+          case ImageQuality.IQANY                    => 10.0
+        }
+        ccAdjust + iqAdjust
+      }
+
+      def gpiIChecks(target: SiderealTarget, cond: Condition):List[(Severity.Value, String)] = {
+        val magAdj = magAdjust(cond)
+        for {
           m <- target.magnitudes
           if m.band == MagnitudeBand.I
-          iMag = m.value
-          if iMag < 3.0 || iMag > 8.0
+          iMag = m.value + magAdj // REL-3413: apply adjustments to mag based on conditions.
+          if iMag < 3.0 || iMag > 9.0
           severity = if (iMag <= 1.0 || iMag > 10.0) Severity.Error else Severity.Warning
           message = if (iMag < 3.0 && iMag > 1.0) {
-              s"""GPI Target "${target.name}" may be too bright for the OIWFS."""
-            } else if (iMag <= 1.0) {
-              s"""GPI Target "${target.name}" too bright to work with the OIWFS."""
-            } else {
-              s"""GPI Target "${target.name}" is too faint for proper AO (OIWFS) operation, the AO performance will be poor."""
-            }
+            s"""GPI Target "${target.name}" may be too bright for the OIWFS."""
+          } else if (iMag <= 1.0) {
+            s"""GPI Target "${target.name}" too bright to work with the OIWFS."""
+          } else {
+            s"""GPI Target "${target.name}" is too faint for proper AO (OIWFS) operation, the AO performance will be poor."""
+          }
         } yield (severity, message)
+      }
 
       def gpiIfsChecks(obsMode: GpiObservingMode, disperser: GpiDisperser, target: SiderealTarget):List[(Severity.Value, String)] = for {
           m <- target.magnitudes
@@ -387,17 +404,20 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           if (scienceMag < coronographLimit && GpiObservingMode.isCoronographMode(obsMode)) || (scienceMag < directLimit && GpiObservingMode.isDirectMode(obsMode))
         } yield (Severity.Warning, s"""GPI Target "${target.name}" risks saturating the science detector even for short exposure times.""")
 
-      def gpiLowfsChecks(obsMode: GpiObservingMode, target: SiderealTarget):List[(Severity.Value, String)] = for {
-        m <- target.magnitudes
-        if m.band == MagnitudeBand.H && GpiObservingMode.isCoronographMode(obsMode)
-        hMag = m.value
-        if hMag < 2.0 || hMag > 10.0
-        message = if (hMag < 2.0) {
+      def gpiLowfsChecks(obsMode: GpiObservingMode, target: SiderealTarget, cond: Condition): List[(Severity.Value, String)] = {
+        val magAdj = magAdjust(cond)
+        for {
+          m <- target.magnitudes
+          if m.band == MagnitudeBand.H && GpiObservingMode.isCoronographMode(obsMode)
+          hMag = m.value + magAdj // REL-3413: apply adjustments to mag based on conditions.
+          if hMag < 2.0 || hMag > 9.0
+          message = if (hMag < 2.0) {
             s"""GPI Target "${target.name}" is too bright, it will saturate the LOWFS."""
           } else  {
             s"""GPI Target "${target.name}" is too faint for proper CAL (LOWFS) operation and thus mask centering on the coronograph will be severely affected."""
           }
-      } yield (Severity.Warning, message)
+        } yield (Severity.Warning, message)
+      }
 
       val gpiTargetsWithProblems: List[(SiderealTarget, List[(Severity, String)])] = for {
           o <- p.observations
@@ -407,7 +427,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           disperser = b.asInstanceOf[GpiBlueprint].disperser
           t @ SiderealTarget(_, _, _, _, _, mag) <- o.target
           c <- o.condition
-        } yield (t, (gpiMagnitudesPresent(t) :: gpiIChecks(t, c) :: gpiLowfsChecks(obsMode, t) :: gpiIfsChecks(obsMode, disperser, t) :: Nil).flatten)
+        } yield (t, (gpiMagnitudesPresent(t) :: gpiIChecks(t, c) :: gpiLowfsChecks(obsMode, t, c) :: gpiIfsChecks(obsMode, disperser, t) :: Nil).flatten)
 
       for {
         gpiProblems <- gpiTargetsWithProblems

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -361,7 +361,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
         ~(((requiredBands & observationBands) =/= requiredBands) option {List((Severity.Error, "The magnitude information in the GPI target component should include the bandpasses I, Y, J, H, and K."))})
       }
 
-      def gpiIChecks(target: SiderealTarget):List[(Severity.Value, String)] = for {
+      def gpiIChecks(target: SiderealTarget, cond: Condition):List[(Severity.Value, String)] = for {
           m <- target.magnitudes
           if m.band == MagnitudeBand.I
           iMag = m.value
@@ -406,7 +406,8 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           obsMode = b.asInstanceOf[GpiBlueprint].observingMode
           disperser = b.asInstanceOf[GpiBlueprint].disperser
           t @ SiderealTarget(_, _, _, _, _, mag) <- o.target
-        } yield (t, (gpiMagnitudesPresent(t) :: gpiIChecks(t) :: gpiLowfsChecks(obsMode, t) :: gpiIfsChecks(obsMode, disperser, t) :: Nil).flatten)
+          c <- o.condition
+        } yield (t, (gpiMagnitudesPresent(t) :: gpiIChecks(t, c) :: gpiLowfsChecks(obsMode, t) :: gpiIfsChecks(obsMode, disperser, t) :: Nil).flatten)
 
       for {
         gpiProblems <- gpiTargetsWithProblems


### PR DESCRIPTION
The faintness level acceptable by GPI in the PIT is now affected by the conditions (image quality and cloud cover). This incorporates the faintness level adjustments as per the JIRA task, and prioritizes problem messages as per discussions with Frederik and Bryan.

(Note: it is possible, with the new updates, for a target to be simultaneously "too bright" and "too dark" if certain conditions are chosen: hence why the error messages are prioritized. This was discussed with science and despite the oddity of it, is the desired requirement.)