### PR TITLE
REL-2718: untangle AGS and GeMS plots

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/TpeImageWidget.java
@@ -80,7 +80,7 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
     private boolean _baseOutOfView = false;
 
     // Dialog for GeMS manual guide star selection
-    private GemsGuideStarSearchDialog _gemsGuideStarSearchDialog;
+    private Option<GemsGuideStarSearchDialog> _gemsGuideStarSearchDialog = ImOption.empty();
 
     // Action to use to show the guide star search window
     private final AbstractAction _manualGuideStarAction = new AbstractAction(
@@ -639,9 +639,7 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
         if (_ctx.instrument().isDefined()) {
             // This is bad but it is the only way to link changes from the instrument
             // to the dialog box, talk about side-effects
-            if (_gemsGuideStarSearchDialog != null) {
-                _gemsGuideStarSearchDialog.updatedInstrument(ctx.instrument());
-            }
+            _gemsGuideStarSearchDialog.foreach(d -> d.updatedInstrument(ctx.instrument()));
             _ctx.instrument().get().addPropertyChangeListener(this);
             setPosAngle(_ctx.instrument().get().getPosAngleDegrees());
         }
@@ -1034,17 +1032,25 @@ public class TpeImageWidget extends CatalogImageDisplay implements MouseInputLis
     }
 
     private void showGemsGuideStarSearchDialog() {
-        if (_gemsGuideStarSearchDialog == null) {
-            _gemsGuideStarSearchDialog = new GemsGuideStarSearchDialog(this, scala.concurrent.ExecutionContext$.MODULE$.global());
+        if (_gemsGuideStarSearchDialog.isEmpty()) {
+            _gemsGuideStarSearchDialog = ImOption.apply(new GemsGuideStarSearchDialog(this, scala.concurrent.ExecutionContext$.MODULE$.global()));
         } else {
-            _gemsGuideStarSearchDialog.reset();
-            _gemsGuideStarSearchDialog.setVisible(true);
+            _gemsGuideStarSearchDialog.foreach(d -> {
+               d.reset();
+               d.setVisible(true);
+            });
         }
-        try {
-            _gemsGuideStarSearchDialog.query();
-        } catch (Exception e) {
-            DialogUtil.error(e);
-        }
+        _gemsGuideStarSearchDialog.foreach(d -> {
+            try {
+                d.query();
+            } catch (Exception e) {
+                DialogUtil.error(e);
+            }
+        });
+    }
+
+    public Option<GemsGuideStarSearchDialog> getGemsGuideStarSearchDialog() {
+        return _gemsGuideStarSearchDialog;
     }
 
     /**

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/CandidateGuideStarsTableModel.java
@@ -12,6 +12,7 @@ import jsky.catalog.skycat.SkycatTable;
 
 import javax.swing.table.DefaultTableModel;
 import java.util.*;
+import java.util.function.Predicate;
 
 /**
  * OT-111: Model for {@link CandidateGuideStarsTable}
@@ -167,18 +168,37 @@ class CandidateGuideStarsTableModel extends DefaultTableModel {
         };
     }
 
-    /**
-     * Returns a list of SiderealTargets corresponding to the checked rows in the table
-     */
-    List<SiderealTarget> getCandidates() {
+    private List<SiderealTarget> getFilteredCandidates(Predicate<Integer> f) {
         final List<SiderealTarget> result = new ArrayList<>();
         final int numRows = getRowCount();
-        final int col = Cols.CHECK.ordinal();
+
         for(int row = 0; row < numRows; row++) {
-            if (!((Boolean) getValueAt(row, col))) {
-                result.add(_siderealTargets.get(row));
-            }
+            if (f.test(row)) result.add(_siderealTargets.get(row));
         }
         return result;
+    }
+
+    private final Predicate<Integer> checked =
+            r -> (Boolean) getValueAt(r, Cols.CHECK.ordinal());
+
+    /**
+     * Returns the subset of all candidate targets that are checked in the UI.
+     */
+    List<SiderealTarget> getCheckedCandidates() {
+        return getFilteredCandidates(checked);
+    }
+
+    /**
+     * Returns the subset of all candidate targets that are not checked in the UI.
+     */
+    List<SiderealTarget> getUncheckedCandidates() {
+        return getFilteredCandidates(checked.negate());
+    }
+
+    /**
+     * Returns all candidate targets.
+     */
+    List<SiderealTarget> getAllCandidates() {
+        return getFilteredCandidates(r -> true);
     }
 }


### PR DESCRIPTION
The GeMS manual guide star search dialog plots guide stars on the TPE image widget.  Independently, the `TpeCatalogFeature` plots AGS guide stars.  When viewing the GeMS manual guide star search, *both* were being plotted using conflicting symbols and breaking the two-way selection link between tables and the symbols in the plot.

This is a modest attempt to improve the situation by placing the GeMS plotting under the control of the `TpeCatalogFeature` just as for the AGS and normal manual guide star search.  It adds a fourth plot case, `GemsPlot`, in addition to the existing `NoPlot`, `AgsPlot`, and normal `ManualPlot`.

At this point, one of the four options will always be plotted -- or not plotted in the case of `NoPlot`.  However which is selected will depend upon which, if any, manual search tool is open.  This can lead to confusion if both the catalog query tool and the gems manual search is open.  All this PR does is to respect the catalog feature toggle button and stop the TPE from displaying multiple plots at once and breaking the link between plot symbol selection and tables.