### PR TITLE
REL-3519: make twilight calculation consistent

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import edu.gemini.qpt.core.Alloc;
 import edu.gemini.qpt.core.Marker;
+import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.Variant;
 import edu.gemini.qpt.core.Alloc.Circumstance;
 import edu.gemini.qpt.core.Marker.Severity;
@@ -40,9 +41,14 @@ public class LimitsListener extends MarkerModelListener<Variant> {
     public static final int MIN_ELEVATION_WARN_LIMIT = 42;
 
     public void propertyChange(PropertyChangeEvent evt) {
-        Variant v = (Variant) evt.getSource();
-        MarkerManager mm = v.getSchedule().getMarkerManager();
+        final Variant  v               = (Variant) evt.getSource();
+        final Schedule schedule        = v.getSchedule();
+        final MarkerManager mm         = schedule.getMarkerManager();
         mm.clearMarkers(this, v);
+
+        final TwilightBoundedNight tbn = Twilight.forTime(schedule.getStart(), schedule.getSite());
+        final Interval nightInterval   = new Interval(tbn.getStartTime(), tbn.getEndTime());
+        final Supplier<Union<Interval>> wholeNight = () -> new Union<>(nightInterval);
 
         for (Alloc a: v.getAllocs()) {
 
@@ -96,14 +102,11 @@ public class LimitsListener extends MarkerModelListener<Variant> {
                 mm.addMarker(false, this, Severity.Warning, msg, v, a);
             }
 
-            final TwilightBoundedNight tbn = Twilight.forTime(a.getStart(), v.getSchedule().getSite());
-            final Interval nightInterval   = new Interval(tbn.getStartTime(), tbn.getEndTime());
-            final Supplier<Union<Interval>> wholeNight = () -> new Union<>(nightInterval);
 
             final BiFunction<Function<Interval, Long>, String, Predicate<Long>> matchWith =
                 (f, cacheName) ->
                     ts -> {
-                        final Map<Obs, Union<Interval>> c = v.getSchedule().getCache(cacheName);
+                        final Map<Obs, Union<Interval>> c = schedule.getCache(cacheName);
                         final Union<Interval> u = c.getOrDefault(a.getObs(), new Union<>());
 
                         return u.getIntervals().stream().anyMatch(i -> f.apply(i).equals(ts));
@@ -139,7 +142,7 @@ public class LimitsListener extends MarkerModelListener<Variant> {
             // Function to create markers that report solver intervals.
             final Supplier<Option<Marker>> createSolverMarker =
                 () -> {
-                    final Map<Obs, Union<Interval>> c = v.getSchedule().getCache(Variant.CONSTRAINED_UNION_CACHE);
+                    final Map<Obs, Union<Interval>> c = schedule.getCache(Variant.CONSTRAINED_UNION_CACHE);
                     final Union<Interval>       valid = c.getOrDefault(a.getObs(), new Union<>());
                     final Union<Interval>     invalid = wholeNight.get();
                     invalid.remove(valid);

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Ephemeris.scala
@@ -20,7 +20,7 @@ final class Ephemeris(val site: Site, val compressedData: Deflated[List[(Long, F
 
     // Decompress if needed
     if (_data == null) {
-      logger.info("Inflating compressed ephemeris.")
+      logger.fine("Inflating compressed ephemeris.")
       _data = ==>>.fromList(compressedData.inflate.map { case (t, r, d) =>
         t -> Coordinates.fromDegrees(r, d).getOrElse(sys.error(s"corrupted ephemeris data: $t $r $d"))
       })
@@ -30,7 +30,7 @@ final class Ephemeris(val site: Site, val compressedData: Deflated[List[(Long, F
     if (_task != null) _task.cancel()
     _task = new TimerTask {
       def run(): Unit = {
-        logger.info("Discarding inflated ephemeris.")
+        logger.fine("Discarding inflated ephemeris.")
         Ephemeris.this.synchronized(_data = null)
       }
     }
@@ -86,7 +86,7 @@ final class Ephemeris(val site: Site, val compressedData: Deflated[List[(Long, F
     Ephemeris.apply(site, data)
 
   override def equals(a: Any): Boolean =
-    a match { 
+    a match {
       case e: Ephemeris => e.site == site && e.compressedData == compressedData
       case _            => false
     }


### PR DESCRIPTION
This PR makes a small but important change to the way that the twilight bounds are calculated for the purpose of adding markers explaining observability limits.  Instead of repeatedly calculating the twilight bounds based on the time of individual allocations, we make it consistent with the schedule caches themselves using the schedule start time as a whole.

This fixes an issue in which an allocation well off of the night into the morning (when adjusted from a previous schedule and used as a template) was triggering an exception.