### PR TITLE
REL-3533: null check now performed after call to getObsAsterism.

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -548,7 +548,7 @@ public class GeneralRule implements IRule {
             if (templateFolderNode != null) {
 
                 final Asterism a = getObsAsterism(elements);
-                if (a.asterismType() == AsterismType.Single) {
+                if (a != null && a.asterismType() == AsterismType.Single) {
                     // There should be only one target here, namely the science target.
                     a.allSpTargetsJava().foreach(obsTarget -> {
                         // We're going to drive this off the target, so we first want to narrow it


### PR DESCRIPTION
The only P2 rule using a call to `getObsAsterism` was not checking `null`, which the method can return, thus causing a NPE in the OT when trying to open programs.