### PR TITLE
REL-3519: widen the valid allocation time range in QPT schedule files

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/ScheduleIO.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/ScheduleIO.java
@@ -113,7 +113,7 @@ public class ScheduleIO {
             if (intervals.size() == 0) throw new IOException("Schedule has no blocks.");
 
             // Check that all allocs are in range.
-            Schedule.validateAllocs(core, blocks);
+            Schedule.validateAllocs(siteDesc, core, blocks);
 
             if (LttsServicesClient.getInstance() == null) {
                 LttsServicesClient.newInstance(intervals.first().getStart(), peer);


### PR DESCRIPTION
TIL that QCs will deliberately "schedule" observations in the day time as alternatives. When we open a queue plan with allocations during the day surrounding the schedule night, they shouldn't be flagged as incorrect. This PR widens the valid range to include the surrounding day time.