### PR TITLE
REL-3530 Update 2MASS image server URL in the OT

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalog.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalog.scala
@@ -88,7 +88,7 @@ abstract class AstroCatalog(id: CatalogId, displayName: String, shortName: Strin
   def adjacentOverlap: Angle = Angle.zero
 
   override def queryUrl(c: Coordinates, site: Option[Site]): NonEmptyList[URL] =
-    NonEmptyList(new URL(s" http://irsa.ipac.caltech.edu/cgi-bin/Oasis/2MASSImg/nph-2massimg?objstr=${c.ra.toAngle.formatHMS}%20${c.dec.formatDMS}&size=${size.toArcsecs.toInt}&band=${band.name}"))
+    NonEmptyList(new URL(s" https://irsa.ipac.caltech.edu:443/cgi-bin/Oasis/2MASSImg/nph-2massimg?objstr=${c.ra.toAngle.formatHMS}%20${c.dec.formatDMS}&size=${size.toArcsecs.toInt}&band=${band.name}"))
 }
 
 // Concrete instances of image catalogs


### PR DESCRIPTION
This updates the 2MASS image server URL used by the TPE … they switched to SSL for some reason. Tested on a handful of targets. Works, also pretty fast.