### PR TITLE
PIT 2019A REL-3290: Add empty template observations (take three!)

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -109,13 +109,15 @@ class Observation private (val blueprint:Option[BlueprintBase],
   override lazy val hashCode = kernel.hashCode()
 
   def isPartialObservationOf(o:Observation) =
-    progTime.isEmpty  && // If I have time defined, I might be incomplete but I'm not partial
-    (band == o.band) && // must be the same band
-    isEmpty && // Must have *some* empty component
-    isPartial(blueprint, o.blueprint) &&
-    isPartial(target, o.target) &&
-    isPartial(condition, o.condition) &&
-    isPartial(calculatedTimes, o.calculatedTimes)
+    band == o.band &&
+      (isEmpty ||
+        (o.nonEmpty &&
+          progTime.isEmpty && // If I have time defined, I might be incomplete but I'm not partial
+          (blueprint.isEmpty || target.isEmpty || condition.isEmpty || calculatedTimes.isEmpty) && // Must have *some* empty component
+          isPartial(blueprint, o.blueprint) &&
+          isPartial(target, o.target) &&
+          isPartial(condition, o.condition) &&
+          isPartial(calculatedTimes, o.calculatedTimes)))
 
   private def isPartial[A](a:Option[A], b:Option[A]) = a.isEmpty || a == b
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Proposal.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Proposal.scala
@@ -31,7 +31,6 @@ object Proposal {
 
   // Remove [partial] duplicates from appearing in the observation list
   def clean(os:List[Observation]) = {
-
     // Calculate what's a partial obs of what. O(N^2) sadly
     val partial:Map[(Observation, Observation), Boolean] = (for {
       o0 <- os
@@ -39,7 +38,7 @@ object Proposal {
     } yield ((o0, o1), o0.isPartialObservationOf(o1))).toMap
 
     val obsList = os.foldRight(List.empty[Observation]) {(o, os) =>
-      if (os.exists(x => partial((o, x)))) {
+      if (o.isEmpty || os.exists(x => partial((o, x)))) {
         os
       } else if (os.exists(x => partial((x, o)))) {
         os.map {
@@ -49,10 +48,10 @@ object Proposal {
       } else {
         o :: os
       }
-    } filterNot (_.isEmpty)
+    }
 
     // We always want a non-empty list of observations: the empty observations if nothing.
-    nonEmptyObsList(os)
+    nonEmptyObsList(obsList)
   }
 
   private val validate = Option(System.getProperty("edu.gemini.model.p1.validate")).isDefined
@@ -88,8 +87,8 @@ object Proposal {
     // Make sure we have one observation for bands 1/2, and one for band 3.
     val band12missing = !olist.exists(o => o.band === M.Band.BAND_1_2 && o.nonEmpty)
     val band3missing  = !olist.exists(o => o.band === M.Band.BAND_3 && o.nonEmpty)
-    (band12missing ? List(Observation.empty) | olist.filter(_.band === Band.BAND_1_2)) ++
-       (band3missing ? List(Observation.emptyBand3) | olist.filter(_.band === Band.BAND_3))
+    (band12missing ? List(Observation.empty) | olist.filter(o => o.nonEmpty && o.band === Band.BAND_1_2)) ++
+       (band3missing ? List(Observation.emptyBand3) | olist.filter(o =>  o.nonEmpty && o.band === Band.BAND_3))
   }
 }
 


### PR DESCRIPTION
This should fix the issues that Andy discovered that arose when I tried to enhance the template to both 1/2 and 3 bands.

Specifically:

1. Band-3 problems (such as missing target) were being reported as problems even if Band 3 had not been selected.

2. I believe I fixed the UI so that elements merge together as they did before, automatically.

3. Drag and drop should now work as expected.

4. Same with new (conditions | resource |  target | timing info) and delete buttons.