### PR TITLE
REL-1958: QV observation table bug fixes

### DIFF
--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/ObservationTable.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/ObservationTable.scala
@@ -325,7 +325,7 @@ class ObservationTable(ctx: QvContext) extends GridBagPanel { ui =>
         import InstallationState._
 
         // Lookup the installation state.
-        val is = dataModel.installationState(r)
+        val is = dataModel.installationState(viewToModelRow(r))
 
         // Set the appropriate highlight/background color if not selected.
         if (!selected) {

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/ObservationTable.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/table/ObservationTable.scala
@@ -182,6 +182,7 @@ class ObservationTable(ctx: QvContext) extends GridBagPanel { ui =>
 
     peer.setDefaultRenderer(classOf[java.lang.String], NormalRenderer)
     peer.setDefaultRenderer(classOf[java.lang.Double], DoubleValueRenderer)
+    peer.setDefaultRenderer(classOf[java.lang.Integer], IntegerValueRenderer)
     peer.setDefaultRenderer(classOf[RaValue], RaValueRenderer)
     peer.setDefaultRenderer(classOf[DecValue], DecValueRenderer)
     peer.setDefaultRenderer(classOf[TimeValue], TimeValueRenderer)
@@ -383,6 +384,14 @@ class ObservationTable(ctx: QvContext) extends GridBagPanel { ui =>
       override def setValue(value: Object) = value match {
         case v: java.lang.Double =>
           setText(f"$v%.2f")
+          setBorder(BorderFactory.createEmptyBorder(0,0,0,5))
+      }
+    }
+    private object IntegerValueRenderer extends AvailabilityRenderer {
+      setHorizontalAlignment(SwingConstants.RIGHT)
+      override def setValue(value: Object) = value match {
+        case v: java.lang.Integer =>
+          setText(f"$v%d")
           setBorder(BorderFactory.createEmptyBorder(0,0,0,5))
       }
     }


### PR DESCRIPTION
This PR fixes a couple of bugs with ICTD integration.  Namely:

* adds a renderer for integer columns so that they appear with the proper highlight colors
* handles rendering correctly when the table is reordered via sorting