### PR TITLE
REL-1958: show which configuration items are missing

### DIFF
--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/InstallationState.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/InstallationState.scala
@@ -1,5 +1,7 @@
 package edu.gemini.qv.plugin.table
 
+import scalaz.NonEmptyList
+
 /**
  * Instrument component installation state, according to the ICTD.
  */
@@ -8,11 +10,11 @@ sealed trait InstallationState extends Product with Serializable
 object InstallationState {
 
   /** All instrument components and custom mask (if any) known to be installed. */
-  case object AllInstalled     extends InstallationState
+  case object AllInstalled extends InstallationState
 
   /** One or more components or custom mask known to be not installed. */
-  case object SomeNotInstalled extends InstallationState
+  final case class SomeNotInstalled(missing: NonEmptyList[String]) extends InstallationState
 
   /** Unknown installation state (ICTD unavailable). */
-  case object Unknown          extends InstallationState
+  case object Unknown extends InstallationState
 }


### PR DESCRIPTION
This PR implements an additional feature request for REL-1958: ICTD / QV integration.  Namely, it shows *which* instrument components in an observation configuration are not installed in a tooltip popup.