### PR TITLE
REL-361-B: timing window notification override flag

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -110,6 +110,9 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     /** This attribute indicates if the PI should be notified when the obs is done */
     public static final String NOTIFY_PI_PROP = "notifyPi";
 
+    /** Attribute used to determine whether to send timing window notifications. */
+    public static final String TIMING_WINDOW_NOTIFICATION_PROP = "timingWindowNotification";
+
     /** This attribute indicates the rollover status of this program */
     public static final String ROLLOVER_FLAG_PROP = "rolloverFlag";
 
@@ -433,6 +436,8 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
     // Indicates if the PI should be notified when the observation is done
     private YesNoType _notifyPi = YesNoType.YES; // REL-1150
 
+    private boolean _timingWindowNotification = true;  // REL-361
+
     // indicates the final date that the program is active in the database.
     // This will be extended by the ITAC rearranging software when a program from the
     // previous semester is to be "rolled over".
@@ -728,10 +733,6 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
         return _notifyPi;
     }
 
-    public int getNotifyPiIndex() {
-        return _notifyPi.ordinal();
-    }
-
     public boolean isNotifyPi() {
         return _notifyPi == YesNoType.YES;
     }
@@ -752,7 +753,16 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
         setNotifyPi(YesNoType.getYesNoType(name, oldValue));
     }
 
+    public boolean getTimingWindowNotification() {
+        return _timingWindowNotification;
+    }
 
