### PR TITLE
REL-1958: ICTD / QV Integration

### DIFF
--- a/bundle/edu.gemini.ictd/build.sbt
+++ b/bundle/edu.gemini.ictd/build.sbt
@@ -23,6 +23,8 @@ osgiSettings
 
 ocsBundleSettings
 
+OsgiKeys.bundleActivator := Some("edu.gemini.ictd.service.osgi.Activator")
+
 OsgiKeys.bundleSymbolicName := name.value
 
 OsgiKeys.dynamicImportPackage := Seq("*")

--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/IctdDatabase.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/IctdDatabase.scala
@@ -1,7 +1,7 @@
 package edu.gemini.ictd
 
 import edu.gemini.spModel.core.Site
-import edu.gemini.spModel.ictd.Availability
+import edu.gemini.spModel.ictd.{ Availability, CustomMaskKey }
 
 import doobie.imports._
 

--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/dao/CustomMaskDao.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/dao/CustomMaskDao.scala
@@ -4,7 +4,7 @@ import edu.gemini.ictd._
 import edu.gemini.pot.sp.Instrument
 import edu.gemini.pot.sp.Instrument._
 import edu.gemini.spModel.core.{ProgramId, Site}
-import edu.gemini.spModel.ictd.Availability
+import edu.gemini.spModel.ictd.{CustomMaskKey, Availability}
 
 import doobie.imports._
 

--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/Activator.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/Activator.scala
@@ -63,6 +63,8 @@ class Activator extends BundleActivator {
 
         Some(t)
     }
+
+    tracker.foreach(_.open())
   }
 
   override def stop(ctx: BundleContext): Unit = {

--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/Activator.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/Activator.scala
@@ -1,0 +1,100 @@
+package edu.gemini.ictd.service.osgi
+
+import edu.gemini.ictd.IctdDatabase
+import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.spModel.ictd.IctdService
+import edu.gemini.util.osgi.SecureServiceFactory
+import edu.gemini.util.osgi.SecureServiceFactory._
+import edu.gemini.util.osgi.Tracker._
+
+import org.osgi.framework.{ Bundle, BundleActivator, BundleContext, ServiceRegistration }
+import org.osgi.util.tracker.ServiceTracker
+
+import java.security.Principal
+import java.util.logging.Logger
+
+import scalaz._
+import Scalaz._
+
+/**
+ * An activator for the ICTD bundle that creates IctdService instances on
+ * demand.
+ */
+class Activator extends BundleActivator {
+  import Activator._
+
+  private var tracker: Option[ServiceTracker[_,_]] = None
+
+  override def start(ctx: BundleContext): Unit = {
+
+    // Extract the named property value or throw an exception if not present.
+    def prop(name: String): String =
+      Option(ctx.getProperty(name)).getOrElse {
+        val msg = s"Missing bundle property $name"
+        Log.severe(msg)
+        sys.error(msg)
+      }
+
+    tracker = Mode(ctx) match {
+
+      case Api     =>
+        Log.info("Starting edu.gemini.ictd in Api mode")
+        None
+
+      case Service =>
+        Log.info("Starting edu.gemini.ictd in Service mode")
+
+        val user = prop(IctdUserProp)
+        val pass = prop(IctdPassProp)
+        val gn   = IctdDatabase.Configuration(prop(IctdGnProp), user, pass)
+        val gs   = IctdDatabase.Configuration(prop(IctdGsProp), user, pass)
+
+        val t = track[IDBDatabaseService, (() => Unit)](ctx) { odb =>
+          val factory = new SecureServiceFactory[IctdService] {
+            def getService(ps: Set[Principal]): IctdService =
+              IctdServiceImpl.service(odb, gn, gs, ps)
+          }
+
+          Log.info("Registering IctdService")
+          val reg = ctx.registerSecureService(factory, Map("trpc" -> ""))
+
+          () => reg.unregister()
+        } { _.apply() }
+
+        Some(t)
+    }
+  }
+
+  override def stop(ctx: BundleContext): Unit = {
+    Log.info("Stopping edu.gemini.ictd")
+    tracker.foreach(_.close())
+    tracker = None
+  }
+}
+
+object Activator {
+  val Log: Logger = Logger.getLogger(classOf[Activator].getName)
+
+  val IctdModeProp: String = "edu.gemini.ictd.mode"
+  val IctdPassProp: String = "edu.gemini.ictd.password"
+  val IctdUserProp: String = "edu.gemini.ictd.user"
+  val IctdGnProp: String   = "edu.gemini.ictd.gn"
+  val IctdGsProp: String   = "edu.gemini.ictd.gs"
+
+  /**
+   * Bundle mode, either "api" or "service".  If "api" nothing is started or
+   * registered (this is the default).  If "service" then register a secure
+   * service factory for creating IctdService on demand.
+   */
+  sealed abstract class Mode(val name: String)
+  case object Api     extends Mode("api")
+  case object Service extends Mode("service")
+
+  val AllModes = List(Api, Service)
+
+  object Mode {
+    def apply(ctx: BundleContext): Mode =
+      Option(ctx.getProperty(IctdModeProp)).flatMap(s => AllModes.find(_.name === s)) | Api
+  }
+
+}

--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/IctdServiceImpl.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/IctdServiceImpl.scala
@@ -1,0 +1,57 @@
+package edu.gemini.ictd.service.osgi
+
+import java.security.{AccessControlException, Permission, Principal}
+
+import edu.gemini.ictd.IctdDatabase
+import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.spModel.core.Site
+import edu.gemini.spModel.ictd.{IctdService, IctdSummary}
+import edu.gemini.util.security.permission.StaffPermission
+import edu.gemini.util.security.policy.ImplicitPolicy
+
+import scalaz.effect.IO
+
+/**
+ * A service that runs in the ODB and conducts ICTD queries on behalf of ODB
+ * clients.  The service is configured with user/password information from the
+ * ODB OSGI activator so that this information isn't distributed to clients like
+ * the OT and QPT.
+ */
+object IctdServiceImpl {
+
+  /**
+   * The service method creates the service via a registered OSGi secure service
+   * factory (see the Activator start method for more information).
+   */
+  def service(
+    db: IDBDatabaseService,
+    gn: IctdDatabase.Configuration,
+    gs: IctdDatabase.Configuration,
+    ps: Set[Principal]
+  ): IctdService =
+
+    new IctdService {
+
+      def config(site: Site): IctdDatabase.Configuration =
+        site match {
+          case Site.GN => gn
+          case Site.GS => gs
+        }
+
+      def withPermission[A](p: Permission)(a: => IO[A]): IO[A] =
+        ImplicitPolicy.hasPermission(db, ps, p).flatMap { b =>
+          if (b) a else IO.throwIO[A](new AccessControlException("permission needed to access ICTD"))
+        }
+
+      def action(site: Site): IO[IctdSummary] =
+        withPermission(StaffPermission(None)) {
+          for {
+            fa <- IctdDatabase.feature.select(config(site))
+            ms <- IctdDatabase.mask.select(config(site), site)
+          } yield IctdSummary(fa.availabilityMap(site).enumMap, ms)
+        }
+
+      override def summary(site: Site): IctdSummary =
+        action(site).unsafePerformIO
+    }
+}

--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/IctdServiceImpl.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/IctdServiceImpl.scala
@@ -52,6 +52,6 @@ object IctdServiceImpl {
         }
 
       override def summary(site: Site): IctdSummary =
-        action(site).unsafePerformIO
+        action(site).unsafePerformIO()
     }
 }

