### PR TITLE
REL-3111: Cutting back the number of ephemerides entries to 200.

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/HorizonsLookup.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/HorizonsLookup.scala
@@ -111,9 +111,8 @@ final class HorizonsLookup(editor: TargetEditor, site: Site, when: Long) {
       val d1 = new Date(n.getStartTime)
       val d2 = new Date(n.getEndTime)
       for {
-        e1 <- HorizonsService2.lookupEphemerisWithPadding(d, site, 1000, s)
-        e2 <- HorizonsService2.lookupEphemeris(d, site, d1, d2, 300)
-      } yield Ephemeris(site, e1.data.union(e2.data))
+        e1 <- HorizonsService2.lookupEphemerisWithPadding(d, site, 200, s)
+      } yield Ephemeris(site, e1.data)
     }
 
   /** Create a new phase 1 target from a name and phase-2 (!) ephemeris. */


### PR DESCRIPTION
This is in response to Bryan's note on REL-3111 saying there were too many ephemeris data entries during PIT lookups (where we had approximately four): Rob and Bryan decided to cut the number back to 200 entries.