### PR TITLE
REL-3545: ancillary changes around OcsCredentials update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ jres.sbt
 app/**/idea
 *.iml
 *.ipr
+*.iws
 
 # Eclipse specific
 .project

--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -24,7 +24,6 @@ ocsAppManifest := {
         with_gogo(v),
           rnorris(v),
           swalker(v),
-          dnavarro(v),
           jluhrs(v),
           cquiroz(v),
           sraaphorst(v),
@@ -233,36 +232,6 @@ def swalker(version: Version) = AppConfig(
     "edu.gemini.util.trpc.name"                  -> "Shane's ODB (Test)"
   )
 ) extending List(with_gogo(version), swalker_credentials(version))
-
-// DNAVARRO
-def dnavarro(version: Version) = AppConfig(
-  id = "dnavarro",
-  distribution = List(TestDistro),
-  vmargs = List(
-    "-Xmx1024M",
-    "-Dcom.cosylab.epics.caj.CAJContext.addr_list=172.17.2.255",
-    "-Dedu.gemini.site=south",
-    "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005",
-    "-Dcron.*.edu.gemini.dbTools.html.ftpHost=localhost",
-    "-Dcron.*.edu.gemini.dbTools.html.ftpDestDir=/Users/jnavarro/sftp",
-    "-Dcron.reports.edu.gemini.spdb.reports.public.host=localhost",
-    "-Dcron.reports.edu.gemini.spdb.reports.public.remotedir=/Users/jnavarro/cron",
-    "-Dcron.archive.edu.gemini.dbTools.html.ftpHost=localhost",
-    "-Dcron.archive.edu.gemini.dbTools.html.ftpDestDir=/Users/jnavarro/cron"
-  ),
-  props = Map(
-    "edu.gemini.auxfile.fits.dest"               -> "/gemsoft/var/data/ictd/test/GS@SEMESTER@/@PROG_ID@",
-    "edu.gemini.auxfile.fits.host"               -> "gsconfig.gemini.edu",
-    "edu.gemini.auxfile.other.dest"              -> "/gemsoft/var/data/finder/GSqueue/Finders-Test/@SEMESTER@/@PROG_ID@",
-    "edu.gemini.auxfile.root"                    -> "/Users/jnavarro/.auxfile",
-    "edu.gemini.dataman.gsa.summit.host"         -> "cpofits-lv1new.cl.gemini.edu",
-    "edu.gemini.dbTools.tcs.ephemeris.directory" -> "/Users/jnavarro/.ephemeris",
-    "edu.gemini.services.server.start"           -> "false",
-    "edu.gemini.smartgcal.host"                  -> "localhost",
-    "edu.gemini.spdb.dir"                        -> "/Users/jnavarro/.spdb/",
-    "edu.gemini.util.trpc.name"                  -> "Dannys's ODB (Test)"
-  )
-) extending List(with_gogo(version), dnavarro_credentials(version))
 
 // FNUSSBER
 def fnussber(version: Version) = AppConfig(


### PR DESCRIPTION
`OcsCredentials.scala` (from the `ocs-credentials` svn project) needed an update to make the test and production ICTD configuration work for the ODB.  Along the way, I removed the `dnavarro` config and updated the `.gitignore` to ignore Idea's `.iws` files.

In other words, this PR doesn't fix the problem with the ICTD configuration but was necessitated by updates to OCS credentials that do fix the problem.

<b>Update your `ocs-credentials` project when this is merged.</b>