### PR TITLE
Fixes for TPE image handling.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageDisplayFrame.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageDisplayFrame.java
@@ -58,5 +58,19 @@ public class TpeImageDisplayFrame extends ImageDisplayControlFrame {
         return tpeToolBar;
     }
 
+    /**
+     * usage: java TpeImageDisplayFrame [fileOrUrl]
+     */
+    public static void main(String[] args) {
+        String fileOrUrl = null;
+
+        if (args.length >= 1)
+            fileOrUrl = args[0];
+
+        ImageDisplayControlFrame frame = new TpeImageDisplayFrame(fileOrUrl);
+
+        frame.setVisible(true);
+    }
+
 }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/image/fits/codec/FITSDataDouble.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/image/fits/codec/FITSDataDouble.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.nio.DoubleBuffer;
 import java.nio.MappedByteBuffer;
 
-import javax.media.jai.DataBufferDouble;
+import java.awt.image.DataBufferDouble;
 
 // -------------------------------------------------------------------
 // Note: The FITSData<type> classes can be generated from FITSDataDouble

--- a/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImageDisplayControl.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImageDisplayControl.java
@@ -16,7 +16,7 @@ import jsky.util.I18N;
  * @version $Revision: 5923 $
  * @author Allan Brighton
  */
-public class ImageDisplayControl extends JPanel {
+public abstract class ImageDisplayControl extends JPanel {
 
     // Used to access internationalized strings (see i18n/gui*.properties)
     private static final I18N _I18N = I18N.getInstance(ImageDisplayControl.class);
@@ -84,9 +84,7 @@ public class ImageDisplayControl extends JPanel {
     }
 
     /** Make and return the image display window */
-    protected TpeImageWidget makeImageDisplay() {
-        return (TpeImageWidget)new DivaMainImageDisplay(parent);
-    }
+    protected abstract TpeImageWidget makeImageDisplay();
 
     /**
      * Make and return the pan window.

--- a/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImageDisplayControlFrame.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/image/gui/ImageDisplayControlFrame.java
@@ -18,7 +18,7 @@ import jsky.util.Preferences;
  * @version $Revision: 5923 $
  * @author Allan Brighton
  */
-public class ImageDisplayControlFrame extends JFrame {
+public abstract class ImageDisplayControlFrame extends JFrame {
 
     // Used to access internationalized strings (see i18n/gui*.properties)
     private static final I18N _I18N = I18N.getInstance(ImageDisplayControlFrame.class);
@@ -119,22 +119,6 @@ public class ImageDisplayControlFrame extends JFrame {
      *
      * @param size the size (width, height) to use for the pan and zoom windows.
      */
-    protected ImageDisplayControl makeImageDisplayControl(int size) {
-        return new ImageDisplayControl(this, size);
-    }
+    protected abstract ImageDisplayControl makeImageDisplayControl(int size);
 
-    /**
-     * usage: java ImageDisplayControlFrame [fileOrUrl]
-     */
-    public static void main(String[] args) {
-        String fileOrUrl = null;
-        int size = ImagePanner.DEFAULT_SIZE;
-
-        if (args.length >= 1)
-            fileOrUrl = args[0];
-
-        ImageDisplayControlFrame frame = new ImageDisplayControlFrame(size, fileOrUrl);
-
-        frame.setVisible(true);
-    }
 }


### PR DESCRIPTION
These are some fixes to bugs I found when prototyping a mosaic service for 2MASS images.

I tried to open a Montage-generated FITS image and immediately ran into destruction.

- `ImageDisplayControlFrame` and `ImageDisplayControl` need to be abstract … the constructor does some downcasting that only works if you're using the one and only subclass `TpeImageDisplayFrame`. So I made them abstract and moved the non-functioning `main` method.
- `FITSDataDouble` was downcasting to a JAI class that has since appeared in `java.awt`, I guess. Changing it to use the AWT class instead made it work. No idea.
- We couldn't deal with FITS images with double-precision data so I copy/pasted the handler for `Float` to deal with it. Seems to work.

**Late addition:** I also noticed that every image request was getting sent twice, once for the headers (to determine the content type and encoding) and again to fetch the actual data. So I fixed that.
