### PR TITLE
REL-3550: update GeMS CWFS limits

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsGuideStars.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsGuideStars.scala
@@ -133,7 +133,7 @@ case class GemsGuideStars(pa: Angle, tiptiltGroup: GemsGuideProbeGroup, strehl: 
 
     val guiders = guideGroup.getReferencedGuiders.asScala.map { gp =>
       val target = guideGroup.get(gp).getValue.getPrimary.getValue
-      s"$gp[${target.getRaString(NoTime)},${target.getRaString(NoTime)}]"
+      s"$gp[${target.getName},${target.getRaString(NoTime).asScalaOpt},${target.getDecString(NoTime).asScalaOpt}]"
     }
     s"GemsGuideStars{pa=$pa, tiptilt=${tiptiltGroup.getKey}, avg Strehl=${strehl.avg * 100}, guiders=${guiders.mkString(" ")}}"
   }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
@@ -111,14 +111,12 @@ case class GemsVoTableCatalog(backend: VoTableBackend = ConeSearchBackend, catal
    */
   private def assignToCriterion(basePosition: Coordinates, criterions: List[GemsCatalogSearchCriterion], targets: List[SiderealTarget]): List[GemsCatalogSearchResults] = {
 
-    def matchCriteria(basePosition: Coordinates, criter: GemsCatalogSearchCriterion, targets: List[SiderealTarget]): List[SiderealTarget] = {
+    def matchCriteria(basePosition: Coordinates, criter: GemsCatalogSearchCriterion): List[SiderealTarget] = {
       val matcher = criter.criterion.matcher(basePosition)
       targets.filter(matcher.matches).distinct
     }
 
-    for {
-      c <- criterions
-    } yield GemsCatalogSearchResults(c, matchCriteria(basePosition, c, targets))
+    criterions.map(c => GemsCatalogSearchResults(c, matchCriteria(basePosition, c)))
   }
 
   // Returns a list of radius limits used in the criteria.

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
@@ -87,7 +87,7 @@ object Mascot {
                        filter: Star => Boolean = defaultFilter)
   : (List[Star], List[Strehl]) = {
     // sort by selected mag and select
-    val sortedStarList = starList.sortWith((s1,s2) => s1.r < s2.r)
+    val sortedStarList = starList.distinct.sortWith((s1,s2) => s1.r < s2.r)
     val filteredStarList = selectStarsOnMag(sortedStarList).filter(filter)
 
     val ns = filteredStarList.length

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsGuideSearchOptionsSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsGuideSearchOptionsSpec.scala
@@ -40,7 +40,7 @@ class GemsGuideSearchOptionsSpec extends Specification {
       criteria.head.key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, GsaoiOdgw.Group.instance))
       criteria.head.criterion.magConstraint should beEqualTo(MagnitudeConstraints(SingleBand(MagnitudeBand.H), FaintnessConstraint(14.5), Some(SaturationConstraint(7.3))))
       criteria(1).key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.flexure, Canopus.Wfs.Group.instance))
-      criteria(1).criterion.magConstraint should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(16.8), Some(SaturationConstraint(9.3))))
+      criteria(1).criterion.magConstraint should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(15.5), Some(SaturationConstraint(8.0))))
     }
     "provide search options for gsaoi in canopus tip tilt mode" in {
       val instrument = GemsInstrument.gsaoi
@@ -51,7 +51,7 @@ class GemsGuideSearchOptionsSpec extends Specification {
 
       criteria should be size 2
       criteria.head.key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, Canopus.Wfs.Group.instance))
-      criteria.head.criterion.magConstraint should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(16.8), Some(SaturationConstraint(9.3))))
+      criteria.head.criterion.magConstraint should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(15.5), Some(SaturationConstraint(8.0))))
       criteria(1).key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.flexure, GsaoiOdgw.Group.instance))
       criteria(1).criterion.magConstraint should beEqualTo(MagnitudeConstraints(SingleBand(MagnitudeBand.H), FaintnessConstraint(17.0), Some(SaturationConstraint(8))))
     }
