### PR TITLE
REL-3495: Preparing PIT for 2019A release.

### DIFF
--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -44,7 +44,7 @@ def common(pv: Version) = AppConfig(
     // line out for PIT production releases.
     // (I think it seems to work if you quit sbt, change it, restart sbt,
     // clean, compile, and then build the PIT.)
-    "edu.gemini.pit.test"                     -> "true",
+    //"edu.gemini.pit.test"                     -> "true",
     
     "edu.gemini.ags.host"                     -> "gnauxodb.gemini.edu",
     "edu.gemini.ags.port"                     -> "8443"

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization in Global := "edu.gemini.ocs"
 
 ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2019A", true, 1, 1, 0)
+pitVersion in ThisBuild := OcsVersion("2019A", false, 1, 1, 0)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion

--- a/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2019A.xml
+++ b/bundle/edu.gemini.p1monitor/src/main/resources/edu/gemini/p1monitor/config/conf.production-2019A.xml
@@ -6,92 +6,92 @@
     <bcc>sraaphorst@gemini.edu</bcc>
 
     <type name="FastTurnaround">
-        <dir>/home/software/test_proposals/fast_turnaround/proposals/2019A</dir>
+        <dir>/home/software/proposals/fast_turnaround/proposals/2019A</dir>
         <to>pitft@gemini.edu</to>
     </type>
 
     <type name="DirectorTime">
-        <dir>/home/software/test_proposals/directors_time/proposals/2019A</dir>
+        <dir>/home/software/proposals/directors_time/proposals/2019A</dir>
         <to>pitdd@gemini.edu</to>
         <template>dt</template>
     </type>
 
     <type name="PoorWeather">
-        <dir>/home/software/test_proposals/poor_weather/proposals/2019A</dir>
+        <dir>/home/software/proposals/poor_weather/proposals/2019A</dir>
         <to>pitpw@gemini.edu</to>
         <template>pw</template>
     </type>
 
     <type name="DemoScience">
-        <dir>/home/software/test_proposals/demo_science/proposals/2019A</dir>
+        <dir>/home/software/proposals/demo_science/proposals/2019A</dir>
         <to>pitds@gemini.edu</to>
     </type>
 
     <type name="SystemVerification">
-        <dir>/home/software/test_proposals/system_verification/proposals/2019A</dir>
+        <dir>/home/software/proposals/system_verification/proposals/2019A</dir>
         <to>pitsv@gemini.edu</to>
     </type>
 
     <type name="LargeProgram">
-        <dir>/home/software/test_proposals/large_program/proposals/2019A</dir>
+        <dir>/home/software/proposals/large_program/proposals/2019A</dir>
         <to>pitlp@gemini.edu</to>
     </type>
 
     <type name="SIP">
-        <dir>/home/software/test_proposals/subaru_intensive_program/proposals/2019A</dir>
+        <dir>/home/software/proposals/subaru_intensive_program/proposals/2019A</dir>
         <to>pitlp@gemini.edu</to>
     </type>
 
     <type name="ar">
-        <dir>/home/software/test_proposals/ar/proposals/2019A</dir>
+        <dir>/home/software/proposals/ar/proposals/2019A</dir>
         <to>pit.ar@gemini.edu</to>
     </type>
 
     <type name="au">
-        <dir>/home/software/test_proposals/au/proposals/2019A</dir>
+        <dir>/home/software/proposals/au/proposals/2019A</dir>
         <to>pit.au@gemini.edu</to>
         <template>au</template>
     </type>
 
     <type name="br">
-        <dir>/home/software/test_proposals/br/proposals/2019A</dir>
+        <dir>/home/software/proposals/br/proposals/2019A</dir>
         <to>pit.br@gemini.edu</to>
     </type>
 
     <type name="ca">
-        <dir>/home/software/test_proposals/ca/proposals/2019A</dir>
+        <dir>/home/software/proposals/ca/proposals/2019A</dir>
         <to>pit.ca@gemini.edu</to>
     </type>
 
     <type name="cfh">
-        <dir>/home/software/test_proposals/cfh/proposals/2019A</dir>
+        <dir>/home/software/proposals/cfh/proposals/2019A</dir>
         <to>pit.cfh@gemini.edu</to>
     </type>
 
     <type name="cl">
-        <dir>/home/software/test_proposals/cl/proposals/2019A</dir>
+        <dir>/home/software/proposals/cl/proposals/2019A</dir>
         <to>pit.cl@gemini.edu</to>
         <template>cl</template>
     </type>
 
     <type name="kr">
-        <dir>/home/software/test_proposals/kr/proposals/2019A</dir>
+        <dir>/home/software/proposals/kr/proposals/2019A</dir>
         <to>pit.kr@gemini.edu</to>
     </type>
 
     <type name="uh">
-        <dir>/home/software/test_proposals/uh/proposals/2019A</dir>
+        <dir>/home/software/proposals/uh/proposals/2019A</dir>
         <to>pit.uh@gemini.edu</to>
     </type>
 
     <type name="us">
-        <dir>/home/software/test_proposals/us/proposals/2019A</dir>
+        <dir>/home/software/proposals/us/proposals/2019A</dir>
         <to>pit.us@gemini.edu</to>
         <template>us</template>
     </type>
 
     <type name="subaru">
-        <dir>/home/software/test_proposals/subaru/proposals/2019A</dir>
+        <dir>/home/software/proposals/subaru/proposals/2019A</dir>
         <to>pit.subaru@gemini.edu</to>
     </type>
 


### PR DESCRIPTION
This makes the changes to prepare for the 2019A actual PIT release, instead of the test releases.

Based off previous PR to do the same for 2018B:

https://github.com/gemini-hlsw/ocs/commit/2de0681b744a036dba5c944d68cee37fb6ed2fe1