### PR TITLE
REL-3536: Added ri filter for GMOS-N.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
@@ -186,6 +186,7 @@ public class GmosNorthType {
         Ha_G0310("Ha_G0310", "Ha", "0.655",          Ictd.track("Ha")),
         HaC_G0311("HaC_G0311", "HaC", "0.662",       Ictd.track("HaC")),
         DS920_G0312("DS920_G0312", "DS920", "0.920", Ictd.track("DS920")),
+        RI_G0349("ri_G0349", "ri", "0.700",          Ictd.track("ri")),
         SII_G0317("SII_G0317", "SII", "0.672",       Ictd.track("SII")),
         OIII_G0318("OIII_G0318", "OIII", "0.499",    Ictd.track("OIII")),
         OIIIC_G0319("OIIIC_G0319", "OIIIC", "0.514", Ictd.track("OIIIC")),


### PR DESCRIPTION
We have a new filter for GMOS-N: this just adds it.

It's taking the place of `DS920_G0312`, but I have been told not to obsolete it.