### PR TITLE
REL-1985: fix ODF file name suffix

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/maskcheck/MaskCheckCron.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/maskcheck/MaskCheckCron.scala
@@ -54,10 +54,10 @@ object MaskCheckCron {
       val nagAt     = lastMod.plus(nag)
       val lastEmail = f.getLastEmailed.asScalaOpt.getOrElse(Instant.MIN)
 
-      f.getName.endsWith(".odf") &&   // Only ODF Files
-      !f.isChecked               &&   // that haven't been checked
-      lastMod.isAfter(lastEmail) &&   // that have been modified more recently than the last nagging email (if any)
-      now.isAfter(nagAt)              // that haven't been checked in at least a week
+      f.getName.toLowerCase.endsWith("_odf.fits") &&   // Only ODF Files
+      !f.isChecked                                &&   // that haven't been checked
+      lastMod.isAfter(lastEmail)                  &&   // that have been modified more recently than the last nagging email (if any)
+      now.isAfter(nagAt)                               // that haven't been checked in at least a week
     })
 
   private def allPending(


### PR DESCRIPTION
Sadly the only way we have to determine if a file is a mask definition file is by name.  Instead of ending with `.odf` though as previously assumed, they are in fact terminated with `_odf.fits`.