--- a/bundle/edu.gemini.ictd/src/test/scala/edu/gemini/ictd/CustomMaskKeySpec.scala
+++ b/bundle/edu.gemini.ictd/src/test/scala/edu/gemini/ictd/CustomMaskKeySpec.scala
@@ -1,6 +1,7 @@
 package edu.gemini.ictd
 
 import edu.gemini.spModel.core.{ProgramType, Site, ProgramId, ProgramIdGen}
+import edu.gemini.spModel.ictd.CustomMaskKey
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/spdb/osgi/Activator.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/spdb/osgi/Activator.java
@@ -34,6 +34,17 @@ public class Activator implements BundleActivator {
      */
     public static final String BUNDLE_PROP_DIR = "edu.gemini.spdb.dir";
 
+    /**
+     * Bundle property specifying the ICTD database user.
+     */
+    public static final String ICTD_USER_PROP = "edu.gemini.ictd.user";
+
+    /**
+     * Bundle property specifying the ICTD database password.
+     */
+    public static final String ICTD_PASS_PROP = "edu.gemini.ictd.password";
+
+
     // Mutable state
     private DatabaseLoader loader;
 
@@ -95,11 +106,11 @@ public class Activator implements BundleActivator {
             this.db = db;
 
             LOGGER.info("Exporting database to OSGi.");
-            final Dictionary<String, Object> properties1 = new Hashtable<String, Object>();
+            final Dictionary<String, Object> properties1 = new Hashtable<>();
             dbReg = ctx.registerService(IDBDatabaseService.class, db, properties1);
 
             LOGGER.info("Exporting query runner to OSGi and TRPC.");
-            final Dictionary<String, Object> properties2 = new Hashtable<String, Object>();
+            final Dictionary<String, Object> properties2 = new Hashtable<>();
             properties2.put("trpc", ""); // publish just the QueryRunner as TRPC service
             // A factory to make a new query runner for each TRPC user
             final SecureServiceFactoryForJava<IDBQueryRunner> factory = new SecureServiceFactoryForJava<IDBQueryRunner>() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/spdb/osgi/Activator.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/spdb/osgi/Activator.java
@@ -34,17 +34,6 @@ public class Activator implements BundleActivator {
      */
     public static final String BUNDLE_PROP_DIR = "edu.gemini.spdb.dir";
 
-    /**
-     * Bundle property specifying the ICTD database user.
-     */
-    public static final String ICTD_USER_PROP = "edu.gemini.ictd.user";
-
-    /**
-     * Bundle property specifying the ICTD database password.
-     */
-    public static final String ICTD_PASS_PROP = "edu.gemini.ictd.password";
-
-
     // Mutable state
     private DatabaseLoader loader;
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/CustomMaskKey.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/CustomMaskKey.scala
@@ -1,9 +1,6 @@
-package edu.gemini.ictd
+package edu.gemini.spModel.ictd
 
-import edu.gemini.spModel.core.{ ProgramId, Site }
-import edu.gemini.spModel.ictd.Availability
-
-import scala.collection.immutable.TreeMap
+import edu.gemini.spModel.core.ProgramId
 
 import scalaz._
 import Scalaz._

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/CustomMaskKey.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/CustomMaskKey.scala
@@ -46,7 +46,7 @@ object CustomMaskKey {
     parse(s).getOrElse(sys.error(s"Could not parse $s as a CustomMaskKey"))
 
   implicit val OrderingCustomMaskKey: scala.math.Ordering[CustomMaskKey] =
-    scala.math.Ordering.by(k => (k.id.siteVal, k.id.semesterVal, k.id.ptypeVal, k.id.index, k.index))
+    scala.math.Ordering.by(k => (k.id, k.index))
 
   implicit val OrderCustomMaskKey: Order[CustomMaskKey] =
     Order.fromScalaOrdering

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdService.scala
@@ -1,0 +1,12 @@
+package edu.gemini.spModel.ictd
+
+import edu.gemini.spModel.core.Site
+
+/**
+ *
+ */
+trait IctdService {
+
+  def summary(site: Site): IctdSummary
+
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdService.scala
@@ -3,10 +3,13 @@ package edu.gemini.spModel.ictd
 import edu.gemini.spModel.core.Site
 
 /**
- *
+ * A minimal service that obtains ICTD availability information for ODB clients.
  */
 trait IctdService {
 
+  /**
+   * Produces ICTD availability information for the given site.
+   */
   def summary(site: Site): IctdSummary
 
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdSummary.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdSummary.scala
@@ -29,26 +29,4 @@ object IctdSummary {
 
     IctdSummary(f.asScala.toMap, TreeMap(m.asScala.toList: _*))
 
-  /*
-  val Feature: String = "feature"
-  val Mask:    String = "mask"
-  val Entry:   String = "entry"
-  val Avail:   String = "avail"
-  val Name:    String = "name"
-  val Class:   String = "class"
-
-  def apply(params: ParamSet): IctdSummary = {
-
-  }
-
-  private def enumParamSet(factory: PioFactory, name: String, e: Enum[_]): ParamSet = {
-    val params = factory.createParamSet(name)
-    Pio.addParam(factory, params, Class, e.getClass.getName)
-    Pio.addParam(factory, params, Name,  e.name)
-    params
-  }
-
-  private
-  */
-
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdSummary.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdSummary.scala
@@ -1,0 +1,47 @@
+package edu.gemini.spModel.ictd
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.TreeMap
+
+/**
+ * All feature and mask availability data extracted from the ICTD in format
+ * suitable for use by the QPT and QVis.
+ */
+final case class IctdSummary(
+  featureAvailability: Map[java.lang.Enum[_], Availability],
+  maskAvailability:    TreeMap[CustomMaskKey, Availability]
+) {
+
+  def featureAvailabilityJava: java.util.Map[java.lang.Enum[_], Availability] =
+    featureAvailability.asJava
+
+  def maskAvailabilityJava: java.util.Map[CustomMaskKey, Availability] =
+    maskAvailability.asJava
+
+}
+
+object IctdSummary {
+
+  /*
+  val Feature: String = "feature"
+  val Mask:    String = "mask"
+  val Entry:   String = "entry"
+  val Avail:   String = "avail"
+  val Name:    String = "name"
+  val Class:   String = "class"
+
+  def apply(params: ParamSet): IctdSummary = {
+
+  }
+
+  private def enumParamSet(factory: PioFactory, name: String, e: Enum[_]): ParamSet = {
+    val params = factory.createParamSet(name)
+    Pio.addParam(factory, params, Class, e.getClass.getName)
+    Pio.addParam(factory, params, Name,  e.name)
+    params
+  }
+
+  private
+  */
+
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdSummary.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdSummary.scala
@@ -4,7 +4,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeMap
 
 /**
- * All feature and mask availability data extracted from the ICTD in format
+ * All feature and mask availability data extracted from the ICTD in a format
  * suitable for use by the QPT and QVis.
  */
 final case class IctdSummary(

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdSummary.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/IctdSummary.scala
@@ -22,6 +22,13 @@ final case class IctdSummary(
 
 object IctdSummary {
 
+  def fromJava(
+    f: java.util.Map[java.lang.Enum[_], Availability],
+    m: java.util.Map[CustomMaskKey, Availability]
+  ): IctdSummary =
+
+    IctdSummary(f.asScala.toMap, TreeMap(m.asScala.toList: _*))
+
   /*
   val Feature: String = "feature"
   val Mask:    String = "mask"

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
@@ -1,6 +1,6 @@
 package edu.gemini.qpt.core;
 
-import edu.gemini.ictd.CustomMaskKey;
+import edu.gemini.spModel.ictd.CustomMaskKey;
 import edu.gemini.qpt.core.listeners.Listeners;
 import edu.gemini.qpt.core.util.*;
 import edu.gemini.qpt.core.util.Variants.EditException;
@@ -15,7 +15,6 @@ import edu.gemini.skycalc.TwilightBoundedNight;
 import static edu.gemini.skycalc.TwilightBoundType.CIVIL;
 import static edu.gemini.skycalc.TwilightBoundType.NAUTICAL;
 import edu.gemini.shared.util.immutable.DefaultImList;
-import edu.gemini.shared.util.immutable.ImList;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.Site;
@@ -36,7 +35,6 @@ import edu.gemini.spModel.gemini.trecs.TReCSParams;
 import edu.gemini.spModel.pio.Param;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
-import edu.gemini.spModel.pio.PioPath;
 import edu.gemini.spModel.pio.PioFactory;
 import jsky.coords.WorldCoordinates;
 import jsky.util.DateUtil;

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Variant.java
@@ -1,6 +1,6 @@
 package edu.gemini.qpt.core;
 
-import edu.gemini.ictd.CustomMaskKey;
+import edu.gemini.spModel.ictd.CustomMaskKey;
 import edu.gemini.qpt.core.Marker.Severity;
 import edu.gemini.qpt.core.util.*;
 import edu.gemini.qpt.core.util.Interval.Overlap;

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/EmptyIctdListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/EmptyIctdListener.java
@@ -18,7 +18,7 @@ public final class EmptyIctdListener extends MarkerModelListener<Schedule> {
 
         mm.clearMarkers(this, s);
 
-        if (s.getIctd().isEmpty()) {
+        if (s.getIctdSummary().isEmpty()) {
             mm.addMarker(true, this, Severity.Warning, "ICTD information unavailable.", s);
         }
     }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/osgi/Activator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/osgi/Activator.java
@@ -10,12 +10,10 @@ import java.util.Hashtable;
 import java.util.logging.Logger;
 
 import edu.gemini.ags.conf.ProbeLimitsTable;
-import edu.gemini.ictd.IctdDatabase;
 
 import edu.gemini.qpt.core.util.LttsServicesClient;
 
 import edu.gemini.qpt.ui.action.PublishAction;
-import edu.gemini.qpt.shared.sp.Ictd;
 
 import edu.gemini.spModel.core.Version;
 import edu.gemini.util.security.auth.keychain.KeyChain;
@@ -48,29 +46,6 @@ public final class Activator implements BundleActivator {
     private static final String PROP_USER = "edu.gemini.qpt.ui.action.destination.user";
     private ServiceTracker<KeyChain, KeyChain> keyChainServiceTracker = null;
     private final CtrKeyListener ctrKeyListener = new CtrKeyListener();
-
-    private static String getIctdProperty(final String name, final BundleContext ctx) {
-        final String fullName = "edu.gemini.ictd." + name;
-        final String value    = ctx.getProperty(fullName);
-
-        if (value == null) {
-            final String message = "Missing bundle.properties value " + fullName;
-            LOGGER.severe(message);
-            throw new RuntimeException(message);
-        }
-
-        return value;
-    }
-
-    private static Ictd.SiteConfig getIctdSiteConfig(final BundleContext ctx) {
-        final String user     = getIctdProperty("user", ctx);
-        final String password = getIctdProperty("password", ctx);
-
-        return new Ictd.SiteConfig(
-            new IctdDatabase.Configuration(getIctdProperty("gn", ctx), user, password),
-            new IctdDatabase.Configuration(getIctdProperty("gs", ctx), user, password)
-        );
-    }
 
     @SuppressWarnings({ "deprecation", "unchecked" })
     public void start(final BundleContext context) throws Exception {
@@ -118,7 +93,7 @@ public final class Activator implements BundleActivator {
                         PasswordDialog.unlock(ac, null);
                 });
 
-                Activator.this.advisor = new ShellAdvisor("Gemini QPT", Version.current.toString(), root, ac, internal, pachon, getIctdSiteConfig(context), ProbeLimitsTable.loadOrThrow());
+                Activator.this.advisor = new ShellAdvisor("Gemini QPT", Version.current.toString(), root, ac, internal, pachon, ProbeLimitsTable.loadOrThrow());
                 shellRegistration = context.registerService(IShellAdvisor.class.getName(), advisor, new Hashtable<>());
                 return ac;
             }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/ShellAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/ShellAdvisor.java
@@ -1,6 +1,5 @@
 package edu.gemini.qpt.ui;
 
-import edu.gemini.qpt.shared.sp.Ictd;
 import static edu.gemini.qpt.ui.util.BooleanToolPreference.TOOL_MAINTAIN_SPACING;
 import static edu.gemini.qpt.ui.util.BooleanToolPreference.TOOL_SNAP;
 import static edu.gemini.qpt.ui.util.BooleanViewPreference.*;
@@ -134,17 +133,15 @@ public class ShellAdvisor implements IShellAdvisor, PropertyChangeListener {
     }
 
     private final PublishAction.Destination internal, pachon;
-    private final Ictd.SiteConfig ictdConfig;
     private final AgsMagnitude.MagnitudeTable magTable;
 
-    public ShellAdvisor(String name, String version, String rootURL, KeyChain authClient, PublishAction.Destination internal, PublishAction.Destination pachon, Ictd.SiteConfig ictdConfig, AgsMagnitude.MagnitudeTable magTable) {
+    public ShellAdvisor(String name, String version, String rootURL, KeyChain authClient, PublishAction.Destination internal, PublishAction.Destination pachon, AgsMagnitude.MagnitudeTable magTable) {
         this.title      = name + " " + version;
         this.rootURL    = rootURL;
         this.version    = version;
         this.authClient = authClient;
         this.internal   = internal;
         this.pachon     = pachon;
-        this.ictdConfig = ictdConfig;
         this.magTable   = magTable;
     }
 
@@ -171,7 +168,7 @@ public class ShellAdvisor implements IShellAdvisor, PropertyChangeListener {
 
                 Menu.File,
 
-                new NewAction(shell, authClient, ictdConfig, magTable),
+                new NewAction(shell, authClient, magTable),
                 new OpenAction(shell, authClient, magTable),
                 new OpenFromWebAction(shell, authClient, magTable),
                 null,
@@ -210,7 +207,7 @@ public class ShellAdvisor implements IShellAdvisor, PropertyChangeListener {
                 new RefreshAction(shell, authClient, magTable),
                 new MergeAction(shell, authClient, magTable),
                 null,
-                new IctdAction(shell, authClient, ictdConfig)
+                new IctdAction(shell, authClient)
 
         );
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/IctdAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/IctdAction.java
@@ -16,7 +16,6 @@ import edu.gemini.util.security.auth.keychain.KeyChain;
 import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.logging.Logger;
 import javax.swing.JOptionPane;
 
 
@@ -27,7 +26,6 @@ import javax.swing.JOptionPane;
 public final class IctdAction extends AbstractAsyncAction implements PropertyChangeListener {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger LOGGER = Logger.getLogger(IctdAction.class.getName());
 
     private final IShell shell;
     private final KeyChain authClient;
@@ -68,23 +66,21 @@ public final class IctdAction extends AbstractAsyncAction implements PropertyCha
 
             pm.setMessage("Querying ICTD database ...");
 
-
             Ictd.query(authClient, peer, site).biForEach(
-                    msg -> {
-                        pd.setVisible(false);
-                        JOptionPane.showMessageDialog(
-                                shell.getPeer(),
-                                "There was a problem communicating with the ICTD, sorry..",
-                                "ICTD Error",
-                                JOptionPane.ERROR_MESSAGE);
-                    },
-                    ictd -> {
-                        pm.setMessage("Updating model...");
-                        sched.setIctd(ImOption.apply(ictd));
+                msg -> {
+                    pd.setVisible(false);
+                    JOptionPane.showMessageDialog(
+                        shell.getPeer(),
+                        "There was a problem communicating with the ICTD, sorry..",
+                        "ICTD Error",
+                        JOptionPane.ERROR_MESSAGE);
+                },
+                ictd -> {
+                    pm.setMessage("Updating model...");
+                    sched.setIctdSummary(ImOption.apply(ictd));
 
-                        GSelection<?> sel = shell.getSelection();
-                        shell.setModel(null);
-                        shell.setModel(sched);
+                    shell.setModel(null);
+                    shell.setModel(sched);
                 }
             );
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/NewAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/NewAction.java
@@ -15,11 +15,10 @@ import java.util.logging.Logger;
 import javax.swing.*;
 
 import edu.gemini.ags.api.AgsMagnitude;
-import edu.gemini.ictd.IctdDatabase;
 import edu.gemini.qpt.core.Block;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.ScheduleIO;
-import edu.gemini.qpt.shared.sp.Ictd;
+import edu.gemini.qpt.shared.util.Ictd;
 import edu.gemini.qpt.shared.sp.MiniModel;
 import edu.gemini.qpt.core.util.LttsServicesClient;
 import edu.gemini.qpt.ui.util.AbstractAsyncAction;
@@ -35,6 +34,7 @@ import edu.gemini.skycalc.TwilightBoundType;
 import edu.gemini.skycalc.TwilightBoundedNight;
 import edu.gemini.spModel.core.Peer;
 import edu.gemini.spModel.core.Site;
+import edu.gemini.spModel.ictd.IctdSummary;
 import edu.gemini.ui.workspace.IShell;
 import edu.gemini.util.security.auth.keychain.KeyChain;
 
@@ -50,14 +50,12 @@ public class NewAction extends AbstractAsyncAction {
 
     private final IShell shell;
     private final KeyChain authClient;
-    private final Ictd.SiteConfig ictdConfig;
     private final AgsMagnitude.MagnitudeTable magTable;
 
-    public NewAction(IShell shell, final KeyChain authClient, Ictd.SiteConfig ictdConfig, AgsMagnitude.MagnitudeTable magTable) {
+    public NewAction(IShell shell, final KeyChain authClient, AgsMagnitude.MagnitudeTable magTable) {
         super("New Plan...", authClient);
         this.shell      = shell;
         this.authClient = authClient;
-        this.ictdConfig = ictdConfig;
         this.magTable   = magTable;
         putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_N, Platform.MENU_ACTION_MASK));
         authClient.asJava().addListener(() -> setEnabled(!authClient.asJava().isLocked()));
@@ -135,7 +133,7 @@ public class NewAction extends AbstractAsyncAction {
                     } else {
                         pm.setMessage("Querying ICTD ...");
 
-                        final Option<Ictd> ictd = Ictd.query(ictdConfig, nd.getSite()).toOption();
+                        final Option<IctdSummary> ictd = Ictd.query(authClient, nd.getAuthPeer(), nd.getSite()).toOption();
 
                         sched = new Schedule(miniModel, ictd);
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
@@ -19,11 +19,11 @@ import javax.swing.tree.DefaultTreeModel;
 
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.shared.sp.Inst;
-import edu.gemini.qpt.shared.sp.Ictd;
 import edu.gemini.qpt.ui.view.instrument.OutlineNode.TriState;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.ictd.Availability;
+import edu.gemini.spModel.ictd.IctdSummary;
 import edu.gemini.ui.workspace.IShell;
 import edu.gemini.ui.workspace.IViewAdvisor;
 import edu.gemini.ui.workspace.IViewContext;
@@ -162,8 +162,8 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
         public void propertyChange(PropertyChangeEvent evt) {
             if (Schedule.PROP_ICTD.equals(evt.getPropertyName())) {
                 // Update from the feature availability map.
-                ((Option<Ictd>) evt.getNewValue()).foreach(ictd ->
-                    updateFromAvailability(ictd.featureAvailability)
+                ((Option<IctdSummary>) evt.getNewValue()).foreach(ictd ->
+                    updateFromAvailability(ictd.featureAvailabilityJava())
                 );
             }
         }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
@@ -1,9 +1,8 @@
 package edu.gemini.qpt.ui.view.mask;
 
-import edu.gemini.ictd.CustomMaskKey;
+import edu.gemini.spModel.ictd.CustomMaskKey;
 import edu.gemini.spModel.ictd.Availability;
 import edu.gemini.shared.util.immutable.ImOption;
-import edu.gemini.shared.util.immutable.Option;
 
 import edu.gemini.ui.gface.GTableController;
 import edu.gemini.ui.gface.GViewer;

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
@@ -15,7 +15,6 @@ import java.beans.PropertyChangeListener;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Map;
 
 
@@ -63,7 +62,7 @@ public final class MaskController implements GTableController<Schedule, Map.Entr
     private synchronized void fetchMasks() {
         final Map<CustomMaskKey, Availability> masks;
         masks = ImOption.apply(schedule)
-                        .flatMap(s -> schedule.getIctd())
+                        .flatMap(s -> schedule.getIctdSummary())
                         .map(IctdSummary::maskAvailabilityJava)
                         .getOrElse(Collections::emptyMap);
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskController.java
@@ -4,6 +4,7 @@ import edu.gemini.spModel.ictd.CustomMaskKey;
 import edu.gemini.spModel.ictd.Availability;
 import edu.gemini.shared.util.immutable.ImOption;
 
+import edu.gemini.spModel.ictd.IctdSummary;
 import edu.gemini.ui.gface.GTableController;
 import edu.gemini.ui.gface.GViewer;
 
@@ -63,16 +64,11 @@ public final class MaskController implements GTableController<Schedule, Map.Entr
         final Map<CustomMaskKey, Availability> masks;
         masks = ImOption.apply(schedule)
                         .flatMap(s -> schedule.getIctd())
-                        .map(i -> i.maskAvailability)
-                        .getOrElse(() -> Collections.emptyMap());
+                        .map(IctdSummary::maskAvailabilityJava)
+                        .getOrElse(Collections::emptyMap);
 
         this.entries = masks.entrySet().toArray(new Map.Entry[masks.size()]);
 
-        Arrays.sort(entries, new Comparator<Map.Entry<CustomMaskKey, Availability>>() {
-            @Override
-            public int compare(Map.Entry<CustomMaskKey, Availability> e1, Map.Entry<CustomMaskKey, Availability> e2) {
-                return CustomMaskKey.OrderingCustomMaskKey().compare(e1.getKey(), e2.getKey());
-            }
-        });
+        Arrays.sort(entries, (e1, e2) -> CustomMaskKey.OrderingCustomMaskKey().compare(e1.getKey(), e2.getKey()));
     }
 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskDecorator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskDecorator.java
@@ -1,6 +1,6 @@
 package edu.gemini.qpt.ui.view.mask;
 
-import edu.gemini.ictd.CustomMaskKey;
+import edu.gemini.spModel.ictd.CustomMaskKey;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.spModel.ictd.Availability;
 import edu.gemini.ui.gface.GSubElementDecorator;

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/mask/MaskViewAdvisor.java
@@ -4,7 +4,7 @@ import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.ui.util.ScrollPanes;
 import static edu.gemini.qpt.ui.view.mask.MaskAttribute.*;
 
-import edu.gemini.ictd.CustomMaskKey;
+import edu.gemini.spModel.ictd.CustomMaskKey;
 import edu.gemini.spModel.ictd.Availability;
 
 import edu.gemini.ui.gface.GTableViewer;

--- a/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/TestLauncher.scala
+++ b/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/TestLauncher.scala
@@ -3,8 +3,8 @@ package edu.gemini.qpt
 import java.io.File
 
 import edu.gemini.ags.conf.ProbeLimitsTable
-import edu.gemini.ictd.IctdDatabase;
-import edu.gemini.qpt.shared.sp.Ictd
+import edu.gemini.ictd.IctdDatabase
+;
 import edu.gemini.qpt.ui.ShellAdvisor
 import edu.gemini.qpt.ui.action.PublishAction
 import edu.gemini.spModel.core.{Peer, Site, Version}
@@ -39,7 +39,7 @@ object QptTestLauncher {
     val title = "QPT Test Launcher"
 
     // The QPT UI handler
-    val adv = new ShellAdvisor(title, Version.current.toString(), root, keys, internal, pachon, Ictd.SiteConfig.forTesting, ProbeLimitsTable.loadOrThrow())
+    val adv = new ShellAdvisor(title, Version.current.toString(), root, keys, internal, pachon, ProbeLimitsTable.loadOrThrow())
 
     // Workspace to manage windows
     val ws = new Workspace(null)

--- a/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/TestLauncher.scala
+++ b/bundle/edu.gemini.qpt.client/src/main/scala/edu/gemini/qpt/TestLauncher.scala
@@ -3,8 +3,6 @@ package edu.gemini.qpt
 import java.io.File
 
 import edu.gemini.ags.conf.ProbeLimitsTable
-import edu.gemini.ictd.IctdDatabase
-;
 import edu.gemini.qpt.ui.ShellAdvisor
 import edu.gemini.qpt.ui.action.PublishAction
 import edu.gemini.spModel.core.{Peer, Site, Version}

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Ictd.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Ictd.java
@@ -1,14 +1,12 @@
 package edu.gemini.qpt.shared.sp;
 
-import edu.gemini.ictd.CustomMaskKey;
+import edu.gemini.spModel.ictd.CustomMaskKey;
 import edu.gemini.ictd.IctdDatabase;
 import edu.gemini.shared.util.immutable.ImEither;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Left;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Right;
-import edu.gemini.spModel.core.ProgramId;
-import edu.gemini.spModel.core.ProgramId$;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.ictd.Availability;
 import edu.gemini.spModel.pio.ParamSet;
@@ -27,7 +25,7 @@ import java.util.logging.Logger;
 import java.io.Serializable;
 
 /**
- * Collection of ICTD data relevant to the QPT.
+ * Collection of ICTD data relevant to the QPT and QVis.
  */
 public final class Ictd implements Serializable, PioSerializable {
     private static final Logger LOGGER = Logger.getLogger(Ictd.class.getName());

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/util/Ictd.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/util/Ictd.java
@@ -17,18 +17,15 @@ import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.util.security.auth.keychain.KeyChain;
 import edu.gemini.util.trpc.client.TrpcClient$;
 
-import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import java.io.Serializable;
 
 /**
- * Collection of ICTD data relevant to the QPT and QVis.
+ * Utility for querying the ICTD and for converting to/from ParamSet.
  */
 public final class Ictd {
     private static final Logger LOGGER = Logger.getLogger(Ictd.class.getName());

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/util/Ictd.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/util/Ictd.java
@@ -1,21 +1,24 @@
-package edu.gemini.qpt.shared.sp;
+package edu.gemini.qpt.shared.util;
 
 import edu.gemini.spModel.ictd.CustomMaskKey;
-import edu.gemini.ictd.IctdDatabase;
+import edu.gemini.spModel.ictd.IctdService;
+import edu.gemini.spModel.ictd.IctdSummary;
 import edu.gemini.shared.util.immutable.ImEither;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Left;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Right;
+import edu.gemini.spModel.core.Peer;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.ictd.Availability;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
+import edu.gemini.util.security.auth.keychain.KeyChain;
+import edu.gemini.util.trpc.client.TrpcClient$;
 
-import edu.gemini.qpt.shared.util.EnumPio;
-import edu.gemini.qpt.shared.util.PioSerializable;
-
+import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,52 +30,35 @@ import java.io.Serializable;
 /**
  * Collection of ICTD data relevant to the QPT and QVis.
  */
-public final class Ictd implements Serializable, PioSerializable {
+public final class Ictd {
     private static final Logger LOGGER = Logger.getLogger(Ictd.class.getName());
 
-    /** ICTD Database configuration for the two sites. */
-    public static final class SiteConfig {
-        public final IctdDatabase.Configuration gn;
-        public final IctdDatabase.Configuration gs;
-
-        public SiteConfig(IctdDatabase.Configuration gn, IctdDatabase.Configuration gs) {
-            assert gn != null;
-            assert gs != null;
-            this.gn = gn;
-            this.gs = gs;
-        }
-
-        public IctdDatabase.Configuration configFor(final Site s) {
-            final IctdDatabase.Configuration c;
-            switch (s) {
-                case GN: c = gn; break;
-                case GS: c = gs; break;
-                default: throw new RuntimeException("Unexpected site: " + s);
-            }
-            return c;
-        }
-
-        public static final SiteConfig forTesting =
-                new SiteConfig(
-                        IctdDatabase.asJava().testConfiguration(),
-                        IctdDatabase.asJava().testConfiguration());
+    private Ictd() {
+        // defeat instantiation
     }
 
     /**
      * Constructs an ICTD instance from query results, if possible. Returns a
      * Right<String, Ictd> if so, and a Left<String, Ictd> if not.
      */
-    public static ImEither<String, Ictd> query(SiteConfig dbs, Site s) {
-        final IctdDatabase.Configuration c = dbs.configFor(s);
+    public static ImEither<String, IctdSummary> query(KeyChain kc, Peer peer, Site s) {
+
+        final ClassLoader cl = Thread.currentThread().getContextClassLoader();
 
         try {
-            return new Right<>(new Ictd(
-                IctdDatabase.asJava().unsafeSelectFeatureAvailability(c, s),
-                IctdDatabase.asJava().unsafeSelectMaskAvailability(c, s)
-            ));
-        } catch (Exception ex) {
-            LOGGER.log(Level.WARNING, "Could not query ICTD", ex);
+
+            final ClassLoader classLoader = Ictd.class.getClassLoader();
+            Thread.currentThread().setContextClassLoader(classLoader);
+
+            final IctdService service = TrpcClient$.MODULE$.apply(peer.host, peer.port).withKeyChain(kc).proxy(IctdService.class);
+            return new Right<>(service.summary(peer.site));
+
+        } catch (UndeclaredThrowableException ute) {
+            LOGGER.log(Level.WARNING, "Could not query ICTD", ute);
             return new Left<>("Error querying the ICTD, sorry.");
+
+        } finally {
+            Thread.currentThread().setContextClassLoader(cl);
         }
 
     }
@@ -83,19 +69,7 @@ public final class Ictd implements Serializable, PioSerializable {
     public static final String AVAIL   = "avail";
     public static final String NAME    = "name";
 
-
-    public final Map<Enum<?>,       Availability> featureAvailability;
-    public final Map<CustomMaskKey, Availability> maskAvailability;
-
-    public Ictd(
-        Map<Enum<?>,       Availability> featureAvailability,
-        Map<CustomMaskKey, Availability> maskAvailability
-    ) {
-        this.featureAvailability = Collections.unmodifiableMap(new HashMap<>(featureAvailability));
-        this.maskAvailability    = Collections.unmodifiableMap(new HashMap<>(maskAvailability));
-    }
-
-    public Ictd(ParamSet params) {
+    public static IctdSummary decode(ParamSet params) {
         final ParamSet feature = params.getParamSet(FEATURE);
         final Map<Enum<?>, Availability> f = new HashMap<>();
         for (ParamSet entry : feature.getParamSets(ENTRY)) {
@@ -124,15 +98,14 @@ public final class Ictd implements Serializable, PioSerializable {
             ok.foreach(k -> m.put(k, a));
         }
 
-        this.featureAvailability = Collections.unmodifiableMap(f);
-        this.maskAvailability    = Collections.unmodifiableMap(m);
+        return IctdSummary.fromJava(f, m);
     }
 
-    public ParamSet getParamSet(PioFactory factory, String name) {
+    public static ParamSet encode(PioFactory factory, String name, IctdSummary summary) {
         final ParamSet params  = factory.createParamSet(name);
 
         final ParamSet feature = factory.createParamSet(FEATURE);
-        for (Map.Entry<Enum<?>, Availability> me: featureAvailability.entrySet()) {
+        for (Map.Entry<Enum<?>, Availability> me : summary.featureAvailabilityJava().entrySet()) {
             final ParamSet e = EnumPio.getEnumParamSet(factory, ENTRY, me.getKey());
             Pio.addEnumParam(factory, e, AVAIL, me.getValue());
             feature.addParamSet(e);
@@ -140,7 +113,7 @@ public final class Ictd implements Serializable, PioSerializable {
         params.addParamSet(feature);
 
         final ParamSet mask = factory.createParamSet(MASK);
-        for (Map.Entry<CustomMaskKey, Availability> me: maskAvailability.entrySet()) {
+        for (Map.Entry<CustomMaskKey, Availability> me: summary.maskAvailabilityJava().entrySet()) {
             final ParamSet e = factory.createParamSet(ENTRY);
             Pio.addParam    (factory, e, NAME,  me.getKey().format());
             Pio.addEnumParam(factory, e, AVAIL, me.getValue());

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/QvToolMenu.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/QvToolMenu.scala
@@ -71,11 +71,10 @@ object QvToolMenu {
       prepare()
       SolutionProvider(ctx).clear()
 
-      val oldObservations = ctx.dataSource.observations
       for {
-        observations <- ctx.dataSource.refresh                                 // wait for new observations loaded
-        result <- SolutionProvider(ctx).update(ctx, observations, oldObservations)  // wait for all constraints updated
-      } yield result
+        os <- ctx.dataSource.refresh                 // wait for new observations loaded
+        _  <- SolutionProvider(ctx).update(ctx, os)  // wait for all constraints updated
+      } yield ()
 
     }
 
@@ -89,7 +88,7 @@ class QvToolMenu(frame: Frame, ctx: QvContext) extends MenuBar {
   private val reloadAction = Action("Change Data and Reload") {
     new RefreshDialog(frame, ctx).open()
   }
-  
+
   private val refreshAction = new RefreshAction("Refresh", ctx)
 
   private def exportFilterAction(c: Component) = Action("Export Filter...") { new StoreExporter(c, QvStore.filters) }

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/QvToolMenu.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/QvToolMenu.scala
@@ -72,8 +72,8 @@ object QvToolMenu {
       SolutionProvider(ctx).clear()
 
       for {
-        os <- ctx.dataSource.refresh                 // wait for new observations loaded
-        _  <- SolutionProvider(ctx).update(ctx, os)  // wait for all constraints updated
+        tup <- ctx.dataSource.refresh                     // wait for new observations loaded
+        _   <- SolutionProvider(ctx).update(ctx, tup._1)  // wait for all constraints updated
       } yield ()
 
     }

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/StatusPanel.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/StatusPanel.scala
@@ -19,7 +19,7 @@ class StatusPanel(ctx: QvContext) extends GridBagPanel {
 
   var constraintsTotal = 0
   var constraintsDone = 0
-  
+
   val messageLabel = new Label()
 
   val observationsProgress = new ProgressBar {
@@ -99,9 +99,9 @@ class StatusPanel(ctx: QvContext) extends GridBagPanel {
       observationsLabel.text = "Loading..."
       revalidate()
 
-    case DataSourceRefreshEnd(result) =>
+    case DataSourceRefreshEnd((os, _)) =>
       observationsProgress.visible = false
-      observationsLabel.text = s"Total ${result.size} loaded."
+      observationsLabel.text = s"Total ${os.size} loaded."
       revalidate()
 
     // === events from caches (SolutionProvider)
@@ -144,7 +144,7 @@ class StatusPanel(ctx: QvContext) extends GridBagPanel {
       scheduleLabel.text = "Not Available."
 
   }
-  
+
   def showMessage(message: String) = messageLabel.text = message
 
 

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/DataSource.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/DataSource.scala
@@ -4,6 +4,7 @@ import java.util.Date
 
 import edu.gemini.qpt.shared.sp.Obs
 import edu.gemini.spModel.core.{ProgramType, Semester, Site}
+import edu.gemini.spModel.ictd.IctdSummary
 import edu.gemini.spModel.obs.ObservationStatus
 import edu.gemini.spModel.obsclass.ObsClass
 
@@ -13,7 +14,7 @@ import scala.swing.event.Event
 /** Notify listeners that we are loading data from this data source. */
 case object DataSourceRefreshStart extends Event
 /** Notify listeners that we are finished loading. */
-case class DataSourceRefreshEnd(observations: Set[Obs]) extends Event
+case class DataSourceRefreshEnd(observations: (Set[Obs], Option[IctdSummary])) extends Event
 
 /**
  * Base class for data sources that provide observations to the QV tool.
@@ -50,7 +51,7 @@ trait DataSource extends ObservationProvider {
    * Refresh the data in this observation provider (e.g. by re-reading observations from the ODB).
    * Implementations should initiate a series of events which listeners can use to react appropriately.
    */
-  def refresh: Future[Set[Obs]]
+  def refresh: Future[(Set[Obs], Option[IctdSummary])]
 
 }
 
@@ -59,7 +60,7 @@ object DataSource {
   /** An empty data source. */
   def empty(s: Site): DataSource =
     new DataSource {
-      def refresh() = Future.successful(Set.empty)
+      def refresh = Future.successful((Set.empty[Obs], None))
       def site = s
     }
 

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/InstallationState.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/InstallationState.scala
@@ -1,0 +1,18 @@
+package edu.gemini.qv.plugin.table
+
+/**
+ * Instrument component installation state, according to the ICTD.
+ */
+sealed trait InstallationState extends Product with Serializable
+
+object InstallationState {
+
+  /** All instrument components and custom mask (if any) known to be installed. */
+  case object AllInstalled     extends InstallationState
+
+  /** One or more components or custom mask known to be not installed. */
+  case object SomeNotInstalled extends InstallationState
+
+  /** Unknown installation state (ICTD unavailable). */
+  case object Unknown          extends InstallationState
+}

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/ObservationTable.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/ObservationTable.scala
@@ -130,7 +130,7 @@ class ObservationTable(ctx: QvContext) extends GridBagPanel {
       }
     }
   }
-  
+
   class HeaderTableGrid extends ObservationTableGrid {
 
     // store a copy of the all columns of the table's column model, do this before we make any changes to it by

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/ObservationTableModel.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/ObservationTableModel.scala
@@ -322,7 +322,7 @@ object ObservationTableModel {
     c.dataSource.ictd.map { i =>
 
       def mask: Boolean =
-        Option(o.getCustomMask).forall { m =>
+        Option(o.getCustomMask).map(_.trim).filterNot(_.isEmpty).forall { m =>
           CustomMaskKey.parse(m).exists(i.maskAvailability.get(_).contains(Installed))
         }
 

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/SolutionProvider.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/SolutionProvider.scala
@@ -67,7 +67,7 @@ sealed class SolutionProvider(site: Site) extends Publisher {
   }
 
   /** Reloads and recalculates all constraints in the background. */
-  def update(ctx: QvContext, newObservations: Set[Obs], oldObservations: Set[Obs]): Future[Unit] = {
+  def update(ctx: QvContext, newObservations: Set[Obs]): Future[Unit] = {
     scheduleCache.update(ctx.peer, range)
     constraintsCache.update(ctx, nights, newObservations)
   }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramId.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramId.scala
@@ -2,6 +2,7 @@ package edu.gemini.spModel.core
 
 import java.util.{GregorianCalendar, Calendar}
 import scala.util.Try
+import scalaz.Order
 
 sealed trait ProgramId extends java.io.Serializable {
   def site: Option[Site]
@@ -65,6 +66,12 @@ object ProgramId {
     override def toString: String =
       format
   }
+
+  implicit val OrderingScience: Ordering[Science] =
+    scala.math.Ordering.by(k => (k.siteVal, k.semesterVal, k.ptypeVal, k.index))
+
+  implicit val OrderScience: Order[Science] =
+    Order.fromScalaOrdering[Science]
 
   case class Daily(siteVal: Site, ptypeVal: ProgramType, year: Int, month: Int, day: Int) extends StandardProgramId {
     def site: Option[Site]         = Some(siteVal)

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramType.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/ProgramType.scala
@@ -1,6 +1,7 @@
 package edu.gemini.spModel.core
 
 import scala.collection.JavaConverters._
+import scalaz.Order
 
 sealed trait ProgramType extends Ordered[ProgramType] {
   def name: String
@@ -104,4 +105,7 @@ object ProgramType {
 
   // Java convenience ...
   def readOrNull(id: SPProgramID): ProgramType = ProgramId.parse(id.toString).ptype.orNull
+
+  implicit val OrderProgramType: Order[ProgramType] =
+    Order.fromScalaOrdering[ProgramType]
 }

--- a/bundle/jsky.app.ot.testlauncher/src/main/scala/jsky/app/ot/testlauncher/TestLauncher.scala
+++ b/bundle/jsky.app.ot.testlauncher/src/main/scala/jsky/app/ot/testlauncher/TestLauncher.scala
@@ -1,7 +1,7 @@
 package jsky.app.ot.testlauncher
 
 import edu.gemini.ags.conf.ProbeLimitsTable
-import edu.gemini.qv.plugin.{QvTool, ShowQvToolAction}
+import edu.gemini.qv.plugin.ShowQvToolAction
 import edu.gemini.sp.vcs2.{Vcs, VcsServer}
 import jsky.app.ot.gemini.obscat.OTBrowserPresetsPersistence
 import jsky.app.ot.vcs.VcsOtClient
@@ -14,8 +14,6 @@ import edu.gemini.util.trpc.auth.TrpcKeyChain
 import edu.gemini.util.security.auth.keychain.Action._
 import edu.gemini.util.security.ext.auth.ui.{AuthDialog, PasswordDialog}
 import java.io.File
-import java.security.{Provider, Security}
-import java.util.logging.{Level, Logger}
 
 import edu.gemini.catalog.image.ImageCacheWatcher
 import edu.gemini.sp.vcs.reg.impl.VcsRegistrarImpl

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -195,7 +195,6 @@ trait OcsBundle {
 
   lazy val bundle_edu_gemini_qpt_client =
     project.in(file("bundle/edu.gemini.qpt.client")).dependsOn(
-      bundle_edu_gemini_ictd,
       bundle_edu_gemini_shared_skyobject,
       bundle_edu_gemini_pot,
       bundle_edu_gemini_qpt_shared,
@@ -213,7 +212,6 @@ trait OcsBundle {
   lazy val bundle_edu_gemini_qpt_shared =
     project.in(file("bundle/edu.gemini.qpt.shared")).dependsOn(
       bundle_edu_gemini_ags,
-      bundle_edu_gemini_ictd,
       bundle_edu_gemini_shared_skyobject,
       bundle_edu_gemini_pot,
       bundle_edu_gemini_shared_util,

--- a/project/OcsBundle.scala
+++ b/project/OcsBundle.scala
@@ -59,7 +59,9 @@ trait OcsBundle {
       bundle_edu_gemini_pot,
       bundle_edu_gemini_shared_util,
       bundle_edu_gemini_spModel_core % "test->test;compile->compile",
-      bundle_edu_gemini_spModel_pio
+      bundle_edu_gemini_spModel_pio,
+      bundle_edu_gemini_util_osgi,
+      bundle_edu_gemini_util_security
     )
 
   lazy val bundle_edu_gemini_itc_shared =

--- a/project/OcsCredentials.scala.template
+++ b/project/OcsCredentials.scala.template
@@ -26,30 +26,18 @@ object OcsCredentials {
     def with_test_dbs_credentials(version: Version) = AppConfig(
       id = "with-test-dbs-credentials",
       props = Map(
-        "edu.gemini.ictd.gn"       -> "",
-        "edu.gemini.ictd.gs"       -> "",
-        "edu.gemini.ictd.user"     -> "",
-        "edu.gemini.ictd.password" -> ""
       )
     )
 
     def with_production_dbs_credentials(version: Version) = AppConfig(
       id = "with-production-dbs-credentials",
       props = Map(
-        "edu.gemini.ictd.gn"       -> "",
-        "edu.gemini.ictd.gs"       -> "",
-        "edu.gemini.ictd.user"     -> "",
-        "edu.gemini.ictd.password" -> ""
       )
     )
 
     def development_credentials(version: Version) = AppConfig(
       id = "development_credentials",
       props = Map(
-        "edu.gemini.ictd.gn"       -> "",
-        "edu.gemini.ictd.gs"       -> "",
-        "edu.gemini.ictd.user"     -> "",
-        "edu.gemini.ictd.password" -> ""
       )
     )
 
@@ -73,6 +61,10 @@ object OcsCredentials {
         "edu.gemini.smartgcal.uploadPassword"   -> "",
         "org.ops4j.pax.web.ssl.keypassword"     -> "",
         "org.ops4j.pax.web.ssl.password"        -> "",
+        "edu.gemini.ictd.gn"                    -> "",
+        "edu.gemini.ictd.gs"                    -> "",
+        "edu.gemini.ictd.user"                  -> "",
+        "edu.gemini.ictd.password"              -> "",
         // do these need to be private?
         "edu.gemini.services.telescope.schedule.calendar.id.north"  -> "",
         "edu.gemini.services.telescope.schedule.calendar.id.south"  -> "",


### PR DESCRIPTION
This PR adds minimal ICTD integration with the QV tool.  In particular, it adds a column to the observation table listing that indicates whether each observation's requested instrument components (and custom mask if any) are installed.  It also adds a somewhat redundant option to highlight observation rows according to the availability of their components.

Because the QV tool is distributed with the OT, I was hesitant to allow the OT to directly query the ICTD. To do so would have meant distributing an ICTD user and password with the OT. Instead I created a service that runs in the ODB and receives queries on behalf of the QV forwarding the results back to the OT.  Note that the QPT was written to directly query the ICTD so I also refactored it to use the new `IctdService` just as the OT/QV now do.