### PR TITLE
PIT REL-3290: Extend template observations to band 3

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -25,8 +25,8 @@ object Observation {
   def unapply(o:Observation) = Some((o.blueprint, o.condition, o.target, o.progTime, o.band))
 
   // REL-3290: We need an empty band 3 observation to add to the band 3 tab.
-  val empty = new Observation(None, None, None, None, M.Band.BAND_1_2)
-  val emptyBand3 = new Observation(None, None, None, None, M.Band.BAND_3)
+  val empty = new Observation(None, None, None, None, M.Band.BAND_1_2, None, true)
+  val emptyBand3 = new Observation(None, None, None, None, M.Band.BAND_3, None, true)
 }
 
 // REL-2985: It is unfortunate that we have to pass progTime here, but it is necessary for the migration to 2017B,
@@ -104,7 +104,7 @@ class Observation private (val blueprint:Option[BlueprintBase],
     case _             => false
   }
 
-  private lazy val kernel = (blueprint, condition, target, progTime, band, meta)
+  private lazy val kernel = (blueprint, condition, target, progTime, band, meta, enabled)
 
   override lazy val hashCode = kernel.hashCode()
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -24,7 +24,9 @@ object Observation {
 
   def unapply(o:Observation) = Some((o.blueprint, o.condition, o.target, o.progTime, o.band))
 
+  // REL-3290: We need an empty band 3 observation to add to the band 3 tab.
   val empty = new Observation(None, None, None, None, M.Band.BAND_1_2)
+  val emptyBand3 = new Observation(None, None, None, None, M.Band.BAND_3)
 }
 
 // REL-2985: It is unfortunate that we have to pass progTime here, but it is necessary for the migration to 2017B,
@@ -93,7 +95,8 @@ class Observation private (val blueprint:Option[BlueprintBase],
     m
   }
 
-  def isEmpty = blueprint.isEmpty && condition.isEmpty && target.isEmpty && calculatedTimes.isEmpty
+  def isEmpty = this == Observation.empty || this == Observation.emptyBand3
+
   def nonEmpty = !isEmpty
 
   override def equals(a:Any) = a match {
@@ -108,7 +111,7 @@ class Observation private (val blueprint:Option[BlueprintBase],
   def isPartialObservationOf(o:Observation) =
     progTime.isEmpty  && // If I have time defined, I might be incomplete but I'm not partial
     (band == o.band) && // must be the same band
-    (blueprint.isEmpty || target.isEmpty || condition.isEmpty || calculatedTimes.isEmpty) && // Must have *some* empty component
+    isEmpty && // Must have *some* empty component
     isPartial(blueprint, o.blueprint) &&
     isPartial(target, o.target) &&
     isPartial(condition, o.condition) &&

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Proposal.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Proposal.scala
@@ -86,10 +86,10 @@ object Proposal {
   // then an empty one is provided to serve as a dummy observation for users to edit.
   def nonEmptyObsList(olist: List[Observation]): List[Observation] = {
     // Make sure we have one observation for bands 1/2, and one for band 3.
-    val band12missing = olist.exists(_.band === M.Band.BAND_1_2)
-    val band3missing  = olist.exists(_.band === M.Band.BAND_3)
+    val band12missing = !olist.exists(o => o.band === M.Band.BAND_1_2 && o.nonEmpty)
+    val band3missing  = !olist.exists(o => o.band === M.Band.BAND_3 && o.nonEmpty)
     (band12missing ? List(Observation.empty) | olist.filter(_.band === Band.BAND_1_2)) ++
-      (band3missing ? List(Observation.emptyBand3) | olist.filter(_.band === Band.BAND_3))
+       (band3missing ? List(Observation.emptyBand3) | olist.filter(_.band === Band.BAND_3))
   }
 }
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -30,7 +30,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           proposal.targets must beEmpty
           proposal.conditions must beEmpty
           proposal.blueprints must have size 1
-          proposal.observations must have size 1
+          proposal.observations must have size 2
           Option(proposal.proposalClass) must beSome
 
           // Check the instruments
@@ -72,7 +72,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           proposal.targets must beEmpty
           proposal.conditions must beEmpty
           proposal.blueprints must have size 1
-          proposal.observations must have size 1
+          proposal.observations must have size 2
           Option(proposal.proposalClass) must beSome
 
           // Check the instruments
@@ -116,7 +116,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           proposal.targets must beEmpty
           proposal.conditions must beEmpty
           proposal.blueprints must have size 1
-          proposal.observations must have size 1
+          proposal.observations must have size 2
           Option(proposal.proposalClass) must beSome
 
           proposal.schemaVersion must beEqualTo(Proposal.currentSchemaVersion)
@@ -230,8 +230,9 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
+          println(s"${(result \\ "observations").toString()}")
           (result \\ "observations") must ==/(<observations>
-            <observation enabled="false" band="Band 1/2"/>
+            <observation band="Band 1/2" enabled="false"/>
           </observations>)
 
           val proposal = ProposalIo.read(result.toString())

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -230,7 +230,6 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          println(s"${(result \\ "observations").toString()}")
           (result \\ "observations") must ==/(<observations>
             <observation band="Band 1/2" enabled="false"/>
           </observations>)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -281,7 +281,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band) extends BorderPanel with
       this.viewer.getTable.setDragEnabled(canEdit)
     }
 