+    public void setTimingWindowNotification(boolean timingWindowNotification) {
+        if (_timingWindowNotification != timingWindowNotification) {
+            _timingWindowNotification = timingWindowNotification;
+            firePropertyChange(TIMING_WINDOW_NOTIFICATION_PROP, !timingWindowNotification, timingWindowNotification);
+        }
+    }
 
     /**
      * Returns the contact scientist for this proposal.
@@ -990,6 +1000,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
 
         Pio.addParam(factory, paramSet, COMPLETED_PROP, Boolean.toString(isCompleted()));
         Pio.addParam(factory, paramSet, NOTIFY_PI_PROP, getNotifyPi().name());
+        Pio.addBooleanParam(factory, paramSet, TIMING_WINDOW_NOTIFICATION_PROP, getTimingWindowNotification());
 
         // SCT 201
         if (_gsa != null) {
@@ -1085,6 +1096,9 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
         if (v != null) _setCompleted(v);
         v = Pio.getValue(paramSet, NOTIFY_PI_PROP);
         if (v != null) _setNotifyPi(v);
+
+        v = Pio.getValue(paramSet, TIMING_WINDOW_NOTIFICATION_PROP);
+        setTimingWindowNotification((v == null) || Boolean.parseBoolean(v));
 
         v = Pio.getValue(paramSet, ROLLOVER_FLAG_PROP);
         if (v != null) setRolloverStatus(Boolean.parseBoolean(v));

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPProgram.java
@@ -1097,8 +1097,7 @@ public class SPProgram extends AbstractDataObject implements ISPStaffOnlyFieldPr
         v = Pio.getValue(paramSet, NOTIFY_PI_PROP);
         if (v != null) _setNotifyPi(v);
 
-        v = Pio.getValue(paramSet, TIMING_WINDOW_NOTIFICATION_PROP);
-        setTimingWindowNotification((v == null) || Boolean.parseBoolean(v));
+        setTimingWindowNotification(Pio.getBooleanValue(paramSet, TIMING_WINDOW_NOTIFICATION_PROP, true));
 
         v = Pio.getValue(paramSet, ROLLOVER_FLAG_PROP);
         if (v != null) setRolloverStatus(Boolean.parseBoolean(v));

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/timingwindowcheck/TimingWindowFunctor.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/timingwindowcheck/TimingWindowFunctor.scala
@@ -76,7 +76,7 @@ private class TimingWindowFunctor(interval: Interval) extends DBAbstractQueryFun
 
   override def execute(db: IDBDatabaseService, node: ISPNode, principals: JSet[Principal]): Unit =
     node match {
-      case p: ISPProgram if p.isScience && p.isOngoing =>
+      case p: ISPProgram if p.isScience && p.isOngoing && p.spProgram.exists(_.getTimingWindowNotification) =>
         results = results ++
           p.allObservations
             .filter(o => o.timingWindowExpiration.exists(interval.contains) && o.isActive)

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/timingwindowcheck/Arbitraries.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/timingwindowcheck/Arbitraries.scala
@@ -47,8 +47,9 @@ trait Arbitraries {
         i <- arbitrary[SPProgramID]
         a <- arbitrary[Active]
         c <- arbitrary[Boolean]
+        n <- arbitrary[Boolean]
         o <- arbitrary[List[Obs]]
-      } yield Prog(i, a, c, o)
+      } yield Prog(i, a, c, n, o)
     }
 
 }

--- a/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/timingwindowcheck/Setup.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/test/java/edu/gemini/dbTools/timingwindowcheck/Setup.scala
@@ -33,16 +33,18 @@ object Setup {
   }
 
   final case class Prog(
-    pid:       SPProgramID,
-    active:    Active,
-    completed: Boolean,
-    obs:       List[Obs]
+    pid:          SPProgramID,
+    active:       Active,
+    completed:    Boolean,
+    shouldNotify: Boolean,
+    obs:          List[Obs]
   ) {
 
     def valid: Boolean =
       ProgramId.parse(pid.toString).ptype.exists(_.isScience) &&
         active == Active.YES                                  &&
-        !completed
+        !completed                                            &&
+        shouldNotify
 
     /** Creates an ISPProgram matching the specification. */
     def create(f: ISPFactory, tw: List[TimingWindow]): ISPProgram = {
@@ -51,6 +53,7 @@ object Setup {
       val pd = new SPProgram
       pd.setActive(active)
       pd.setCompleted(completed)
+      pd.setTimingWindowNotification(shouldNotify)
       pn.setDataObject(pd)
 
       val ons = obs.map { o =>

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
@@ -78,6 +78,10 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _w.notifyPiCheckBox.addItemListener(e ->
                 getDataObject().setNotifyPi(_w.notifyPiCheckBox.isSelected() ? YesNoType.YES : YesNoType.NO));
 
+        _w.timingWindowNotificationCheckBox.addItemListener(e ->
+            getDataObject().setTimingWindowNotification(_w.timingWindowNotificationCheckBox.isSelected())
+        );
+
         // override green theme for value labels
         _w.totalPlannedPiTime.setForeground(Color.black);
         _w.totalPlannedExecTime.setForeground(Color.black);
@@ -136,6 +140,7 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _showActiveState();
         _showCompletedState();
         _showNotifyPiState();
+        _showTimingWindowNotificationState();
         _updateEnabledStates();
 
         // The total planed time is updated whenever the sequence or instrument
@@ -191,6 +196,10 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
 
     private void _showNotifyPiState() {
         _w.notifyPiCheckBox.setSelected(getDataObject().isNotifyPi());
+    }
+
+    private void _showTimingWindowNotificationState() {
+        _w.timingWindowNotificationCheckBox.setSelected(getDataObject().getTimingWindowNotification());
     }
 
     private void _showPiInfo() {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/ProgramForm.java
@@ -42,6 +42,8 @@ public class ProgramForm extends JPanel {
                         FormFactory.DEFAULT_ROWSPEC,
                         FormFactory.LINE_GAP_ROWSPEC,
                         FormFactory.DEFAULT_ROWSPEC,
+                        FormFactory.LINE_GAP_ROWSPEC,
+                        FormFactory.DEFAULT_ROWSPEC,
                         FormFactory.PARAGRAPH_GAP_ROWSPEC,
                         FormFactory.DEFAULT_ROWSPEC,
                         FormFactory.LINE_GAP_ROWSPEC,
@@ -65,90 +67,127 @@ public class ProgramForm extends JPanel {
                 })
         );
 
+        // Program Attribute Section
+
+        // Program Title
+        int row = 3;
+
         final JLabel titleLabel = new JLabel("Program Title");
         titleBox = new TextBoxWidget();
         titleLabel.setLabelFor(titleBox);
-        add(titleLabel, cc.xy(1, 3));
-        add(titleBox, cc.xywh(3, 3, 9, 1));
+        add(titleLabel, cc.xy(1, row));
+        add(titleBox, cc.xywh(3, row, 9, 1));
 
-        add(new JLabel("Program Reference"), cc.xy(1, 5));
+        // Program Reference
+        row += 2;
+
+        add(new JLabel("Program Reference"), cc.xy(1, row));
         progRefBox = new JLabel("GN0000000");
-        add(progRefBox, cc.xywh(3, 5, 9, 1));
+        add(progRefBox, cc.xywh(3, row, 9, 1));
 
+        // TOO Status, Active, Completed
+        row += 2;
 
-        add(new JLabel("TOO Status"), cc.xy(1, 7));
+        add(new JLabel("TOO Status"), cc.xy(1, row));
         tooStatusLabel = new JLabel();
         tooStatusLabel.setText("None");
-        add(tooStatusLabel, cc.xy(3, 7));
+        add(tooStatusLabel, cc.xy(3, row));
 
         final GridBagLayout panel1Layout = new GridBagLayout();
-        panel1Layout.columnWidths = new int[]{0, 0, 0, 0};
+        panel1Layout.columnWidths = new int[]{0, 0, 0};
         panel1Layout.rowHeights = new int[]{0, 0};
-        panel1Layout.columnWeights = new double[]{0.0, 0.0, 0.0, 1.0E-4};
+        panel1Layout.columnWeights = new double[]{0.0, 0.0, 1.0E-4};
         panel1Layout.rowWeights = new double[]{1.0, 1.0E-4};
         final JPanel panel1 = new JPanel(panel1Layout);
 
-        notifyPiCheckBox = new JCheckBox("Notify PI");
-        notifyPiCheckBox.setToolTipText("Enable/disable automatic notification of PI when data are collected");
-        panel1.add(notifyPiCheckBox, new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
+        activeCheckBox = new JCheckBox("Active");
+        activeCheckBox.setToolTipText("Mark this program as active or inactive");
+        panel1.add(activeCheckBox, new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
                     GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
                     new Insets(0, 0, 0, 0), 0, 0));
 
-        activeCheckBox = new JCheckBox("Active");
-        activeCheckBox.setToolTipText("Mark this program as active or inactive");
-        panel1.add(activeCheckBox, new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
-                    GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
-                    new Insets(0, 15, 0, 0), 0, 0));
-
         completedCheckBox = new JCheckBox("Completed");
-        panel1.add(completedCheckBox, new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0,
+        panel1.add(completedCheckBox, new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
                     GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
                     new Insets(0, 15, 0, 0), 0, 0));
 
-        add(panel1, cc.xywh(5, 7, 7, 1));
-        add(compFactory.createSeparator("Principal Investigator / Contact"), cc.xywh(1, 9, 11, 1));
+        add(panel1, cc.xywh(5, row, 7, 1, CellConstraints.LEFT, CellConstraints.DEFAULT));
 
+        // Notifications
+        row += 2;
+
+        add(new JLabel("Notifications"), cc.xy(1, row));
+
+        notifyPiCheckBox = new JCheckBox("New science data");
+        notifyPiCheckBox.setToolTipText("Enable/disable automatic notification of PI when data are collected");
+        add(notifyPiCheckBox, cc.xy(3, row, CellConstraints.LEFT, CellConstraints.DEFAULT));
+
+        timingWindowNotificationCheckBox = new JCheckBox("Expired timing windows");
+        timingWindowNotificationCheckBox.setToolTipText("Enable/disable email notifications sent for expired timing windows");
+        add(timingWindowNotificationCheckBox, cc.xywh(5, row, 7, 1, CellConstraints.LEFT, CellConstraints.DEFAULT));
+
+        // Prinicipal Investigator Section Heading
+        row += 2;
+
+        add(compFactory.createSeparator("Principal Investigator / Contact"), cc.xywh(1, row, 11, 1));
+
+        // First Name / Last Name
+        row += 2;
 
         final JLabel firstNameLabel = new JLabel("First Name");
         firstNameBox = new TextBoxWidget();
         firstNameLabel.setLabelFor(firstNameBox);
-        add(firstNameLabel, cc.xy(1, 11));
-        add(firstNameBox, cc.xy(3, 11));
+        add(firstNameLabel, cc.xy(1, row));
+        add(firstNameBox, cc.xy(3, row));
 
         final JLabel lastNamelabel = new JLabel("Last Name");
         lastNameBox = new TextBoxWidget();
         lastNamelabel.setLabelFor(lastNameBox);
-        add(lastNamelabel, cc.xywh(7, 11, 1, 1, CellConstraints.RIGHT, CellConstraints.DEFAULT));
-        add(lastNameBox, cc.xywh(9, 11, 3, 1));
+        add(lastNamelabel, cc.xywh(7, row, 1, 1, CellConstraints.RIGHT, CellConstraints.DEFAULT));
+        add(lastNameBox, cc.xywh(9, row, 3, 1));
 
-        add(new JLabel("Support"), cc.xy(1, 13));
+        // Support / Phone
+        row += 2;
+
+        add(new JLabel("Support"), cc.xy(1, row));
         affiliationBox = new JLabel();
-        add(affiliationBox, cc.xy(3, 13));
+        add(affiliationBox, cc.xy(3, row));
 
         final JLabel phoneLabel = new JLabel("Phone");
         phoneBox = new TextBoxWidget();
         phoneLabel.setLabelFor(phoneBox);
-        add(phoneLabel, cc.xywh(7, 13, 1, 1, CellConstraints.RIGHT, CellConstraints.DEFAULT));
-        add(phoneBox, cc.xywh(9, 13, 3, 1));
+        add(phoneLabel, cc.xywh(7, row, 1, 1, CellConstraints.RIGHT, CellConstraints.DEFAULT));
+        add(phoneBox, cc.xywh(9, row, 3, 1));
+
+        // PI Email
+        row += 2;
 
         final JLabel emailLabel = new JLabel("Investigator Email");
         emailBox = new TextBoxWidget();
         emailLabel.setLabelFor(emailBox);
-        add(emailLabel, cc.xy(1, 15));
-        add(emailBox, cc.xywh(3, 15, 9, 1));
+        add(emailLabel, cc.xy(1, row));
+        add(emailBox, cc.xywh(3, row, 9, 1));
+
+        // Support Email
+        row += 2;
 
         principalSupportBox = new TextBoxWidget();
         final JLabel principalSupportLabel = new JLabel("Principal Support Email");
         principalSupportLabel.setLabelFor(principalSupportBox);
-        add(principalSupportLabel, cc.xy(1, 17));
-        add(principalSupportBox, cc.xywh(3, 17, 9, 1));
+        add(principalSupportLabel, cc.xy(1, row));
+        add(principalSupportBox, cc.xywh(3, row, 9, 1));
 
-        add(new JLabel("Additional Support Email"), cc.xy(1, 19));
+        // Additional Support Email
+        row += 2;
+
+        add(new JLabel("Additional Support Email"), cc.xy(1, row));
         additionalSupportBox = new JLabel();
-        add(additionalSupportBox, cc.xywh(3, 19, 9, 1));
+        add(additionalSupportBox, cc.xywh(3, row, 9, 1));
 
-        // --- Observing Time ---
-        add(compFactory.createSeparator("Observing Time"), cc.xywh(1, 21, 11, 1));
+        // Observing Time Section Header
+        row += 2;
+
+        add(compFactory.createSeparator("Observing Time"), cc.xywh(1, row, 11, 1));
         final JPanel timePanel = new JPanel(new FormLayout(
                     new ColumnSpec[]{
                             new ColumnSpec(ColumnSpec.CENTER, Sizes.dluX(36), FormSpec.NO_GROW),
@@ -218,22 +257,25 @@ public class ProgramForm extends JPanel {
         remainingTime.setToolTipText("Remaining Program Time (total of Allocated Program Time minus the sum of the Program Time fields in the observations)");
         timePanel.add(remainingTime, cc.xy(13, 5));
 
-        add(timePanel, cc.xywh(1, 23, 11, 1));
+        row += 2;
+        add(timePanel, cc.xywh(1, row, 11, 1));
 
-        // --- History ---
+        // History
+        row += 2;
         final JPanel historyPanel = new JPanel(new BorderLayout());
         historyTable = new JTable();
         historyTable.setBackground(Color.lightGray);
         historyPanel.add(new JScrollPane(historyTable), BorderLayout.CENTER);
         tabbedPane = new JTabbedPane();
         tabbedPane.addTab("Sync History", historyPanel);
-        add(tabbedPane, cc.xywh(1, 25, 11, 1));
+        add(tabbedPane, cc.xywh(1, row, 11, 1));
     }
 
     final TextBoxWidget titleBox;
     final JLabel progRefBox;
     final JLabel tooStatusLabel;
     final JCheckBox notifyPiCheckBox;
+    final JCheckBox timingWindowNotificationCheckBox;
     final JCheckBox activeCheckBox;
     final JCheckBox completedCheckBox;
     final TextBoxWidget firstNameBox;


### PR DESCRIPTION
This PR finishes REL-361 by adding a support for a requirement found in the comment section that I had overlooked in #1576.  Namely, it provides a timing window notification override flag that can be set by anybody with access to the program in the top-level node editor. 

> Recently there have been some programs that create many (~100) observations with one timing window per observation, for example, GN-2018A-Q-124 NIRI observations of Io. Programs like this may prefer to not get an email every time a window expires. One possible solution would be to add a checkbox at the top of the program "Notify of expired timing windows" where PIs can opt-out of these emails. In this case, we may want to relabel the "Notify PI" checkbox and possibly put the two notification checkboxes on a new line, e.g.:
>Notifications: [] New science data   [] Expired timing windows

![screen shot 2018-10-25 at 12 14 56](https://user-images.githubusercontent.com/4906023/47511081-d5748780-d84f-11e8-9466-2c069b8cfb3f.png)