@@ -65,13 +65,13 @@ class GemsGuideSearchOptionsSpec extends Specification {
 
       criteria should be size 4
       criteria.head.key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, Canopus.Wfs.Group.instance))
-      criteria.head.criterion.magConstraint should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(16.8), Some(SaturationConstraint(9.3))))
+      criteria.head.criterion.magConstraint should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(15.5), Some(SaturationConstraint(8.0))))
       criteria(1).key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.flexure, GsaoiOdgw.Group.instance))
       criteria(1).criterion.magConstraint should beEqualTo(MagnitudeConstraints(SingleBand(MagnitudeBand.H), FaintnessConstraint(17.0), Some(SaturationConstraint(8))))
       criteria(2).key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, GsaoiOdgw.Group.instance))
       criteria(2).criterion.magConstraint should beEqualTo(MagnitudeConstraints(SingleBand(MagnitudeBand.H), FaintnessConstraint(14.5), Some(SaturationConstraint(7.3))))
       criteria(3).key should beEqualTo(GemsCatalogSearchKey(GemsGuideStarType.flexure, Canopus.Wfs.Group.instance))
-      criteria(3).criterion.magConstraint should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(16.8), Some(SaturationConstraint(9.3))))
+      criteria(3).criterion.magConstraint should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(15.5), Some(SaturationConstraint(8.0))))
     }
   }
 }

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
@@ -46,8 +46,8 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
 
   private val LOGGER = Logger.getLogger(classOf[GemsResultsAnalyzerSpec].getName)
 
-  class TestGemsVoTableCatalog(file: String) extends GemsVoTableCatalog {
-    override val backend = TestVoTableBackend(file)
+  class TestGemsVoTableCatalog(file: String, c: Conditions) extends GemsVoTableCatalog {
+    override val backend = TestVoTableBackend(file, GemsTestVoTableMod.forCwfsMagnitudeLimitChange(c))
   }
 
   val NoTime = JNone.instance[java.lang.Long]
@@ -59,7 +59,7 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       val tipTiltMode = GemsTipTiltMode.canopus
 
       val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY).wv(SPSiteQuality.WaterVapor.ANY)
-      val (results, gemsGuideStars) = search(inst, base.getRA.toString, base.getDec.toString, tipTiltMode, conditions, new TestGemsVoTableCatalog("/gems_TYC_8345_1155_1.xml"))
+      val (results, gemsGuideStars) = search(inst, base.getRA.toString, base.getDec.toString, tipTiltMode, conditions, new TestGemsVoTableCatalog("/gems_TYC_8345_1155_1.xml", conditions))
 
       val expectedResults = if (tipTiltMode == GemsTipTiltMode.both) 4 else 2
       results should have size expectedResults
@@ -119,8 +119,9 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       val base = new WorldCoords("05:35:28.020", "-69:16:11.07")
       val inst = new Gsaoi <| {_.setPosAngle(0.0)} <| {_.setIssPort(IssPort.UP_LOOKING)}
       val tipTiltMode = GemsTipTiltMode.canopus
+      val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
 
-      val (results, gemsGuideStars) = search(inst, base.getRA.toString, base.getDec.toString, tipTiltMode, SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY), new TestGemsVoTableCatalog("/gems_sn1987A.xml"))
+      val (results, gemsGuideStars) = search(inst, base.getRA.toString, base.getDec.toString, tipTiltMode, conditions, new TestGemsVoTableCatalog("/gems_sn1987A.xml", conditions))
 
       val expectedResults = if (tipTiltMode == GemsTipTiltMode.both) 4 else 2
       results should have size expectedResults
@@ -180,8 +181,9 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       val base = new WorldCoords("17:40:20.000", "-32:15:12.00")
       val inst = new Gsaoi
       val tipTiltMode = GemsTipTiltMode.canopus
+      val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
 
-      val (results, gemsGuideStars) = search(inst, base.getRA.toString, base.getDec.toString, tipTiltMode, SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY), new TestGemsVoTableCatalog("/gems_m6.xml"))
+      val (results, gemsGuideStars) = search(inst, base.getRA.toString, base.getDec.toString, tipTiltMode, conditions, new TestGemsVoTableCatalog("/gems_m6.xml", conditions))
 
       val expectedResults = if (tipTiltMode == GemsTipTiltMode.both) 4 else 2
       results should have size expectedResults
