### PR TITLE
REL-2719: TPE / Catalog Query Tool Integration Bug Fixes

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -117,11 +117,13 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
         QueryResultsFrame.instance().peer().addComponentListener(new ComponentAdapter() {
             @Override
             public void componentShown(ComponentEvent e) {
+                QueryResultsFrame.instance().linkTpe(TpeImageWidget.this);
                 repaint();
             }
 
             @Override
             public void componentHidden(ComponentEvent e) {
+                QueryResultsFrame.instance().unlinkTpe(TpeImageWidget.this);
                 repaint();
             }
         });

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -558,7 +558,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           resultsTable.model match {
             case t: TargetsModel =>
               Swing.onEDT {
-                updateResultsModel(t.copy(info = t.info.map(i => i.copy(ctx = None, conditions = i.conditions.map(_.sb(selection.item))))))
+                updateResultsModel(t.withConditions(_.sb(selection.item)))
                 updateGuideSpeedText()
                 Option(TpeManager.open()).foreach(p => p.getImageWidget.repaint())
               }
@@ -580,7 +580,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           resultsTable.model match {
             case t: TargetsModel =>
               Swing.onEDT {
-                updateResultsModel(t.copy(info = t.info.map(i => i.copy(ctx = None, conditions = i.conditions.map(_.cc(selection.item))))))
+                updateResultsModel(t.withConditions(_.cc(selection.item)))
                 updateGuideSpeedText()
                 Option(TpeManager.open()).foreach(p => p.getImageWidget.repaint())
               }
@@ -602,7 +602,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
           resultsTable.model match {
             case t: TargetsModel =>
               Swing.onEDT {
-                updateResultsModel(t.copy(info = t.info.map(i => i.copy(ctx = None, conditions = i.conditions.map(_.iq(selection.item))))))
+                updateResultsModel(t.withConditions(_.iq(selection.item)))
                 updateGuideSpeedText()
                 Option(TpeManager.open()).foreach(p => p.getImageWidget.repaint())
               }

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -115,6 +115,13 @@ case class ObservationInfo(ctx: Option[ObsContext],
       ObsContext.create(env, i, site.flatten.asGeminiOpt, cond, offsets.map(_.toOldModel).asJava, altair.orNull, JNone.instance()).withPositionAngle(positionAngle)
     }
   }
+
+  def withConditions(f: Conditions => Conditions): ObservationInfo =
+    copy(
+      ctx        = ctx.map(c => c.withConditions(f(c.getConditions))),
+      conditions = conditions.map(f)
+    )
+
 }
 
 object ObservationInfo {
@@ -390,4 +397,7 @@ case class TargetsModel(info: Option[ObservationInfo], base: Coordinates, radius
         case (column, i)        => sorter.setComparator(i, column.ordering)
       }
     } <| { _.sort() }
+
+  def withConditions(f: Conditions => Conditions): TargetsModel  =
+    copy(info = info.map(_.withConditions(f)))
 }


### PR DESCRIPTION
This PR fixes a few issues with the TPE / CQT integration.  Most importantly, it handles guide star candidate selection in the TPE such that the corresponding target row in the CQT is also selected.  This was broken due to an initialization order issue so I reworked it to explicitly link and unlink with the necessary image widget observers instead of doing it on construction.

In addition, when using the visitor instrument, updates to the CQT form would cause the selected site to go missing from the observation context which made it impossible to calculate guide star quality.

These updates are admittedly ad hoc. A complete rewrite of the TPE and catalog search code is probably in oder.  I think given the EOL status of this code and the fact that we're nearing the end of the testing cycle, this should be good enough.