### PR TITLE
REL-3552: Restore code from earlier semester that removes Altair from GMOS-N

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/GmosNorth.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/GmosNorth.scala
@@ -10,10 +10,7 @@ object GmosNorth {
 
   import InstrumentMode._
 
-  // REL-3363: No GMOS-N + Altair offered for 2018B. Skip over the AdaptiveOpticsNode and just use AltairNone.
-  // Constructor for initial node
-  // def apply() = new AdaptiveOpticsNode
-  def apply() = new SelectMode(AltairNone)
+   def apply() = new AdaptiveOpticsNode
 
   class AdaptiveOpticsNode extends SingleSelectNode[Unit, Altair, Altair](()) with AltairNode {
     override val allGuideStarTypes = true

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/GmosNorth.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/GmosNorth.scala
@@ -10,7 +10,10 @@ object GmosNorth {
 
   import InstrumentMode._
 
-   def apply() = new AdaptiveOpticsNode
+  // REL-3363: No GMOS-N + Altair offered for 2018B. Skip over the AdaptiveOpticsNode and just use AltairNone.
+  // Constructor for initial node
+  // def apply() = new AdaptiveOpticsNode
+  def apply() = new SelectMode(AltairNone)
 
   class AdaptiveOpticsNode extends SingleSelectNode[Unit, Altair, Altair](()) with AltairNode {
     override val allGuideStarTypes = true

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -243,7 +243,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 7
+          changes must have length 8
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -268,7 +268,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 7
+          changes must have length 8
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -294,7 +294,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 8
+          changes must have length 9
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")


### PR DESCRIPTION
As LGS isn't possible with GMOS-N for 2019A, we add code to remove Altair nodes from GMOS-N observations, as we did in REL-3363.