@@ -213,12 +215,12 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       val cwfs2 = group.get(Canopus.Wfs.cwfs2).getValue.getPrimary.getValue
       val cwfs3 = group.get(Canopus.Wfs.cwfs3).getValue.getPrimary.getValue
       val odgw2 = group.get(GsaoiOdgw.odgw2)  .getValue.getPrimary.getValue
-      cwfs1.getName must beEqualTo("289-128909")
+      cwfs1.getName must beEqualTo("289-128891")
       cwfs2.getName must beEqualTo("289-128878")
       cwfs3.getName must beEqualTo("289-128908")
       odgw2.getName must beEqualTo("289-128891")
 
-      val cwfs1x = Coordinates.create("17:40:21.743", "-32:14:54.04")
+      val cwfs1x = Coordinates.create("17:40:19.295", "-32:14:58.34")
       val cwfs2x = Coordinates.create("17:40:16.855", "-32:15:55.83")
       val cwfs3x = Coordinates.create("17:40:21.594", "-32:15:50.38")
       val odgw2x = Coordinates.create("17:40:19.295", "-32:14:58.34")
@@ -241,8 +243,9 @@ class GemsResultsAnalyzerSpec extends MascotProgress with SpecificationLike with
       val base = new WorldCoords("12:38:49.820", "-49:48:00.20")
       val inst = new Gsaoi
       val tipTiltMode = GemsTipTiltMode.canopus
+      val conditions = SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY)
 
-      val (results, gemsGuideStars) = search(inst, base.getRA.toString, base.getDec.toString, tipTiltMode, SPSiteQuality.Conditions.NOMINAL.sb(SPSiteQuality.SkyBackground.ANY), new TestGemsVoTableCatalog("/gems_bpm_37093.xml"))
+      val (results, gemsGuideStars) = search(inst, base.getRA.toString, base.getDec.toString, tipTiltMode, conditions, new TestGemsVoTableCatalog("/gems_bpm_37093.xml", conditions))
 
       val expectedResults = if (tipTiltMode == GemsTipTiltMode.both) 4 else 2
       results should have size expectedResults

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsTestVoTableMod.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsTestVoTableMod.scala
@@ -1,0 +1,36 @@
+package edu.gemini.ags.gems
+
+import edu.gemini.spModel.core.{ Magnitude, RBandsList, SiderealTarget }
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.Conditions
+
+import scalaz._
+import Scalaz._
+
+/**
+ * Modification function for test VO table backend that transforms catalog
+ * results so that they continue to work with REL-3550 magnitude limit changes.
+ */
+object GemsTestVoTableMod {
+
+  def forCwfsMagnitudeLimitChange(
+    conds: Conditions
+  ): SiderealTarget => SiderealTarget = t => {
+
+    // In general, we now require stars 1.3 brighter in R but we also ignore
+    // sky background which was previously taken into account.
+    val diff = 1.3 + conds.sb.getAdjustment(RBandsList)
+
+    // Now for every R value, we artifically make the star `diff` brighter so
+    // that it continues to correspond to the test cases
+    val mags = t.magnitudes.map { m =>
+      if (RBandsList.bandSupported(m.band))
+        Magnitude.value.mod(_ - diff, m)
+      else
+        m
+    }
+
+    SiderealTarget.magnitudes.set(t, mags)
+
+  }
+
+}

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsVoTableCatalogSpec.scala
@@ -45,11 +45,12 @@ class GemsVoTableCatalogSpec extends Specification {
       val posAngles = new java.util.HashSet[Angle]()
       val options = new GemsGuideStarSearchOptions(instrument, tipTiltMode, posAngles)
 
-      val results = Await.result(GemsVoTableCatalog(TestVoTableBackend("/gemsvotablecatalogquery.xml")).search(ctx, base, options, scala.None)(implicitly), 30.seconds)
+      val mod = GemsTestVoTableMod.forCwfsMagnitudeLimitChange(conditions)
+      val results = Await.result(GemsVoTableCatalog(TestVoTableBackend("/gemsvotablecatalogquery.xml", mod)).search(ctx, base, options, scala.None)(implicitly), 30.seconds)
       results should be size 2
 
       results.head.criterion should beEqualTo(GemsCatalogSearchCriterion(GemsCatalogSearchKey(GemsGuideStarType.tiptilt, GsaoiOdgw.Group.instance), CatalogSearchCriterion("On-detector Guide Window tiptilt", RadiusConstraint.between(Angle.zero, Angle.fromDegrees(0.01666666666665151)), MagnitudeConstraints(SingleBand(MagnitudeBand.H), FaintnessConstraint(14.5), Some(SaturationConstraint(7.3))), Some(Offset(0.0014984027777700248.degrees[OffsetP], 0.0014984027777700248.degrees[OffsetQ])), scala.None)))
-      results(1).criterion should beEqualTo(GemsCatalogSearchCriterion(GemsCatalogSearchKey(GemsGuideStarType.flexure, Wfs.Group.instance), CatalogSearchCriterion("Canopus Wave Front Sensor flexure", RadiusConstraint.between(Angle.zero, Angle.fromDegrees(0.01666666666665151)), MagnitudeConstraints(RBandsList, FaintnessConstraint(16.8), Some(SaturationConstraint(9.3))), Some(Offset(0.0014984027777700248.degrees[OffsetP], 0.0014984027777700248.degrees[OffsetQ])), scala.None)))
+      results(1).criterion should beEqualTo(GemsCatalogSearchCriterion(GemsCatalogSearchKey(GemsGuideStarType.flexure, Wfs.Group.instance), CatalogSearchCriterion("Canopus Wave Front Sensor flexure", RadiusConstraint.between(Angle.zero, Angle.fromDegrees(0.01666666666665151)), MagnitudeConstraints(RBandsList, FaintnessConstraint(15.5), Some(SaturationConstraint(8.0))), Some(Offset(0.0014984027777700248.degrees[OffsetP], 0.0014984027777700248.degrees[OffsetQ])), scala.None)))
       results.head.results should be size 5
       results(1).results should be size 5
     }
