### PR TITLE
REL-1714: replace access to twilight for velocity template

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/ScheduleDocument.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/html/ScheduleDocument.java
@@ -299,6 +299,12 @@ public class ScheduleDocument {
         return (a.getFirstStep() + 1) + " - " + (a.getLastStep() + 1);
     }
 
+    // WARNING: like other methods in this class, there appear to be no usages
+    // of this method but in fact it is required by the template.vm file.
+    public TwilightBoundedNight getNauticalTwilight() {
+        return new TwilightBoundedNight(TwilightBoundType.NAUTICAL, schedule.getStart(), schedule.getSite());
+    }
+
     public SortedSet<Object> getEvents(Variant v) {
 
         SortedSet<Object> ret = new TreeSet<Object>(new Comparator<Object>() {

--- a/bundle/edu.gemini.qpt.client/src/main/resources/edu/gemini/qpt/ui/html/template.vm
+++ b/bundle/edu.gemini.qpt.client/src/main/resources/edu/gemini/qpt/ui/html/template.vm
@@ -35,7 +35,7 @@
 	<h2>Sky Almanac</h2>
 
 	<table>
-		#set($night=$doc.TwilightBoundedNight)
+		#set($night=$doc.NauticalTwilight)
 		<tr><td>$doc.formatDate("HH:mm", $night.StartTime)</td><td>Nautical Twilight</td></tr>
 		<tr><td>$doc.formatDate("HH:mm", $night.EndTime)</td><td>Nautical Twilight</td></tr>
 	</table>


### PR DESCRIPTION
I inadvertently deleted a QPT `ScheduleDocument` method because it appeared to have no usages only to find out that yes, in fact it is used from a velocity template.  This marks the 1001st time I've relearned that lesson.