### PR TITLE
REL-2719: indicate guide quality in TPE candidate plot

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -156,7 +156,11 @@ object AgsAnalysis {
     else magnitudeAnalysis(ctx, mt, guideProbe, guideStar)
   }
 
-  private def magnitudeAnalysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] = {
+  /**
+   * Analysis of the suitability of the magnitude of the given guide star
+   * regardless of its reachability.
+   */
+  def magnitudeAnalysis(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] = {
     import AgsGuideQuality._
     import GuideSpeed._
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -211,3 +211,19 @@ object AgsAnalysis {
     }
   }
 }
+
+sealed trait GuideInFOV
+case object InsideFOV extends GuideInFOV
+case object OutsideFOV extends GuideInFOV
+
+object GuideInFOV {
+  implicit val order: Order[GuideInFOV] = Order.order {
+    case (InsideFOV, OutsideFOV) => Ordering.GT
+    case (OutsideFOV, InsideFOV) => Ordering.LT
+    case _                       => Ordering.EQ
+  }
+
+  implicit val ordering: scala.Ordering[GuideInFOV] = order.toScalaOrdering
+
+  val All: List[GuideInFOV] = List(InsideFOV, OutsideFOV)
+}

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsAnalysis.scala
@@ -61,41 +61,41 @@ sealed trait AgsAnalysis {
 }
 
 object AgsAnalysis {
-  case class NoGuideStarForProbe(guideProbe: GuideProbe) extends AgsAnalysis {
+  final case class NoGuideStarForProbe(guideProbe: GuideProbe) extends AgsAnalysis {
     override def message(withProbe: Boolean): String = {
       val p = if (withProbe) s"${guideProbe.getKey} " else ""
       s"No ${p}guide star selected."
     }
   }
 
-  case class NoGuideStarForGroup(guideGroup: GuideProbeGroup) extends AgsAnalysis {
+  final case class NoGuideStarForGroup(guideGroup: GuideProbeGroup) extends AgsAnalysis {
     override def message(withProbe: Boolean): String =
       s"No ${guideGroup.getKey} guide star selected."
   }
 
-  case class MagnitudeTooFaint(guideProbe: GuideProbe, target: SiderealTarget) extends AgsAnalysis {
+  final case class MagnitudeTooFaint(guideProbe: GuideProbe, target: SiderealTarget) extends AgsAnalysis {
     override def message(withProbe: Boolean): String = {
       val p = if (withProbe) s"use ${guideProbe.getKey}" else "guide"
       s"Cannot $p with the star in these conditions, even using the slowest guide speed."
     }
   }
 
-  case class MagnitudeTooBright(guideProbe: GuideProbe, target: SiderealTarget) extends AgsAnalysis {
+  final case class MagnitudeTooBright(guideProbe: GuideProbe, target: SiderealTarget) extends AgsAnalysis {
     override def message(withProbe: Boolean): String = {
       val p = if (withProbe) s"${guideProbe.getKey} g" else "G"
       s"${p}uide star is too bright to guide."
     }
   }
 
-  case class NotReachable(guideProbe: GuideProbe, target: SiderealTarget) extends AgsAnalysis {
+  final case class NotReachable(guideProbe: GuideProbe, target: SiderealTarget) extends AgsAnalysis {
     override def message(withProbe: Boolean): String = {
       val p = if (withProbe) s"with ${guideProbe.getKey} " else ""
       s"The star is not reachable ${p}at all positions."
     }
   }
 
-  case class NoMagnitudeForBand(guideProbe: GuideProbe, target: SiderealTarget) extends AgsAnalysis {
-    val probeBands = guideProbe.getBands
+  final case class NoMagnitudeForBand(guideProbe: GuideProbe, target: SiderealTarget) extends AgsAnalysis {
+    private val probeBands = guideProbe.getBands
     override def message(withProbe: Boolean): String = {
       val p = if (withProbe) s"${guideProbe.getKey} g" else "G"
       if (probeBands.bands.length == 1) {
@@ -104,10 +104,10 @@ object AgsAnalysis {
         s"${p}uide star ${probeBands.bands.map(_.name).mkString(", ")}-band magnitudes are missing. Cannot determine guiding performance."
       }
     }
-    override val quality = AgsGuideQuality.PossiblyUnusable
+    override val quality: AgsGuideQuality = AgsGuideQuality.PossiblyUnusable
   }
 
-  case class Usable(guideProbe: GuideProbe, target: SiderealTarget, guideSpeed: GuideSpeed, override val quality: AgsGuideQuality) extends AgsAnalysis {
+  final case class Usable(guideProbe: GuideProbe, target: SiderealTarget, guideSpeed: GuideSpeed, override val quality: AgsGuideQuality) extends AgsAnalysis {
     override def message(withProbe: Boolean): String = {
       val qualityMessage = quality match {
         case AgsGuideQuality.DeliversRequestedIq => ""

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsStrategy.scala
@@ -31,6 +31,8 @@ trait AgsStrategy {
     else analyze(ctx, mt, guideProbe, guideStar).asGeminiOpt
   }
 
+  def analyzeMagnitude(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis]
+
   def candidates(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]]
 
   /**

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala
@@ -50,6 +50,9 @@ trait GemsStrategy extends AgsStrategy {
   override def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe, guideStar)
 
+  def analyzeMagnitude(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
+    AgsAnalysis.magnitudeAnalysis(ctx, mt, guideProbe, guideStar)
+
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] = {
     import AgsAnalysis._
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/OffStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/OffStrategy.scala
@@ -26,6 +26,8 @@ case object OffStrategy extends AgsStrategy {
 
   override def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] = None
 
+  override def analyzeMagnitude(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] = None
+
   override def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery] = Nil
 
   override def candidates(ctx: ObsContext, mt: MagnitudeTable)(ec: ExecutionContext): Future[List[(GuideProbe, List[SiderealTarget])]] = Nil.pure[Future]

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/ScienceTargetStrategy.scala
@@ -24,6 +24,9 @@ case class ScienceTargetStrategy(key: AgsStrategyKey, guideProbe: ValidatableGui
   override def analyze(ctx: ObsContext, mt: MagnitudeTable): List[AgsAnalysis] =
     AgsAnalysis.analysis(ctx, mt, guideProbe).toList
 
+  override def analyzeMagnitude(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
+    analyze(ctx, mt, guideProbe, guideStar)
+
   private def toSiderealTargets(ctx: ObsContext): List[SiderealTarget] = {
     val when = ctx.getSchedulingBlockStart
     val ts   = ctx.getTargets.getAsterism.allSpTargets.map(_.toSiderealTarget(when))

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -40,6 +40,9 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
   override def analyze(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
     AgsAnalysis.analysis(withCorrectedSite(ctx), mt, guideProbe, guideStar)
 
+  override def analyzeMagnitude(ctx: ObsContext, mt: MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
+    AgsAnalysis.magnitudeAnalysis(ctx, mt, guideProbe, guideStar)
+
   override def catalogQueries(ctx: ObsContext, mt: MagnitudeTable): List[CatalogQuery] =
     params.catalogQueries(withCorrectedSite(ctx), mt).toList
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -37,7 +37,7 @@ case object TWOMASS_XSC extends CatalogName("twomass_xsc", "TwoMass XSC @ Gemini
 case object SIMBAD extends CatalogName("simbad", "Simbad")
 
 object CatalogName {
-  implicit val equals = Equal.equal[CatalogName]((a, b) => a.id === b.id)
+  implicit val equals: Equal[CatalogName] = Equal.equal[CatalogName]((a, b) => a.id === b.id)
 }
 
 /**
@@ -59,7 +59,7 @@ case class ConeSearchCatalogQuery(id: Option[Int], base: Coordinates, radiusCons
   val filters: NonEmptyList[QueryResultsFilter] = NonEmptyList(RadiusFilter(base, radiusConstraint), magnitudeConstraints.map(MagnitudeQueryFilter.apply): _*)
   override def filter(t: SiderealTarget):Boolean = filters.toList.forall(_.filter(t))
 
-  override def isSuperSetOf(q: CatalogQuery) = q match {
+  override def isSuperSetOf(q: CatalogQuery): Boolean = q match {
     case c: ConeSearchCatalogQuery =>
 
       // Angular separation, or distance between the two.
@@ -77,7 +77,7 @@ case class ConeSearchCatalogQuery(id: Option[Int], base: Coordinates, radiusCons
 }
 
 object ConeSearchCatalogQuery {
-  implicit val equals = Equal.equalA[ConeSearchCatalogQuery]
+  implicit val equals: Equal[ConeSearchCatalogQuery] = Equal.equalA[ConeSearchCatalogQuery]
 }
 
 /**
@@ -101,5 +101,5 @@ object CatalogQuery {
 
   def apply(search: String):CatalogQuery = NameCatalogQuery(search, SIMBAD)
 
-  implicit val equals = Equal.equalA[CatalogQuery]
+  implicit val equals: Equal[CatalogQuery] = Equal.equalA[CatalogQuery]
 }

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalog.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalog.scala
@@ -117,15 +117,15 @@ object Dss2iESO extends DssCatalog(Dss2IREsoId, "Digitized Sky (Version II infra
 }
 
 object TwoMassJ extends AstroCatalog(TwoMassJId, "2MASS Quick-Look Image Retrieval Service (J Band)", "2MASS-J") {
-  override val band = MagnitudeBand.J
+  override val band: MagnitudeBand = MagnitudeBand.J
 }
 
 object TwoMassH extends AstroCatalog(TwoMassHId, "2MASS Quick-Look Image Retrieval Service (H Band)", "2MASS-H") {
-  override val band = MagnitudeBand.H
+  override val band: MagnitudeBand = MagnitudeBand.H
 }
 
 object TwoMassK extends AstroCatalog(TwoMassKId, "2MASS Quick-Look Image Retrieval Service (K Band)", "2MASS-K") {
-  override val band = MagnitudeBand.K
+  override val band: MagnitudeBand = MagnitudeBand.K
 }
 
 /**
@@ -133,7 +133,7 @@ object TwoMassK extends AstroCatalog(TwoMassKId, "2MASS Quick-Look Image Retriev
   */
 object ImageCatalog {
   val DefaultImageSize: Angle = Angle.fromArcmin(15.0)
-  val DefaultImageCatalog = DssGemini
+  val DefaultImageCatalog: ImageCatalog = DssGemini
 
   /** @group Typeclass Instances */
   implicit val equals: Equal[ImageCatalog] = Equal.equalA[ImageCatalog]

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Target.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Target.scala
@@ -113,7 +113,6 @@ trait TargetLenses {
 
 }
 
-
 /**
  * Target of opportunity, with no coordinates. Use '''TooTarget.empty''' if no name is given.
  * @param name a human-readable name

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/package.scala
@@ -19,13 +19,13 @@ package object core {
     }
 
   type RA = RightAscension
-  val  RA = RightAscension
+  val  RA: RightAscension.type = RightAscension
 
   type Dec = Declination
-  val  Dec = Declination
+  val  Dec: Declination.type = Declination
 
   implicit def SPProgramIdToRichProgramId(id: SPProgramID): RichSpProgramId =
-    new RichSpProgramId(id)
+    RichSpProgramId(id)
 
   implicit val OrderSPProgramID: Order[SPProgramID] =
     Order.fromScalaOrdering(scala.math.Ordering.ordered[SPProgramID])
@@ -60,7 +60,7 @@ package object core {
 
   /** For keys you can subtract we can find the closest matching pair.  */
   implicit class NumericKeyedMapOps[K, V](m: K ==>> V)(implicit N: Numeric[K]) {
-    implicit val KOrder = Order.fromScalaOrdering(N)
+    implicit val KOrder: Order[K] = Order.fromScalaOrdering(N)
 
     /** Find the closest matching pair, if any. */
     def lookupClosestAssoc(k: K): Option[(K, V)] =

--- a/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/BasicTablePlotter.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/catalog/gui/BasicTablePlotter.java
@@ -296,6 +296,7 @@ public class BasicTablePlotter
     private void plotRow(final int row, final Vector<Object> rowVec, final double x, final double y,
                            final int cooSys, final TablePlotSymbol symbol) {
         // eval expr to get condition
+
         final boolean cond = symbol.getCond(rowVec);
         if (!cond)
             return;

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -3,12 +3,12 @@ package edu.gemini.catalog.ui
 import java.awt.Color
 import java.io._
 import java.nio.charset.Charset
+
 import javax.swing.BorderFactory._
 import javax.swing.border.Border
-import javax.swing.{BorderFactory, DefaultComboBoxModel, JOptionPane, UIManager}
-
+import javax.swing._
 import edu.gemini.ags.api.AgsMagnitude.MagnitudeTable
-import edu.gemini.ags.api.{AgsGuideQuality, AgsRegistrar}
+import edu.gemini.ags.api.{AgsGuideQuality, AgsRegistrar, GuideInFOV}
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.catalog.api._
 import edu.gemini.catalog.ui.tpe.CatalogImageDisplay
@@ -40,6 +40,8 @@ import scala.collection.JavaConverters._
 import scala.swing.event._
 import scalaz._
 import Scalaz._
+
+import scala.collection.mutable.ListBuffer
 
 /**
  * Frame to display the Query controls and results

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -103,6 +103,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
         selection.rows += modelToViewRow(e.getRow)
       }
     }))
+    Option(TpeManager.get()).foreach(_.getImageWidget.setPosAngle())
 
     override def rendererComponent(isSelected: Boolean, focused: Boolean, row: Int, column: Int): Component =
       // Note that we need to use the same conversions as indicated on SortableTable to get the value

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TpePlotter.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TpePlotter.scala
@@ -82,44 +82,85 @@ object adapters {
     }
   }
 
-
-
   // This is a hack to change the symbol dynamically depending on the guiding quality
   sealed trait GuideQualitySymbol extends TablePlotSymbol {
-    val quality: Option[AgsGuideQuality]
+    def quality: Option[AgsGuideQuality]
+    def inFOV: Option[GuideInFOV]
 
-    override def getCond(rowVec: java.util.Vector[AnyRef]): Boolean =
-      rowVec.asScala.contains(quality)
+    override def getCond(rowVec: java.util.Vector[AnyRef]): Boolean = {
+      val vec = rowVec.asScala
+      vec.contains(quality) && vec.contains(inFOV)
+    }
   }
 
-  case object DeliversRequestedIqSymbol extends GuideQualitySymbol {
-    val quality = DeliversRequestedIq.some
+  case object DeliversRequestedIqSymbolInFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = DeliversRequestedIq.some
+    val inFOV: Option[GuideInFOV] = InsideFOV.some
     setFg(Color.green)
     setShape(TablePlotSymbol.CIRCLE)
   }
 
-  case object PossibleIqDegradationSymbol extends GuideQualitySymbol {
-    val quality = PossibleIqDegradation.some
+  case object DeliversRequestedIqSymbolOutFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = DeliversRequestedIq.some
+    val inFOV: Option[GuideInFOV] = OutsideFOV.some
     setFg(Color.green)
-    setShape(TablePlotSymbol.ELLIPSE)
+    setShape(TablePlotSymbol.CROSS)
   }
 
-  case object IqDegradationSymbol extends GuideQualitySymbol {
-    val quality = IqDegradation.some
+  case object PossibleIqDegradationSymbolInFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = PossibleIqDegradation.some
+    val inFOV: Option[GuideInFOV] = InsideFOV.some
+    setFg(Color.green)
+    setShape(TablePlotSymbol.CIRCLE)
+  }
+
+  case object PossibleIqDegradationSymbolOutFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = PossibleIqDegradation.some
+    val inFOV: Option[GuideInFOV] = OutsideFOV.some
+    setFg(Color.green)
+    setShape(TablePlotSymbol.CROSS)
+  }
+
+  case object IqDegradationSymbolInFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = IqDegradation.some
+    val inFOV: Option[GuideInFOV] = InsideFOV.some
     setFg(Color.yellow)
     setShape(TablePlotSymbol.CIRCLE)
   }
 
-  case object PossiblyUnusableSymbol extends GuideQualitySymbol {
-    val quality = PossiblyUnusable.some
+  case object IqDegradationSymbolOutFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = IqDegradation.some
+    val inFOV: Option[GuideInFOV] = OutsideFOV.some
+    setFg(Color.yellow)
+    setShape(TablePlotSymbol.CROSS)
+  }
+
+  case object PossiblyUnusableSymbolInFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = PossiblyUnusable.some
+    val inFOV: Option[GuideInFOV] = InsideFOV.some
     setFg(Color.orange)
     setShape(TablePlotSymbol.CIRCLE)
   }
 
-  case object UnusableSymbol extends GuideQualitySymbol {
-    val quality = Unusable.some
+  case object PossiblyUnusableSymbolOutFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = PossiblyUnusable.some
+    val inFOV: Option[GuideInFOV] = OutsideFOV.some
+    setFg(Color.orange)
+    setShape(TablePlotSymbol.CROSS)
+  }
+
+  case object UnusableSymbolInFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = Unusable.some
+    val inFOV: Option[GuideInFOV] = InsideFOV.some
     setFg(Color.red)
     setShape(TablePlotSymbol.CIRCLE)
+  }
+
+  case object UnusableSymbolOutFOV extends GuideQualitySymbol {
+    val quality: Option[AgsGuideQuality] = Unusable.some
+    val inFOV: Option[GuideInFOV] = OutsideFOV.some
+    setFg(Color.red)
+    setShape(TablePlotSymbol.CROSS)
   }
 
   /**
@@ -137,7 +178,17 @@ object adapters {
 
     override def getSymbolDesc(i: Int): TablePlotSymbol = ???
 
-    override def getSymbols: Array[TablePlotSymbol] = Array(DeliversRequestedIqSymbol, PossibleIqDegradationSymbol, IqDegradationSymbol, PossiblyUnusableSymbol, UnusableSymbol)
+    override def getSymbols: Array[TablePlotSymbol] = Array(
+      DeliversRequestedIqSymbolInFOV,
+      DeliversRequestedIqSymbolOutFOV,
+      PossibleIqDegradationSymbolInFOV,
+      PossibleIqDegradationSymbolOutFOV,
+      IqDegradationSymbolInFOV,
+      IqDegradationSymbolOutFOV,
+      PossiblyUnusableSymbolInFOV,
+      PossiblyUnusableSymbolOutFOV,
+      UnusableSymbolInFOV,
+      UnusableSymbolOutFOV)
 
     override def getType: String = ???
 
@@ -189,7 +240,7 @@ object adapters {
         case Some(v) => Double.box(v.value)
         case None => null // This is required for the Java side of plotting
       }
-      new java.util.Vector[AnyRef]((List(t.name, t.coordinates.ra.toAngle.formatHMS, t.coordinates.dec.formatDMS, GuidingQuality.target2Analysis(model.info, t).map(_.quality)) ::: mags).asJavaCollection)
+      new java.util.Vector[AnyRef]((List(t.name, t.coordinates.ra.toAngle.formatHMS, t.coordinates.dec.formatDMS, GuidingQualityColumn.target2Analysis(model.info, t).map(_.quality), GuidingQualityColumn.target2FOV(model.info, t)) ::: mags).asJavaCollection)
     }.asJavaCollection)
 
     override def getColumnDesc(i: Int): FieldDesc = ???
@@ -198,7 +249,7 @@ object adapters {
 
     override def getColumnIdentifiers: java.util.List[String] = {
       val mags = MagnitudeBand.all.map(_.name + "mag")
-      (List("Id", "RAJ2000", "DECJ2000", "GQ") ::: mags).asJava
+      (List("Id", "RAJ2000", "DECJ2000", "GQ", "FOV") ::: mags).asJava
     }
 
     override def hasCoordinates: Boolean = ???

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TpePlotter.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TpePlotter.scala
@@ -104,7 +104,7 @@ object adapters {
     val quality: Option[AgsGuideQuality] = DeliversRequestedIq.some
     val inFOV: Option[GuideInFOV] = OutsideFOV.some
     setFg(Color.green)
-    setShape(TablePlotSymbol.CROSS)
+    setShape(TablePlotSymbol.CIRCLE)
   }
 
   case object PossibleIqDegradationSymbolInFOV extends GuideQualitySymbol {
@@ -118,42 +118,42 @@ object adapters {
     val quality: Option[AgsGuideQuality] = PossibleIqDegradation.some
     val inFOV: Option[GuideInFOV] = OutsideFOV.some
     setFg(Color.green)
-    setShape(TablePlotSymbol.CROSS)
+    setShape(TablePlotSymbol.CIRCLE)
   }
 
   case object IqDegradationSymbolInFOV extends GuideQualitySymbol {
     val quality: Option[AgsGuideQuality] = IqDegradation.some
     val inFOV: Option[GuideInFOV] = InsideFOV.some
-    setFg(Color.yellow)
+    setFg(Color.orange)
     setShape(TablePlotSymbol.CIRCLE)
   }
 
   case object IqDegradationSymbolOutFOV extends GuideQualitySymbol {
     val quality: Option[AgsGuideQuality] = IqDegradation.some
     val inFOV: Option[GuideInFOV] = OutsideFOV.some
-    setFg(Color.yellow)
-    setShape(TablePlotSymbol.CROSS)
+    setFg(Color.orange)
+    setShape(TablePlotSymbol.CIRCLE)
   }
 
   case object PossiblyUnusableSymbolInFOV extends GuideQualitySymbol {
     val quality: Option[AgsGuideQuality] = PossiblyUnusable.some
     val inFOV: Option[GuideInFOV] = InsideFOV.some
-    setFg(Color.orange)
+    setFg(Color.red)
     setShape(TablePlotSymbol.CIRCLE)
   }
 
   case object PossiblyUnusableSymbolOutFOV extends GuideQualitySymbol {
     val quality: Option[AgsGuideQuality] = PossiblyUnusable.some
     val inFOV: Option[GuideInFOV] = OutsideFOV.some
-    setFg(Color.orange)
-    setShape(TablePlotSymbol.CROSS)
+    setFg(Color.red)
+    setShape(TablePlotSymbol.CIRCLE)
   }
 
   case object UnusableSymbolInFOV extends GuideQualitySymbol {
     val quality: Option[AgsGuideQuality] = Unusable.some
     val inFOV: Option[GuideInFOV] = InsideFOV.some
     setFg(Color.red)
-    setShape(TablePlotSymbol.CIRCLE)
+    setShape(TablePlotSymbol.CROSS)
   }
 
   case object UnusableSymbolOutFOV extends GuideQualitySymbol {

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TpePlotter.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TpePlotter.scala
@@ -2,13 +2,13 @@ package edu.gemini.catalog.ui
 
 import java.awt.Color
 import java.net.URL
-import javax.swing.event.TableModelListener
 
+import javax.swing.event.TableModelListener
 import edu.gemini.ags.api.AgsGuideQuality._
-import edu.gemini.ags.api.AgsGuideQuality
+import edu.gemini.ags.api.{AgsGuideQuality, GuideInFOV, InsideFOV, OutsideFOV}
 import edu.gemini.catalog.ui.tpe.CatalogImageDisplay
 import edu.gemini.pot.ModelConverters._
-import edu.gemini.spModel.core.{SiderealTarget, MagnitudeBand}
+import edu.gemini.spModel.core.{MagnitudeBand, SiderealTarget}
 import edu.gemini.shared.util.immutable.{Option => JOption}
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import jsky.catalog._
@@ -179,7 +179,7 @@ object adapters {
 
   /** Table Query Result Adapter to let the BasicTablePlotter work */
   case class TableQueryResultAdapter(model: TargetsModel) extends TableQueryResult {
-    val catalog = new CatalogAdapter(model)
+    val catalog = CatalogAdapter(model)
 
     // Table QueryResult methods
     override def getCatalog: Catalog = catalog
@@ -297,7 +297,7 @@ case class TpePlotter(display: CatalogImageDisplay) {
   }
 
   /**
-   * Plot the given table data.
+   * Select items on the image
    */
   def select(model: TargetsModel, selected: Set[Int]): Unit = {
     val qr = TableQueryResultAdapter(model)

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -214,7 +214,7 @@ object GuidingQualityColumn {
       s   <- o.strategy
       gp  <- o.guideProbe
       ctx <- o.toContext
-      a   <- s.strategy.analyze(ctx, o.mt, gp, t)
+      a   <- s.strategy.analyzeMagnitude(ctx, o.mt, gp, t)
     } yield a
 
   // Calculate if the target is inside the probe FOV

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -230,10 +230,10 @@ object GuidingQualityColumn {
   // Calculate if the target is inside the probe FOV
   def target2FOV(info: Option[ObservationInfo], t: Target): Option[GuideInFOV] = {
     for {
-      o                                           <- info
-      gp                                          <- o.guideProbe
-      ctx                                         <- o.toContext
-      c <- t.coords(None)
+      o   <- info
+      gp  <- o.guideProbe
+      ctx <- o.toContext
+      c   <- t.coords(None)
       st = new SPTarget(SiderealTarget.empty.copy(coordinates = c))
     } yield (gp.validate(st, ctx) === GuideStarValidation.VALID).fold(InsideFOV, OutsideFOV)
   }
@@ -334,7 +334,7 @@ case class TargetsModel(info: Option[ObservationInfo], base: Coordinates, radius
   // Required to give limits to the existential type list
   type ColumnsList = List[CatalogNavigatorColumn[A] forSome { type A >: Null <: AnyRef}]
 
-  def baseColumnNames(base: Coordinates): ColumnsList = List(GuidingQualityColumn(info, ""), InFOVColumn(info, "fov"), IdColumn("Id"), RAColumn("RA"), DECColumn("Dec"), DistanceColumn(base, "Dist. [arcmin]"))
+  def baseColumnNames(base: Coordinates): ColumnsList = List(GuidingQualityColumn(info, ""), InFOVColumn(info, "FOV"), IdColumn("Id"), RAColumn("RA"), DECColumn("Dec"), DistanceColumn(base, "Dist. [arcmin]"))
   val pmColumns: ColumnsList  = List(PMRAColumn("µ RA"), PMDecColumn("µ Dec"))
   val magColumns: List[MagnitudeColumn] = MagnitudeBand.all.map(MagnitudeColumn)
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedback.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/TargetFeedback.scala
@@ -2,10 +2,10 @@ package jsky.app.ot.gemini.editor.targetComponent
 
 import java.awt.Color
 import java.awt.Color._
-import javax.swing.{BorderFactory, Icon}
 
+import javax.swing.{BorderFactory, Icon}
 import edu.gemini.ags.api.AgsAnalysis.{NoGuideStarForGroup, NoGuideStarForProbe}
-import edu.gemini.ags.api.{AgsAnalysis, AgsRegistrar}
+import edu.gemini.ags.api.{AgsAnalysis, AgsRegistrar, InsideFOV}
 import edu.gemini.ags.api.AgsGuideQuality.{DeliversRequestedIq, IqDegradation, PossibleIqDegradation, PossiblyUnusable, Unusable}
 import edu.gemini.ags.api.AgsMagnitude.{MagnitudeCalc, MagnitudeTable}
 import edu.gemini.pot.ModelConverters._
@@ -26,11 +26,12 @@ import scala.swing.GridBagPanel.Fill
 import scala.swing.{Alignment, GridBagPanel, Label}
 import scalaz._
 import Scalaz._
+import javax.swing.border.Border
 
 
 object TargetFeedback {
   sealed trait Row extends GridBagPanel {
-    protected val labelBorder = BorderFactory.createEmptyBorder(2, 2, 2, 2)
+    protected val labelBorder: Border = BorderFactory.createEmptyBorder(2, 2, 2, 2)
   }
 }
 
@@ -38,7 +39,7 @@ object TargetGuidingFeedback {
   import TargetFeedback.Row
 
   case class AnalysisRow(analysis: AgsAnalysis, probeLimits: Option[ProbeLimits], includeProbeName: Boolean) extends Row {
-    val bg = analysis.quality match {
+    val bg: Color = analysis.quality match {
       case DeliversRequestedIq   => HONEY_DEW
       case PossibleIqDegradation => BANANA
       case IqDegradation         => CANTALOUPE


### PR DESCRIPTION
This is a collaborative effort with @cquiroz to change the way that guide star candidates are plotted in the TPE.  The idea is to indicate, using green, orange, and red colors for the guide star circle, the quality of the candidate regardless of whether it is in range of the guide probe.   In particular:

* Green Circle - Delivers requested IQ or possible degradation 
* Orange Circle - Definite degradation
* Red Circle - Possibly unusable 
* Red X - Definitely unusable

(Though I wonder what is the point of plotting unusable options.  Perhaps they should just be filtered out?)

![after](https://user-images.githubusercontent.com/4906023/45240942-e2014880-b2c0-11e8-9387-ab6472564d8f.jpeg)

Because the usability icon no longer incorporates reachability, the Catalog Query Tool has also grown a new column to indicate reachability.

![catalogtable](https://user-images.githubusercontent.com/4906023/45241631-87b5b700-b2c3-11e8-8b56-5337358cf27a.jpeg)

(Though it bothers me that the pie chart icon color is always green instead of matching the TPE plot color.)