### PR TITLE
REL-1985: fix NullPointerException when there are no email recipients

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/mailer/Mailer.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/mailer/Mailer.scala
@@ -44,7 +44,7 @@ sealed abstract class Mailer(val site: Site, val smtpHost: String) {
 
   } >>= send
 
-  def send(m: MimeMessage): IO[Unit]
+  protected def send(m: MimeMessage): IO[Unit]
 
 }
 
@@ -77,7 +77,7 @@ object Mailer {
 
   def apply(site: Site, smtpHost: String): Mailer =
     new Mailer(site, smtpHost) {
-      def send(m: MimeMessage): IO[Unit] =
+      override def send(m: MimeMessage): IO[Unit] =
         write("Production Mailer", m) *> IO(sendAsync(m))
     }
 
@@ -89,7 +89,7 @@ object Mailer {
           case _                   => false
         }
 
-      def send(m: MimeMessage): IO[Unit] = {
+      override def send(m: MimeMessage): IO[Unit] = {
         write("Test Mailer", m) *> {
 
           val allRecipients = m.getRecipients(TO)
@@ -117,7 +117,7 @@ object Mailer {
 
   def forDevelopment(site: Site): Mailer =
     new Mailer(site, "bogus.mail.host") {
-      def send(m: MimeMessage): IO[Unit] =
+      override def send(m: MimeMessage): IO[Unit] =
         write("Development Mailer", m)
     }
 

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/mailer/Mailer.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/mailer/Mailer.scala
@@ -19,9 +19,22 @@ import Scalaz._
 import scalaz.effect.IO
 import scalaz.effect.IO._
 
-
+/**
+ * Mailer is used to send emails from cron jobs.  There are three flavors,
+ * development, test, and production obtained from `Mailer.forDevelopment`,
+ * `Mailer.forTesting`, and `Mailer.apply` respectively.  The development
+ * version simply logs the message that would have been emailed.  The test
+ * version alters the content with a "test only" disclaimer and strips the
+ * message of non-gemini emails.  It is meant to be used during the pre-release
+ * test month.  The production version sends the mail as requested.
+ */
 sealed abstract class Mailer(val site: Site, val smtpHost: String) {
 
+  /**
+   * Creates a program that will send the given message with the given subject
+   * to the given recipients, logging along the way.  Once the client has a
+   * Mailer instance via one of the constructors, this method is the entire API.
+   */
   def sendText(
     to:      List[InternetAddress],
     subject: String,
@@ -32,53 +45,52 @@ sealed abstract class Mailer(val site: Site, val smtpHost: String) {
       (_.setAddress("noreply@gemini.edu")) <|
       (_.setPersonal(s"Gemini ODB (${site.abbreviation})"))
 
-    val props = new java.util.Properties         <|
-      (_.put("mail.transport.protocol", "smtp")) <|
-      (_.put("mail.smtp.host", smtpHost))
-
-    new MimeMessage(Session.getInstance(props, null)) <|
-      (_.setFrom(sender))                             <|
-      (m => to.foreach(m.addRecipient(TO, _)))        <|
-      (_.setSubject(subject))                         <|
-      (_.setContent(message, "text/plain"))
+    SafeMimeMessage(sender, to, subject, message)
 
   } >>= send
 
-  protected def send(m: MimeMessage): IO[Unit]
+  // Left abstract so that the various types of mailer (production, test, dev)
+  // can take the appropriate action.
+  protected def send(m: SafeMimeMessage): IO[Unit]
 
+  protected final def sendAsync(m: SafeMimeMessage): IO[Unit] = IO {
+    import Mailer.Log
+
+    // OCSADV-85: use a future here; it can block for a long time if the mail server is down
+    if (m.to.isEmpty) {
+      Log.info(s"""Cannot send mail "${m.subject}" because there are no recipients.""")
+    } else {
+      val to = m.to.mkString(", ")
+      Future(Transport.send(m.toMimeMessage(smtpHost))).onComplete {
+        case Success(_) => Log.info(s"""Successfully sent mail "${m.subject}" to $to.""")
+        case Failure(e) => Log.log(Level.WARNING, s"""Failed to send mail "${m.subject}" to $to.""", e)
+      }
+    }
+  }
 }
 
 object Mailer {
 
   val Log = Logger.getLogger(getClass.getName)
 
-  private def sendAsync(m: MimeMessage): Unit = {
-    // OCSADV-85: use a future here; it can block for a long time if the mail server is down
-    val to = m.getRecipients(TO).mkString(", ")
-    Future(Transport.send(m)).onComplete {
-      case Success(_) => Log.info(s"Successfully sent mail to $to.")
-      case Failure(e) => Log.log(Level.WARNING, s"Failed to send mail to $to", e)
-    }
-  }
-
-  private def write(prefix: String, m: MimeMessage): IO[Unit] = {
-    def log(m: String): IO[Unit] =
-      putStrLn(s"$prefix: $m")
-
-    for {
-      _ <- putStrLn("")
-      _ <- log(s"From...: ${m.getFrom.mkString(", ")}")
-      _ <- log(s"To.....: ${m.getRecipients(TO).mkString(", ")}")
-      _ <- log(s"Subject: ${m.getSubject}")
-      _ <- log("")
-      _ <- m.getContent.toString.lines.toList.traverseU(log)
-    } yield ()
+  // Logs the message.
+  private def write(prefix: String, m: SafeMimeMessage): IO[Unit] = IO {
+    Log.info(
+       s"""$prefix
+         |
+         |From...: ${m.from}
+         |To.....: ${m.to.mkString(", ")}
+         |Subject: ${m.subject}
+         |
+         |${m.content}
+       """.stripMargin
+    )
   }
 
   def apply(site: Site, smtpHost: String): Mailer =
     new Mailer(site, smtpHost) {
-      override def send(m: MimeMessage): IO[Unit] =
-        write("Production Mailer", m) *> IO(sendAsync(m))
+      override def send(m: SafeMimeMessage): IO[Unit] =
+        write("", m) *> sendAsync(m)
     }
 
   def forTesting(site: Site, smtpHost: String): Mailer =
@@ -89,36 +101,37 @@ object Mailer {
           case _                   => false
         }
 
-      override def send(m: MimeMessage): IO[Unit] = {
-        write("Test Mailer", m) *> {
+      override def send(m: SafeMimeMessage): IO[Unit] = {
+        write("Test Mailer: ", m) *> {
 
-          val allRecipients = m.getRecipients(TO)
+          import SafeMimeMessage.{ Content, Subject, To }
 
-          val content       =
-            s"""
-              |This is a test message that, were it running in production, would have been sent to these recipients:
-              |
-              |  ${allRecipients.mkString(", ")}
-              |
-              |Message Body:
-              |
-              |${m.getContent.toString}
-              |
-            """.stripMargin
+          sendAsync(
+            (for {
+              _ <- To      := m.to.filter(isGeminiAddress)
+              _ <- Subject := s"Test: ${m.subject}"
+              _ <- Content :=
+                s"""
+                  |This is a test message that, were it running in production, would have been sent to these recipients:
+                  |
+                  |  ${m.to.mkString(", ")}
+                  |
+                  |Message Body:
+                  |
+                  |${m.content.toString}
+                  |
+                """.stripMargin
 
-          m.setRecipients(TO, allRecipients.filter(isGeminiAddress))
-          m.setSubject("Test: " + m.getSubject)
-          m.setContent(content, "text/plain")
-
-          IO(sendAsync(m))
+            } yield ()).exec(m)
+          )
         }
       }
     }
 
   def forDevelopment(site: Site): Mailer =
     new Mailer(site, "bogus.mail.host") {
-      override def send(m: MimeMessage): IO[Unit] =
-        write("Development Mailer", m)
+      override def send(m: SafeMimeMessage): IO[Unit] =
+        write("Development Mailer: ", m)
     }
 
   def ofType(t: MailerType, site: Site, smtpHost: String): Mailer =

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/mailer/SafeMimeMessage.scala
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/scala/edu/gemini/dbTools/mailer/SafeMimeMessage.scala
@@ -1,0 +1,48 @@
+package edu.gemini.dbTools.mailer
+
+import javax.mail._
+import javax.mail.Message.RecipientType.TO
+import javax.mail.internet._
+
+import scalaz._
+import Scalaz._
+
+/**
+ * A simple MimeMessage wrapper created to avoid the `null` results from calling
+ * MimeMessage methods.
+ */
+case class SafeMimeMessage(
+  from:    InternetAddress,
+  to:      List[InternetAddress],
+  subject: String,
+  content: String
+) {
+
+  /** Converts to a MimeMessage to be sent via a Java Mail API Transport. */
+  def toMimeMessage(smtpHost: String): MimeMessage = {
+    val props = new java.util.Properties         <|
+      (_.put("mail.transport.protocol", "smtp")) <|
+      (_.put("mail.smtp.host", smtpHost))
+
+    new MimeMessage(Session.getInstance(props, null)) <|
+      (_.setFrom(from))                               <|
+      (m => to.foreach(m.addRecipient(TO, _)))        <|
+      (_.setSubject(subject))                         <|
+      (_.setContent(content, "text/plain"))
+  }
+
+}
+
+object SafeMimeMessage {
+  val From: Lens[SafeMimeMessage, InternetAddress] =
+    Lens.lensu((a, b) => a.copy(from = b), _.from)
+
+  val To: Lens[SafeMimeMessage, List[InternetAddress]] =
+    Lens.lensu((a, b) => a.copy(to = b), _.to)
+
+  val Subject: Lens[SafeMimeMessage, String] =
+    Lens.lensu((a, b) => a.copy(subject = b), _.subject)
+
+  val Content: Lens[SafeMimeMessage, String] =
+    Lens.lensu((a, b) => a.copy(content = b), _.content)
+}


### PR DESCRIPTION
`MimeMessage` returns `null` when asked for recipients if there are no destination addresses, even though the return type is an array which could easily be empty.  This PR hacks around the problem and makes a few other mailer adjustments.