### PR TITLE
REL-2630: Changes to chart colors

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ITCChart.java
+++ b/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ITCChart.java
@@ -60,8 +60,8 @@ public final class ITCChart {
     }
 
     // some specific colors, used for blue/green/red detectors (GMOS)
-    public static Color LightBlue  = Colors.get(0);
-    public static Color DarkBlue   = Colors.get(1);
+    public static Color DarkBlue   = Colors.get(0);
+    public static Color LightBlue  = Colors.get(1);
     public static Color LightGreen = Colors.get(2);
     public static Color DarkGreen  = Colors.get(3);
     public static Color LightRed   = Colors.get(4);

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -668,8 +668,8 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
                 colorFin = ITCChart.LightRed;
             }
 
-            series.add(SpcSeriesData.withVisibility(!disableLegend, SingleS2NData.instance(), s2nTitle, s2n, new Some<>(colorS2N)));
-            series.add(SpcSeriesData.withVisibility(!disableLegend, FinalS2NData.instance(), finTitle, fin, new Some<>(colorFin)));
+            series.add(SpcSeriesData.withVisibility(!disableLegend, SingleS2NData.instance(), s2nTitle, s2n, new Some<>(colorFin)));
+            series.add(SpcSeriesData.withVisibility(!disableLegend, FinalS2NData.instance(), finTitle, fin, new Some<>(colorS2N)));
         }
         return series;
     }


### PR DESCRIPTION
GMOS I changed the GMOSrecipe directly, as it was explicity defined what colors are assigned to what data series. F2, NIFS, NIRI, and GNIRS only need the "Signal" and "SQRT" data series reversed (the S2N charts for these instruments already fit the requested color scheme). For this, I reversed the color indices in ITCchart.java -with suggestions from Sebastian - to reverse the data colors. Tested web bundle before creating pull request. 