### PR TITLE
REL-3485: Hid F2 MOS for 2019A and set up errors.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Flamingos2.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Flamingos2.scala
@@ -3,6 +3,9 @@ package edu.gemini.model.p1.dtree.inst
 import edu.gemini.model.p1.dtree._
 import edu.gemini.model.p1.immutable._
 
+import scalaz._
+import Scalaz._
+
 object Flamingos2 {
 
   object F2Mode extends Enumeration {
@@ -11,6 +14,7 @@ object Flamingos2 {
     val Mos      = Value("Multi-object Spectroscopy")
     type F2Mode = Value
   }
+  implicit val F2ModeEq: Equal[F2Mode.Value] = Equal.equalA[F2Mode.Value]
 
   import F2Mode._
 
@@ -34,7 +38,8 @@ object Flamingos2 {
   class ModeNode extends SingleSelectNode[Unit, F2Mode, Unit](()) {
     val title       = "Select Instrument Mode"
     val description = "Flamingos2 can be used for both imaging and spectroscopy."
-    def choices     = F2Mode.values.toList
+    // REL-3485: MOS is not available in 2019A.
+    def choices     = F2Mode.values.toList.filterNot(_ === Mos)
 
     def apply(m: F2Mode) = m match {
       case Imaging   => Left(new ImagingFilterNode)

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -150,7 +150,14 @@ case object SemesterConverter2018BTo2019A extends SemesterConverter {
     case a @ <altair>{ns@_*}</altair> if (a \\ "lgs").nonEmpty =>
       StepResult(s"Altair Laser Guidestar is currently not offered", a).successNel
   }
-  override val transformers = List(altairLgsNotAvailable)
+
+  // REL-3485: F2 MOS not available for 2019A.
+  val f2MOSNotAvailable: TransformFunction = {
+    case f @ <flamingos2>{ns @ _*}</flamingos2> if (f \ "mos").nonEmpty =>
+      StepResult("Flamingos2 Multi-Object Spectroscopy is not offered", f).successNel
+  }
+
+  override val transformers = List(altairLgsNotAvailable, f2MOSNotAvailable)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -787,7 +787,8 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 4
+          changes must have length 5
+          changes must contain("Flamingos2 Multi-Object Spectroscopy is not offered")
           result \\ "flamingos2" must not(\\("filter") \> "J-lo (1.122 um)")
           result \\ "flamingos2" must not(\\("filter") \> "Y (1.020 um)")
           result \\ "flamingos2" must not(\\("name") \>~ ".*Y (1.020 um).*")

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -84,7 +84,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           List(incompleteInvestigator, missingObsElementCheck, emptyTargetCheck,
             emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck, altairLgsCheck,
             badGuiding, cwfsCorrectionsIssue, badVisibility, iffyVisibility, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsIQ70Check, lgsGemsIQ85Check,
-            lgsCC50Check, texesCCCheck, texesWVCheck, gmosWVCheck, gmosR600Check, band3IQ, band3LGS, band3RapidToO, sbIrObservation).flatten
+            lgsCC50Check, texesCCCheck, texesWVCheck, gmosWVCheck, gmosR600Check, f2MOSCheck, band3IQ, band3LGS, band3RapidToO, sbIrObservation).flatten
       ps.sorted
     }
 
@@ -290,6 +290,13 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           if gmosNDisperser(b, GmosNDisperser.R600) || gmosSDisperser(b, GmosSDisperser.R600)
         } yield new Problem(Severity.Warning, s"The R600 is little used and may be difficult to schedule.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
     }
+
+    private val f2MOSCheck = for {
+      o <- p.nonEmptyObservations
+      b <- o.blueprint
+      if b.isInstanceOf[Flamingos2BlueprintMos]
+    } yield new Problem(Severity.Error, "Flamingos2 Multi-Object Spectroscopy is not offered.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
+
 
     def isBand3(o: Observation) = o.band == Band.BAND_3 && (p.proposalClass match {
                   case q: QueueProposalClass if q.band3request.isDefined => true

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -293,8 +293,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
 
     private val f2MOSCheck = for {
       o <- p.nonEmptyObservations
-      b <- o.blueprint
-      if b.isInstanceOf[Flamingos2BlueprintMos]
+      b <- o.blueprint.collect { case mos: Flamingos2BlueprintMos => mos }
     } yield new Problem(Severity.Error, "Flamingos2 Multi-Object Spectroscopy is not offered.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
 
 


### PR DESCRIPTION
F2 MOS mode is not being offered in 2019A.

This PR:

1. Hides MOS mode from the mode configuration dialog;

2. Reports an error in the upconverter for 2019A if an observation is in F2 MOS mode;

3. Includes this check in a test case; and

4. Reports an error in the "problems" section as long as an F2 MOS observation exists, preventing proposal submission.
