### PR TITLE
REL-1608: temporary change to start time accounting update in 2018B for testing

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
@@ -87,7 +87,7 @@ private[obsrecord] object VisitCalculator {
    * </ul>
    */
   case object Update2019A extends VisitCalculator {
-    val semester = new Semester(2019, Semester.Half.A)
+    val semester = new Semester(2018, Semester.Half.B)
 
     override def validAt(s: Site): Instant =
       Instant.ofEpochMilli(semester.getStartDate(s).getTime)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obsrecord/TimeAccountingSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obsrecord/TimeAccountingSpec.scala
@@ -115,7 +115,7 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
 
   }
 
-  val Semester2019A = new Semester(2019, Semester.Half.A)
+  val Semester2019A = new Semester(2018, Semester.Half.B)
   val GS19AStart    = Instant.ofEpochMilli(Semester2019A.getStartDate(GS).getTime)
   val GS19AEnd      = Instant.ofEpochMilli(Semester2019A.getEndDate(GS).getTime)
   val DayInMs       = Duration.ofDays(1l).toMillis


### PR DESCRIPTION
REL-1608 brought an update to time accounting rules, but only for observations started in 2019A and beyond.  In order to make testing in November 2018 possible, we need to act as though the update works starting in 2018B until it can be verified.  Once verified, I'll need to undo this update.