### PR TITLE
REL-3519: empty schedules have no start

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/listeners/LimitsListener.java
@@ -43,6 +43,11 @@ public class LimitsListener extends MarkerModelListener<Variant> {
     public void propertyChange(PropertyChangeEvent evt) {
         final Variant  v               = (Variant) evt.getSource();
         final Schedule schedule        = v.getSchedule();
+
+        if (!schedule.isEmpty()) updateLimits(v, schedule);
+    }
+
+    private void updateLimits(final Variant v, final Schedule schedule) {
         final MarkerManager mm         = schedule.getMarkerManager();
         mm.clearMarkers(this, v);
 


### PR DESCRIPTION
An addendum to #1581, empty schedules like the ones you (temporarily) get when creating a new plan, have no start and therefore no allocs nor markers.  Since we're now relying on `Schedule.getStart()` to figure out the twilight bounds the schedule needs a start or else the call to `getStart()` generates an `IllegalStateException("Schedule is empty.")`.