### PR TITLE
REL-3519: check usages of viewer.getModel()

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/problem/ProblemController.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/problem/ProblemController.java
@@ -4,24 +4,35 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Collections;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import edu.gemini.qpt.core.Marker;
 import edu.gemini.qpt.core.Schedule;
 import edu.gemini.qpt.core.util.MarkerManager;
 import edu.gemini.qpt.ui.util.TimePreference;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.ui.gface.GTableController;
 import edu.gemini.ui.gface.GViewer;
 
 public class ProblemController implements GTableController<Schedule, Marker, ProblemAttribute>, PropertyChangeListener {
+    private static final Logger LOG = Logger.getLogger(ProblemController.class.getName());
 
     private GViewer<Schedule, Marker> viewer;
     private MarkerManager manager;
     private Marker[] markers;
-    
+
     public synchronized Object getSubElement(Marker element, ProblemAttribute subElement) {
         if (element != null) {
             switch (subElement) {
-            case Description: return element.getUnionText(viewer.getModel().getSite());
+            case Description:
+                final String d = ImOption.apply(viewer.getModel())
+                                         .map(s -> element.getUnionText(s.getSite()))
+                                         .getOrNull();
+                if (d == null) {
+                    LOG.warning("Prevented attempt to get site for a null schedule.  Returning null description.");
+                }
+
+                return d;
             case Resource: return element.getTarget();
             case Severity: return element.getSeverity();
             }
@@ -39,7 +50,7 @@ public class ProblemController implements GTableController<Schedule, Marker, Pro
 
     public synchronized void modelChanged(GViewer<Schedule, Marker> viewer, Schedule oldModel, Schedule newModel) {
         this.viewer = viewer;
-        
+
         if (manager != null) manager.removePropertyChangeListener(this);
         manager = newModel == null ? null : newModel.getMarkerManager();
         if (manager != null) manager.addPropertyChangeListener(this);
@@ -59,5 +70,5 @@ public class ProblemController implements GTableController<Schedule, Marker, Pro
         Set<Marker> set = manager == null ? Collections.<Marker>emptySet() : manager.getMarkers();
         markers = set.toArray(new Marker[set.size()]);
     }
-    
+
 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/variant/VariantViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/variant/VariantViewAdvisor.java
@@ -38,6 +38,7 @@ import edu.gemini.qpt.ui.util.SimpleToolbar.IconButton;
 import edu.gemini.qpt.ui.util.SimpleToolbar.StaticText;
 import edu.gemini.qpt.ui.view.variant.edit.DeleteAction;
 import edu.gemini.qpt.ui.view.variant.edit.PasteAction;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.ui.gface.GSelection;
 import edu.gemini.ui.gface.GSelectionBroker;
 import edu.gemini.ui.gface.GTableViewer;
@@ -50,11 +51,11 @@ import edu.gemini.ui.workspace.util.Factory;
 public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener, ActionListener {
 
     private static final Logger LOGGER = Logger.getLogger(VariantViewAdvisor.class.getName());
-    
+
     private IViewContext context;
 
     // This viewer is the main thing here.
-    private GTableViewer<Schedule, Variant, VariantAttribute> viewer  = 
+    private GTableViewer<Schedule, Variant, VariantAttribute> viewer  =
         new GTableViewer<Schedule, Variant, VariantAttribute>(new VariantController());
 
     // UI Stuff
@@ -66,8 +67,8 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
     private final JButton down = new IconButton(ARROW_DOWN, ARROW_DOWN_DISABLED);
     private final JLabel text = new StaticText("Double-click a variant to edit it.");
     private final JPanel toolbar = new SimpleToolbar();
-    private final JPanel content = new JPanel(new BorderLayout());    
-    
+    private final JPanel content = new JPanel(new BorderLayout());
+
     // All buttons in one place
     private final JButton[] buttons = { add, del, dup, up, down };
 
@@ -84,10 +85,10 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
         viewer.setColumnSize(VariantAttribute.LGS, 25);
         viewer.getTable().addMouseListener(doubleClickToEditListener);
         viewer.setDecorator(new VariantDecorator());
-        
+
         // Set the viewport size for the scrollpane
         ScrollPanes.setViewportHeight(scroll, 11);
-        
+
         // Set up the toolbar.
         for (JButton b: buttons) {
             b.setEnabled(false);
@@ -99,20 +100,20 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
         // Put it all together.
         content.add(scroll, BorderLayout.CENTER);
         content.add(toolbar, BorderLayout.SOUTH);
-        
+
     }
-    
+
     @SuppressWarnings("serial")
     public void open(IViewContext viewContext) {
-        
+
         context = viewContext;
         context.setTitle("Plan Variants");
         context.setContent(content);
         context.getShell().addPropertyChangeListener(IShell.PROP_MODEL, this);
-    
+
         context.addRetargetAction(CommonActions.PASTE, new PasteAction(context.getShell(), viewer, true));
         context.addRetargetAction(CommonActions.DELETE, new DeleteAction(context.getShell(), viewer));
-    
+
     }
 
     public void close(IViewContext context) {
@@ -125,7 +126,7 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
 
     @SuppressWarnings("unchecked")
     public void propertyChange(PropertyChangeEvent pce) {
-        
+
         if (pce.getPropertyName().equals(IShell.PROP_MODEL)) {
 
             // Set the new model
@@ -140,7 +141,7 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
                 add.setEnabled(true);
             }
 
-            // This is an odd case where the selection is actually relevant to 
+            // This is an odd case where the selection is actually relevant to
             // the model, so we need to push an initial selection down into
             // the view.
             if (schedule != null) {
@@ -149,17 +150,17 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
                     viewer.setSelection(new GSelection<Variant>(v));
                 }
             }
-            
+
         }
-        
+
         if (pce.getPropertyName().equals(GSelectionBroker.PROP_SELECTION)) {
-            
+
             if (pce.getSource() == viewer) {
-                
+
                 // User clicked on something (somewhere)
                 GSelection<Variant> sel = viewer.getSelection();
                 Schedule schedule = viewer.getModel();
-                
+
                 // Set the current variant and assert it as our selection.
                 if (schedule != null) {
                     schedule.setCurrentVariant(sel.isEmpty() ? null : sel.first());
@@ -170,47 +171,52 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
                 // Set button enablement (except for add, which is enabled based on the schedul
                 // being null or not -- see the PROP_MODEL handler above).
                 if (sel.isEmpty()) {
-                    
+
                     // All disabled.
                     up.setEnabled(false);
                     down.setEnabled(false);
                     dup.setEnabled(false);
                     del.setEnabled(false);
-                    
+
                 } else {
-                    
+
                     // Dup and del are enabled.
                     dup.setEnabled(true);
                     del.setEnabled(true);
-                    
+
                     // Up and down depend on the selection AND the position in the list,
                     // so we need to call this method both here AND when the reorder methods
                     // are called (since they change the position but not the selection).
-                    setUpDownEnabledState(sel);                    
-                    
+                    setUpDownEnabledState(sel);
+
                 }
-                
+
             }
-            
+
         }
-        
+
     }
 
     private void setUpDownEnabledState(GSelection<Variant> sel) {
-        
+
         // Should never be empty
         assert !sel.isEmpty();
-        
+
         // Up and down depend on whether we have selected the first or last variant.
         // Remember that the viewer is not sorting or filtering any of the variants; we
         // are viewing the full model list in the model-specified order. So we can just
         // look at the model to figure this out.
-        Schedule schedule = viewer.getModel();
-        Variant v = sel.first(); 
-        List<Variant> all = schedule.getVariants();
-        up.setEnabled(v != all.get(0));
-        down.setEnabled(v != all.get(all.size() - 1));
-        
+        final Schedule schedule = viewer.getModel();
+        if (schedule == null) {
+            up.setEnabled(false);
+            down.setEnabled(false);
+        } else {
+            final Variant v = sel.first();
+            final List<Variant> all = schedule.getVariants();
+            up.setEnabled(v != all.get(0));
+            down.setEnabled(v != all.get(all.size() - 1));
+        }
+
     }
 
     public void actionPerformed(ActionEvent e) {
@@ -219,51 +225,52 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
         Object source = e.getSource();
         GSelection<Variant> sel = viewer.getSelection();
         Variant v = sel.isEmpty() ? null : sel.first();
-        Schedule schedule = viewer.getModel();
-        
-        // Force a repaint of the action if it's a button. This is an AWT bug.
-        if (source instanceof JButton)
-            ((JButton) source).repaint();
-        
-        if (source == add) {
 
-            // Add a new variant. Selection will not change but position might.
-            VariantEditor ve = new VariantEditor(context.getShell().getPeer());
-            if (JOptionPane.CANCEL_OPTION != ve.showNew("Untitled", (byte) 0, (byte) 0, (byte) 0))
-                schedule.addVariant(ve.getVariantName(), ve.getVariantConditions(), ve.getVariantWindConstraint(), ve.getVariantLgsConstraint());
-            setUpDownEnabledState(sel); 
+        ImOption.apply(viewer.getModel()).foreach(schedule -> {
 
-        } else if (source == del) {
+            // Force a repaint of the action if it's a button. This is an AWT bug.
+            if (source instanceof JButton)
+                ((JButton) source).repaint();
 
-            // Delete the selected variant. Selection will change.
-            if (JOptionPane.NO_OPTION == JOptionPane.showConfirmDialog(context.getShell().getPeer(), 
+            if (source == add) {
+
+                // Add a new variant. Selection will not change but position might.
+                VariantEditor ve = new VariantEditor(context.getShell().getPeer());
+                if (JOptionPane.CANCEL_OPTION != ve.showNew("Untitled", (byte) 0, (byte) 0, (byte) 0))
+                    schedule.addVariant(ve.getVariantName(), ve.getVariantConditions(), ve.getVariantWindConstraint(), ve.getVariantLgsConstraint());
+                setUpDownEnabledState(sel);
+
+            } else if (source == del) {
+
+                // Delete the selected variant. Selection will change.
+                if (JOptionPane.NO_OPTION == JOptionPane.showConfirmDialog(context.getShell().getPeer(),
                         "Do you really want to remove this variant?",
                         "Confirm Remove", JOptionPane.YES_NO_OPTION))
                     return;
-            
-            schedule.removeVariant(v);
-                
-        } else if (source == up) {
 
-            // Move up. Selection will not change but position will.
-            schedule.moveVariant(v, -1);            
-            setUpDownEnabledState(sel); 
-                
-        } else if (source == down) {
+                schedule.removeVariant(v);
 
-            // Move down. Selection will not change but position will.
-            schedule.moveVariant(v, 1);    
-            setUpDownEnabledState(sel); 
-                
-        } else if (source == dup) {
+            } else if (source == up) {
 
-            // Duplicate. Selection will not change but position might.
-            Variant dup = schedule.duplicateVariant(v);
-            dup.setName("Copy of " + dup.getName());
-            setUpDownEnabledState(sel); 
-            
-        }
-        
+                // Move up. Selection will not change but position will.
+                schedule.moveVariant(v, -1);
+                setUpDownEnabledState(sel);
+
+            } else if (source == down) {
+
+                // Move down. Selection will not change but position will.
+                schedule.moveVariant(v, 1);
+                setUpDownEnabledState(sel);
+
+            } else if (source == dup) {
+
+                // Duplicate. Selection will not change but position might.
+                Variant dup = schedule.duplicateVariant(v);
+                dup.setName("Copy of " + dup.getName());
+                setUpDownEnabledState(sel);
+
+            }
+        });
     }
 
     private final MouseListener doubleClickToEditListener = new MouseAdapter() {
@@ -276,7 +283,7 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
                     Variant v = sel.first();
                     if (JOptionPane.CANCEL_OPTION != ve.showEditor(v)) {
                         v.setName(ve.getVariantName());
-                        v.setConditions(ve.getVariantConditions());        
+                        v.setConditions(ve.getVariantConditions());
                         v.setWindConstraint(ve.getVariantWindConstraint());
                         v.setLgsConstraint(ve.getVariantLgsConstraint());
                     }
@@ -284,7 +291,7 @@ public class VariantViewAdvisor implements IViewAdvisor, PropertyChangeListener,
             }
         }
     };
-    
+
 }
 
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/edit/CutAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/edit/CutAction.java
@@ -10,37 +10,40 @@ import edu.gemini.qpt.core.Alloc;
 import edu.gemini.qpt.core.Variant;
 import edu.gemini.qpt.ui.util.CancelledException;
 import edu.gemini.qpt.ui.util.VariantEditHelper;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.ui.gface.GSelection;
 import edu.gemini.ui.gface.GViewer;
 import edu.gemini.ui.workspace.IShell;
 
 @SuppressWarnings("serial")
 public class CutAction extends AbstractAction implements PropertyChangeListener {
-    
+
     private final IShell shell;
     private final GViewer<Variant, Alloc> viewer;
-    
+
     public CutAction(final IShell shell, final GViewer<Variant, Alloc> viewer) {
         this.shell = shell;
         this.viewer = viewer;
         setEnabled(false);
         viewer.addPropertyChangeListener(GViewer.PROP_SELECTION, this);
     }
-    
+
     public void actionPerformed(ActionEvent e) {
         GSelection<Alloc> sel = viewer.getSelection();
         VariantEditHelper veh = new VariantEditHelper(shell.getPeer());
-        try {
-            GSelection<Alloc> cut = veh.cut(viewer.getModel(), sel);
-            shell.getWorkspaceClipboard().setContents(cut, null);
-        } catch (CancelledException e1) {
-            // user hit cancel; this is ok
-        }
+        ImOption.apply(viewer.getModel()).foreach(variant -> {
+            try {
+                GSelection<Alloc> cut = veh.cut(variant, sel);
+                shell.getWorkspaceClipboard().setContents(cut, null);
+            } catch (CancelledException e1) {
+                // user hit cancel; this is ok
+            }
+        });
     }
 
     public void propertyChange(PropertyChangeEvent evt) {
         GSelection<?> sel = (GSelection<?>) evt.getNewValue();
         setEnabled(sel.isSelectionOf(Alloc.class));
-    }    
-    
+    }
+
 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/edit/DeleteAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/edit/DeleteAction.java
@@ -10,36 +10,39 @@ import edu.gemini.qpt.core.Alloc;
 import edu.gemini.qpt.core.Variant;
 import edu.gemini.qpt.ui.util.CancelledException;
 import edu.gemini.qpt.ui.util.VariantEditHelper;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.ui.gface.GSelection;
 import edu.gemini.ui.gface.GViewer;
 import edu.gemini.ui.workspace.IShell;
 
 @SuppressWarnings("serial")
 public class DeleteAction extends AbstractAction implements PropertyChangeListener {
-    
+
     private final GViewer<Variant, Alloc> viewer;
     private final IShell shell;
-    
+
     public DeleteAction(final IShell shell, final GViewer<Variant, Alloc> viewer) {
         this.shell = shell;
         this.viewer = viewer;
         setEnabled(false);
         viewer.addPropertyChangeListener(GViewer.PROP_SELECTION, this);
     }
-    
+
     public void actionPerformed(ActionEvent e) {
         GSelection<Alloc> sel = viewer.getSelection();
         VariantEditHelper veh = new VariantEditHelper(shell.getPeer());
-        try {
-            veh.cut(viewer.getModel(), sel);
-        } catch (CancelledException e1) {
-            // user hit cancel; this is ok
-        }
+        ImOption.apply(viewer.getModel()).foreach(variant -> {
+            try {
+                veh.cut(variant, sel);
+            } catch (CancelledException e1) {
+                // user hit cancel; this is ok
+            }
+        });
     }
 
     public void propertyChange(PropertyChangeEvent evt) {
         GSelection<?> sel = (GSelection<?>) evt.getNewValue();
         setEnabled(sel.isSelectionOf(Alloc.class));
-    }    
-    
+    }
+
 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/edit/PasteAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/edit/PasteAction.java
@@ -16,6 +16,7 @@ import edu.gemini.qpt.core.Alloc;
 import edu.gemini.qpt.core.Variant;
 import edu.gemini.qpt.ui.util.CancelledException;
 import edu.gemini.qpt.ui.util.VariantEditHelper;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.ui.gface.GSelection;
 import edu.gemini.ui.gface.GViewer;
 import edu.gemini.ui.workspace.IShell;
@@ -23,21 +24,21 @@ import edu.gemini.ui.workspace.IShell;
 // not threadsafe, but does'nt really matter
 @SuppressWarnings("serial")
 public class PasteAction extends AbstractAction implements FlavorListener, PropertyChangeListener {
-    
+
     enum Resolutions {
         Skip,
         Replace,
         Cancel
     }
-    
-    private static final DataFlavor SELECTION_OF_ALLOCS = 
+
+    private static final DataFlavor SELECTION_OF_ALLOCS =
         GSelection.flavorForSelectionOf(Alloc.class);
-    
+
     private final IShell shell;
     private final GViewer<Variant, Alloc> viewer;
-    
+
     private boolean modelAvailable, clipAvailable;
-    
+
     public PasteAction(final IShell shell, final GViewer<Variant, Alloc> viewer) {
         this.shell = shell;
         this.viewer = viewer;
@@ -45,26 +46,26 @@ public class PasteAction extends AbstractAction implements FlavorListener, Prope
         viewer.addPropertyChangeListener(GViewer.PROP_MODEL, this);
         updateEnabledState();
     }
-    
+
     @SuppressWarnings("unchecked")
     public void actionPerformed(ActionEvent e) {
-        try {
-            
-            GSelection<Alloc> paste = (GSelection<Alloc>) shell.getWorkspaceClipboard().getData(SELECTION_OF_ALLOCS);
-            Variant target = viewer.getModel();
-            VariantEditHelper veh = new VariantEditHelper(shell.getPeer());
-            GSelection<Alloc> pasted = veh.paste(target, paste);
-            viewer.setSelection(pasted);
-                        
-        } catch (UnsupportedFlavorException e1) {
-            // TODO Auto-generated catch block
-            e1.printStackTrace();
-        } catch (IOException e1) {
-            // TODO Auto-generated catch block
-            e1.printStackTrace();
-        } catch (CancelledException ce) {
-            // ok
-        }        
+        ImOption.apply(viewer.getModel()).foreach(target -> {
+            try {
+                GSelection<Alloc> paste = (GSelection<Alloc>) shell.getWorkspaceClipboard().getData(SELECTION_OF_ALLOCS);
+                VariantEditHelper veh = new VariantEditHelper(shell.getPeer());
+                GSelection<Alloc> pasted = veh.paste(target, paste);
+                viewer.setSelection(pasted);
+
+            } catch (UnsupportedFlavorException e1) {
+                // TODO Auto-generated catch block
+                e1.printStackTrace();
+            } catch (IOException e1) {
+                // TODO Auto-generated catch block
+                e1.printStackTrace();
+            } catch (CancelledException ce) {
+                // ok
+            }
+        });
     }
 
     public void flavorsChanged(FlavorEvent e) {
@@ -81,5 +82,5 @@ public class PasteAction extends AbstractAction implements FlavorListener, Prope
         modelAvailable = viewer.getModel() != null;
         updateEnabledState();
     }
-    
+
 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/edit/SelectAllAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/edit/SelectAllAction.java
@@ -9,6 +9,7 @@ import javax.swing.AbstractAction;
 
 import edu.gemini.qpt.core.Alloc;
 import edu.gemini.qpt.core.Variant;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.ui.gface.GSelection;
 import edu.gemini.ui.gface.GViewer;
 
@@ -24,8 +25,10 @@ public class SelectAllAction extends AbstractAction implements PropertyChangeLis
     }
 
     public void actionPerformed(ActionEvent e) {
-        Collection<Alloc> all = viewer.getModel().getAllocs();
-        viewer.setSelection(new GSelection<>(all.toArray(new Alloc[all.size()])));
+        ImOption.apply(viewer.getModel()).foreach(variant -> {
+            Collection<Alloc> all = variant.getAllocs();
+            viewer.setSelection(new GSelection<>(all.toArray(new Alloc[all.size()])));
+        });
     }
 
     public void propertyChange(PropertyChangeEvent evt) {


### PR DESCRIPTION
`edu.gemini.ui.gface.GViewer` maintains a nullable `model` field.  It was implemented years before the `Option` concept was fully understood in the Java world and has caused problems, particularly for drag and drop, in the QPT.  Ideally we would refactor `model` to wrap it in an `Option` and in fact I started down that path.  Because the change was beginning to grow beyond what I'm confortable updating during the testing period I punted though and just started doing `null` checks. 

This PR looks more daunting than it actually is because the editor has trimmed trailing whitespace.  If we could ignore whitespace the changes view would be much smaller.