### PR TITLE
REL-3519: warn if plan contains out of range allocs

### DIFF
--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/DefaultImList.java
@@ -364,6 +364,11 @@ public final class DefaultImList<T> implements ImList<T>, Serializable {
         return StreamSupport.stream(spliterator(), false);
     }
 
+    @Override
+    public ImList<T> take(int n) {
+        final int to = Math.min(n, backingList.size());
+        return (to < 0) ? ImCollections.<T>emptyList() : new DefaultImList<>(backingList.subList(0, to));
+    }
 
     /**
      * Calls {@link #mkString(String, String, String)} with the arguments

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImCollections.java
@@ -229,6 +229,11 @@ public class ImCollections {
             return Collections.emptyList().iterator();
         }
 
+        @Override
+        public ImList<Object> take(int n) {
+            return this;
+        }
+
         private Object readResolve() {
             return EMPTY_LIST;
         }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImList.java
@@ -445,4 +445,12 @@ public interface ImList<T> extends Iterable<T> {
      *         }}}
      */
     <K> HashMap<K, ImList<T>> groupBy(Function1<? super T, K> f);
+
+    /**
+     * Selects the first n elements.
+     * @param n the number of elements to take from the list
+     * @return a list consisting only of the first n elements of this list, or
+     * else the whole list if it has less than n elements
+     */
+    ImList<T> take(int n);
 }

--- a/bundle/edu.gemini.shared.util/src/test/java/edu/gemini/shared/util/immutable/ImListTest.java
+++ b/bundle/edu.gemini.shared.util/src/test/java/edu/gemini/shared/util/immutable/ImListTest.java
@@ -431,6 +431,25 @@ public class ImListTest extends TestCase {
         assertSame(lst, lst.sort(c));
     }
 
+    public void testTake() {
+        assertSame(empty,          empty.take(1));
+        assertSame(emptySingleton, emptySingleton.take(1));
+
+        assertEquals(empty,                  emptySingleton.take(1));
+        assertEquals(emptySingleton.take(1), emptySingleton);
+
+        final ImList<Integer> lst = create(1, 2, 3);
+        assertEquals(empty, lst.take(-1));
+        assertEquals(empty, lst.take(0));
+        assertEquals(lst,   lst.take(3));
+
+        assertEquals(create(1),    lst.take(1));
+        assertEquals(create(1, 2), lst.take(2));
+        assertEquals(lst,          lst.take(3));
+        assertEquals(lst,          lst.take(4));
+        assertEquals(lst,          lst.take(Integer.MAX_VALUE));
+    }
+
     public void testReverse() {
         ImList<Integer> lst = create(1, 2, 3, 4);
         lst = lst.reverse();


### PR DESCRIPTION
This PR updates the QPT to validate allocation time against the schedule blocks.  In particular, if any allocs are found that do not at least start or end within the block range, a warning is displayed listing the problem observation(s) and the plan is not opened.

There is an underlying bug that is not being addressed yet in that we do not know how to create plans with allocs out of the time range.  Instead it merely detects this case quickly instead of attempting to open plans with inappropriate allocs and blocking for long periods while it tries to calculate the sun path over decades.