### PR TITLE
REL-3493: Hide CFH option from classical observing.

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -78,6 +78,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           keywordCheck, attachmentCheck, attachmentValidityCheck, attachmentSizeCheck, missingObsDetailsCheck,
           duplicateInvestigatorCheck, ftReviewerOrMentor, ftAffiliationMismatch, band3Obs).flatten ++
           TimeProblems(p, s).all ++
+          TimeProblems.noCFHClassical(p, s) ++
           TimeProblems.partnerZeroTimeRequest(p, s) ++
           TacProblems(p, s).all ++
           Semester2018BProblems(p, s).all ++
@@ -693,6 +694,13 @@ object TimeProblems {
       }
 
   val SCHEDULING_SECTION = "Time Requests"
+
+  // REL-3493: All CFH exchange time will now be done in queue.
+  def noCFHClassical(p: Proposal, s: ShellAdvisor): Option[ProblemRobot.Problem] = p.proposalClass match {
+    case ClassicalProposalClass(_, _, _, Right(ExchangeSubmission(_, _, ExchangePartner.CFH, _)), _) =>
+      Some(new Problem(Severity.Error, "All CFH exchange time will now be done in queue.", SCHEDULING_SECTION, s.inPartnersView(_.editProposalClass())))
+    case _ => None
+  }
 
   // REL-2032 Check that none of the requested times per partner are zero
   def partnerZeroTimeRequest(p: Proposal, s:ShellAdvisor): List[ProblemRobot.Problem] = p.proposalClass match {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/PartnerView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/PartnerView.scala
@@ -999,7 +999,6 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
                 case ExchangeKeck   => c.copy(subs = Right(localKeck))
                 case ExchangeSubaru => c.copy(subs = Right(localSubaru))
                 case _              => c.copy(subs = Left(localGemini))
-                //case ExchangeCFH    => c.copy(subs = Right(localCFH))
               }
             case e:ExchangeProposalClass  =>
               selection.item match {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/PartnerView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/PartnerView.scala
@@ -903,8 +903,9 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
       case _: ClassicalProposalClass => true
     }
 
-    // Request type selector. This one is kind of complicated
-    object partnerType extends ComboBox(PartnerType.values.toSeq) with Bound[Proposal, ProposalClass] {
+    // Request type selector. This one is kind of complicated, especially after REL-3943, which requires filtering
+    // out CHF for classical observations.
+    object partnerType extends ComboBox[PartnerType.Value](PartnerType.values.toSeq) with Bound[Proposal, ProposalClass] {
 
       val lens = Proposal.proposalClass
 
@@ -914,9 +915,30 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
       var localSubaru = ExchangeSubmission(SubmissionRequest.empty, None, ExchangePartner.SUBARU, InvestigatorRef.empty)
       var localCFH    = ExchangeSubmission(SubmissionRequest.empty, None, ExchangePartner.CFH, InvestigatorRef.empty)
 
-      override def refresh(m:Option[ProposalClass]) {
+      override def refresh(m:Option[ProposalClass]): Unit = {
+
         // Enabled?
         enabled = canEdit
+
+        // Update items.
+        deafTo(selection)
+          def updateComboBoxModel(includeCFH: Boolean): Unit = {
+            val newModel = new DefaultComboBoxModel[PartnerType.Value]()
+            newModel.addElement(PartnerType.GeminiPartner)
+            if (includeCFH)
+              newModel.addElement(PartnerType.ExchangeCFH)
+            newModel.addElement(PartnerType.ExchangeKeck)
+            newModel.addElement(PartnerType.ExchangeSubaru)
+            peer.setModel(newModel)
+          }
+          m.foreach { p =>
+            val item = peer.getSelectedItem
+            val wasCFH = peer.getSelectedItem == PartnerType.ExchangeCFH
+            updateComboBoxModel(header.proposalClass.peer.getSelectedItem != ProposalClassSelection.Classical)
+            if (proposalClass.peer.getSelectedItem == ProposalClassSelection.Classical && wasCFH)
+              peer.setSelectedIndex(0)
+            else peer.setSelectedItem(item)
+        }
 
         // Update visibility
         visible = ~m.map {
@@ -934,7 +956,7 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
           case ClassicalProposalClass(_, _, _, Left(ngos), _)                                      => localGemini = ngos
           case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.KECK   => localKeck = e
           case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.SUBARU => localSubaru = e
-          case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.CFH    => localCFH= e
+          case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.CFH    => localGemini = Nil
           case e: ExchangeProposalClass                                                            => localGemini = e.subs
           case _                                                                                   => // ignore
         }
@@ -948,7 +970,7 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
           case ClassicalProposalClass(_, _, _, Left(_), _)                                         => GeminiPartner
           case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.KECK   => ExchangeKeck
           case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.SUBARU => ExchangeSubaru
-          case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.CFH    => ExchangeCFH
+          case ClassicalProposalClass(_, _, _, Right(e), _) if e.partner == ExchangePartner.CFH    => GeminiPartner
           case _: ExchangeProposalClass                                                            => GeminiPartner
           case _: SpecialProposalClass                                                             => GeminiPartner
           case _: LargeProgramClass                                                                => GeminiPartner
@@ -956,11 +978,13 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
           case _: FastTurnaroundProgramClass                                                       => GeminiPartner
         }.getOrElse(PartnerType.GeminiPartner)
 
+        listenTo(selection)
       }
 
       // When the user changes the selection...
       selection.reactions += {
         case SelectionChanged(_) =>
+          if (selection.item != null)
           model = model.map {
             case q:QueueProposalClass     =>
               selection.item match {
@@ -974,7 +998,8 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
                 case GeminiPartner  => c.copy(subs = Left(localGemini))
                 case ExchangeKeck   => c.copy(subs = Right(localKeck))
                 case ExchangeSubaru => c.copy(subs = Right(localSubaru))
-                case ExchangeCFH    => c.copy(subs = Right(localCFH))
+                case _              => c.copy(subs = Left(localGemini))
+                //case ExchangeCFH    => c.copy(subs = Right(localCFH))
               }
             case e:ExchangeProposalClass  =>
               selection.item match {
@@ -1140,6 +1165,10 @@ class PartnerView extends BorderPanel with BoundView[Proposal] {view =>
       case _: FastTurnaroundSubmission          => header.specialTime.edit.doClick()
       case ps: PartnerSubmission[_,_]           => list.edit(ps)
     }
+  }
+
+  def editProposalClass(): Unit = {
+    header.proposalClass.requestFocusInWindow()
   }
 
   def editBand3Time() {


### PR DESCRIPTION
Classical observing with CFH is no longer available: it will  now be done in queue mode.

This PR, as a result:

1. Upconverts  an older classical proposal with CFH to a queue proposal with CFH.

2. Issues an error in the Problems section if  Classical + CFH somehow simultaneously become both selected in the model. (This should never happen.)

3. Changes  the contents of the Request Type combo box to disinclude "Exchange Request (CFH PIs)" when the proposal class is classical.

4. If the Request Type combo box is set to "Exchange Request (CFH PIs)" and the user changes the Proposal Class to Classical, the Request Type is set to "Gemini Partner Request" (the first thing in the Request Type list).