### PR TITLE
REL-3460: Fixed serialization problems with GHOST HR programs.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -238,7 +238,7 @@ object GhostAsterism {
     * guide fibers will be used by default because the target must be bright,
     * but can be explicitly turned off.
     */
-  sealed abstract class HighResolution(target: GhostTarget) extends GhostAsterism {
+  sealed abstract class HighResolution(target: GhostTarget) extends GhostAsterism with Serializable {
     override def allSpTargets: NonEmptyList[SPTarget] =
       NonEmptyList(target.spTarget)
 


### PR DESCRIPTION
Carlos discovered that GHOST high resolution observations were not serializing properly.

This is because the standard resolution observations use a sealed trait, whereas the high resolution observations use a sealed abstract class, which I suppose needs to be marked as serializable.