-    // Repaint everything when the catalog or guidstar state changes
+    // Repaint everything when the catalog or guide star state changes
     AgsRobot.addListener {_:Any => refresh()}
     GsaRobot.addListener {_:Any => refresh()}
 
@@ -322,9 +322,10 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band) extends BorderPanel with
             case n  => Proposal.targets.set(p0, ts.updated(n, newT))
           }
         }
-
+        println(s"${p1}")
         panel.model = Some(p1)
       }
+      println(s"Finally: ${panel.model}")
     }
 
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -322,7 +322,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band) extends BorderPanel with
             case n  => Proposal.targets.set(p0, ts.updated(n, newT))
           }
         }
-        
+
         panel.model = Some(p1)
       }
     }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -322,10 +322,9 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band) extends BorderPanel with
             case n  => Proposal.targets.set(p0, ts.updated(n, newT))
           }
         }
-        println(s"${p1}")
+        
         panel.model = Some(p1)
       }
-      println(s"Finally: ${panel.model}")
     }
 
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/obs/ObsListView.scala
@@ -62,7 +62,7 @@ class ObsListView(shellAdvisor:ShellAdvisor, band:Band) extends BorderPanel with
         case q:QueueProposalClass         => q.band3request.isDefined
         case f:FastTurnaroundProgramClass => f.band3request.isDefined
         case _                    => false
-      }) || p.observations.exists(_.band == Band.BAND_3)
+      }) || p.observations.exists(o => o.band == Band.BAND_3 && o.nonEmpty)
 
       if (tabEnabled) {
 


### PR DESCRIPTION
In the original change I made for REL-3290, I implemented a "template" observation, i.e. an empty observation so that the fields needed to be filled by people filing proposals was more user-friendly:

![screen shot 2018-07-31 at 11 58 55 am](https://user-images.githubusercontent.com/8795653/44047949-64b26aee-9f06-11e8-8add-0404acfe5689.png)

However, it was brought to my attention during testing that the template did not show up for band 3 observations. This PR rectifies that. Note that a bit of ugly hackery is involved, as we need `Observation` to always have a band 1/2 observation and a band 3 observation (although, if empty, these are eliminated before submission).

Here is the final result:

![screen shot 2018-08-13 at 2 29 55 pm](https://user-images.githubusercontent.com/8795653/44048066-b3f9cc28-9f06-11e8-8af4-6d3a5fa29feb.png)

![screen shot 2018-08-13 at 2 30 16 pm](https://user-images.githubusercontent.com/8795653/44048073-baac554a-9f06-11e8-8c40-7bde713cd0c9.png)