@@ -61,14 +62,16 @@ class GemsVoTableCatalogSpec extends Specification {
       val inst = new Gsaoi
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
+      val conditions = SPSiteQuality.Conditions.BEST
+      val ctx = ObsContext.create(env, inst, JNone.instance[Site], conditions, null, null, JNone.instance())
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.instrument
 
       val posAngles = new java.util.HashSet[Angle]()
       val options = new GemsGuideStarSearchOptions(instrument, tipTiltMode, posAngles)
 
-      val results = GemsVoTableCatalog(TestVoTableBackend("/gemsvotablecatalogquery.xml")).getRadiusConstraints(instrument, options.searchCriteria(ctx, scala.None).asScala.toList)
+      val mod = GemsTestVoTableMod.forCwfsMagnitudeLimitChange(conditions)
+      val results = GemsVoTableCatalog(TestVoTableBackend("/gemsvotablecatalogquery.xml", mod)).getRadiusConstraints(instrument, options.searchCriteria(ctx, scala.None).asScala.toList)
       results should be size 1
       results.head should beEqualTo(RadiusConstraint.between(Angle.zero, Angle.fromDegrees(0.01878572819686042)))
     }
@@ -80,17 +83,19 @@ class GemsVoTableCatalogSpec extends Specification {
       val inst = new Gsaoi
       inst.setPosAngle(0.0)
       inst.setIssPort(IssPort.SIDE_LOOKING)
-      val ctx = ObsContext.create(env, inst, JNone.instance[Site], SPSiteQuality.Conditions.BEST, null, null, JNone.instance())
+      val conditions = SPSiteQuality.Conditions.BEST
+      val ctx = ObsContext.create(env, inst, JNone.instance[Site], conditions, null, null, JNone.instance())
       val instrument = GemsInstrument.gsaoi
       val tipTiltMode = GemsTipTiltMode.instrument
 
       val posAngles = new java.util.HashSet[Angle]()
       val options = new GemsGuideStarSearchOptions(instrument, tipTiltMode, posAngles)
 
-      val results = GemsVoTableCatalog(TestVoTableBackend("/gemsvotablecatalogquery.xml")).optimizeMagnitudeConstraints(options.searchCriteria(ctx, scala.None).asScala.toList)
+      val mod = GemsTestVoTableMod.forCwfsMagnitudeLimitChange(conditions)
+      val results = GemsVoTableCatalog(TestVoTableBackend("/gemsvotablecatalogquery.xml", mod)).optimizeMagnitudeConstraints(options.searchCriteria(ctx, scala.None).asScala.toList)
       results should be size 2
       results.head should beEqualTo(MagnitudeConstraints(SingleBand(MagnitudeBand.H), FaintnessConstraint(14.5), Some(SaturationConstraint(7.3))))
-      results(1) should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(16.8), Some(SaturationConstraint(9.3))))
+      results(1) should beEqualTo(MagnitudeConstraints(RBandsList, FaintnessConstraint(15.5), Some(SaturationConstraint(8.0))))
     }
     "preserve the radius constraint for a single item without offsets" in {
       val catalog = GemsVoTableCatalog(TestVoTableBackend(""))

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -20,7 +20,7 @@ import scalaz._
 import Scalaz._
 
 trait VoTableBackend {
-  val catalogUrls: NonEmptyList[URL]
+  def catalogUrls: NonEmptyList[URL]
   protected [votable] def doQuery(query: CatalogQuery, url: URL)(ec: ExecutionContext): Future[QueryResult]
 }
 

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/TestVoTableBackend.scala
@@ -1,17 +1,35 @@
 package edu.gemini.catalog.votable
 
-import java.net.URL
-
 import edu.gemini.catalog.api.{UCAC4, CatalogQuery}
+import edu.gemini.spModel.core.SiderealTarget
+
+import java.net.URL
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scalaz.NonEmptyList
 
-// Backend for tests, reads votable xml files from the classpath
-case class TestVoTableBackend(file: String) extends VoTableBackend {
-  override val catalogUrls = NonEmptyList(new URL(s"file://$file"))
+/**
+ * Backend for tests, reads votable xml files from the classpath.  Applies a
+ * provided modification function to each parsed target.
+ */
+case class TestVoTableBackend(
+    file: String,
+    mod:  SiderealTarget => SiderealTarget
+) extends VoTableBackend {
+
+  override val catalogUrls: NonEmptyList[URL] =
+    NonEmptyList(new URL(s"file://$file"))
 
   override def doQuery(query: CatalogQuery, url: URL)(ec: ExecutionContext) = Future {
-    VoTableParser.parse(UCAC4, this.getClass.getResourceAsStream(file)).fold(p => QueryResult(query, CatalogQueryResult(TargetsTable.Zero, List(p))), y => QueryResult(query, CatalogQueryResult(y).filter(query)))
+    VoTableParser.parse(UCAC4, this.getClass.getResourceAsStream(file))
+                 .map(pvo => ParsedVoResource(pvo.tables.map(pt => ParsedTable(pt.rows.map(_.map(mod))))))
+                 .fold(p => QueryResult(query, CatalogQueryResult(TargetsTable.Zero, List(p))),
+                       y => QueryResult(query, CatalogQueryResult(y).filter(query)))
   }
+
+}
+
+object TestVoTableBackend {
+  def apply(file: String): TestVoTableBackend =
+    TestVoTableBackend(file, identity)
 }


### PR DESCRIPTION
This PR introduces a change to the CWFS magnitude limits and a change to the way that the magnitude limits are adjusted to conditions.  In particular, the nominal R-band magnitude limit itself is lowered from 16.3 to 15.0 to require brighter stars and the sky background is no longer considered relevant.

The main challenge of this task was keeping the test suite working.  To make that possible, I apply magnitude corrections to the canned catalog results such that they correspond to the new limit calculations.  For the most part this worked but the magnitude limit change does produce slightly different strehl calculations which change the result of one test case (see the `gems_m6.xml` cases).