### PR TITLE
REL-3552: Re-enable Altair for rest of 2019A semester.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/AltairNode.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/AltairNode.scala
@@ -7,11 +7,11 @@ trait AltairNode {
   val title       = "Adaptive Optics"
   val description = "Please select an adaptive optics option."
 
-  // REL-3453: Altair LGS not available for 2019A.
-//  def choices     = if (allGuideStarTypes) {
-//      List(AltairNone, AltairLGS(pwfs1 = false, aowfs = true), AltairLGS(pwfs1 = true), AltairLGS(pwfs1 = false, oiwfs = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
-//    } else {
-//      List(AltairNone, AltairLGS(pwfs1 = false), AltairLGS(pwfs1 = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
-//    }
-  def choices = List(AltairNone, AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
+  def choices     = if (allGuideStarTypes) {
+      List(AltairNone, AltairLGS(pwfs1 = false, aowfs = true), AltairLGS(pwfs1 = true), AltairLGS(pwfs1 = false, oiwfs = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
+    } else {
+      List(AltairNone, AltairLGS(pwfs1 = false), AltairLGS(pwfs1 = true), AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
+    }
+  // When Altair is not available, use these choices instead.
+//  def choices = List(AltairNone, AltairNGS(fieldLens = false), AltairNGS(fieldLens = true))
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -145,12 +145,6 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
  * This converter will upgrade to 2019A.
  */
 case object SemesterConverter2018BTo2019A extends SemesterConverter {
-  // REL-3453: Altair LGS not available for 2019A.
-  val altairLgsNotAvailable: TransformFunction = {
-    case a @ <altair>{ns@_*}</altair> if (a \\ "lgs").nonEmpty =>
-      StepResult(s"Altair Laser Guidestar is currently not offered", a).successNel
-  }
-
   // REL-3485: F2 MOS not available for 2019A.
   val f2MOSNotAvailable: TransformFunction = {
     case f @ <flamingos2>{ns @ _*}</flamingos2> if (f \ "mos").nonEmpty =>
@@ -170,7 +164,7 @@ case object SemesterConverter2018BTo2019A extends SemesterConverter {
       StepResult("All CFH exchange time will now be done in queue.", <proposalClass>{ClassicalToQueueTransformer.transform(ns)}</proposalClass>).successNel
   }
 
-  override val transformers = List(altairLgsNotAvailable, f2MOSNotAvailable, cfhClassicalToQueue)
+  override val transformers = List(f2MOSNotAvailable, cfhClassicalToQueue)
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -243,7 +243,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 8
+          changes must have length 7
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -268,7 +268,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 8
+          changes must have length 7
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -294,7 +294,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 9
+          changes must have length 8
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -565,7 +565,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 7
+          changes must have length 6
           changes must contain("GNIRS observation doesn't have a central wavelength range, assigning to '< 2.5um'")
           // Check that the centralWavelength node is added
           result must \\("centralWavelength") \> "< 2.5um"
@@ -743,7 +743,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 5
           result \\ "niri" must \\("filter") \> "HeI (1.083 um)"
           result \\ "niri" must not(\\("filter") \> "J-continuum (1.122 um)")
           result \\ "niri" must not(\\("filter") \> "Jcont (1.065 um)")

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -83,7 +83,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
           TacProblems(p, s).all ++
           Semester2018BProblems(p, s).all ++
           List(incompleteInvestigator, missingObsElementCheck, emptyTargetCheck,
-            emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck, altairLgsCheck,
+            emptyEphemerisCheck, singlePointEphemerisCheck, initialEphemerisCheck, finalEphemerisCheck,
             badGuiding, cwfsCorrectionsIssue, badVisibility, iffyVisibility, minTimeCheck, wrongSite, band3Orphan2, gpiCheck, lgsIQ70Check, lgsGemsIQ85Check,
             lgsCC50Check, texesCCCheck, texesWVCheck, gmosWVCheck, gmosR600Check, f2MOSCheck, band3IQ, band3LGS, band3RapidToO, sbIrObservation).flatten
       ps.sorted
@@ -197,12 +197,6 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
         s"""Ephemeris for target "$n" is undefined between ${dateFormat.format(Instant.ofEpochMilli(firstDay))} and ${dateFormat.format(Instant.ofEpochMilli(p.semester.lastDay))} UTC."""
       }
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
-
-    // REL-3453: Altair LGS not available for 2019A.
-    private lazy val altairLgsCheck = for {
-      o <- p.nonEmptyObservations
-      b <- o.blueprint if bpIsLgs(b) && !bpIsGemsLgs(b)
-    } yield new Problem(Severity.Error, "Altair Laser Guidestar is currently not offered.", "Observations", s.inObsListView(o.band, _.Fixes.fixBlueprint(b)))
 
     def aoPerspectiveIsLgs(ao: AoPerspective): Boolean = ao match {
       case AoLgs => true


### PR DESCRIPTION
Altair will now be offered for all forthcoming 2019A proposals. This undoes the previous changes that made Altair not offered for 2019A.