### PR TITLE
REL-3526: set default wavelength for visitor instruments

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/Visitor.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/Visitor.scala
@@ -13,4 +13,5 @@ case class Visitor(blueprint: SpVisitorBlueprint) extends VisitorBase {
 
   // SET Name from Phase-I
   forObs(sci: _*)(setName fromPI)
+  forObs(sci: _*)(setWavelength fromPI)
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
@@ -9,12 +9,25 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
   val program = "VISITOR INSTRUMENT PHASE I/II MAPPING BPS"
   val seqConfigCompType = VisitorInstrument.SP_TYPE
 
+  val AlopekeWavelength: Double = 0.674
+  val DssiWavelength: Double    = 0.700
+
+  private val WavelengthMapping: List[(String, Double)] =
+    List(
+      "alopeke" -> AlopekeWavelength,
+      "dssi"    -> DssiWavelength
+    )
+
+
   implicit def pimpInst(obs: ISPObservation) = new {
 
     val ed = StaticObservationEditor[edu.gemini.spModel.gemini.visitor.VisitorInstrument](obs, instrumentType)
 
     def setName(n: String): Either[String, Unit] =
       ed.updateInstrument(_.setName(n))
+
+    def setWavelength(microns: Double): Either[String, Unit] =
+      ed.updateInstrument(_.setWavelength(microns))
   }
 
   // HACK: override superclass initialize to hang onto db reference
@@ -36,4 +49,12 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
 
   // DSL Setters
   def setName = Setter[String](blueprint.name)(_.setName(_))
+
+  private def wavelength: Double = {
+    val inst = blueprint.name.toLowerCase
+    WavelengthMapping.collectFirst { case (n, w) if inst.contains(n) => w }
+                     .getOrElse(0.0)
+  }
+
+  def setWavelength = Setter[Double](wavelength)(_.setWavelength(_))
 }


### PR DESCRIPTION
When creating a blueprint for visitor instruments, the changes in this PR will set the wavelength according to the instrument name.  Since we don't have a type for the various visitor instruments and yet we need to distinguish between Alopeke and DSSI to set the default wavelength, we just check the name set from the PIT.