### PR TITLE
REL-3563: Update Altair default LGS guide star magnitude

### DIFF
--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/AOConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/AOConfig.java
@@ -31,7 +31,7 @@ public class AOConfig extends ParamSet {
 
     // Default values
     private static final String DEFAULT_NGS_GSMAG = "11.0";
-    private static final String DEFAULT_LGS_GSMAG = "12.0";
+    private static final String DEFAULT_LGS_GSMAG = "11.0";
     private static final String DEFAULT_SEEING = "0.23";
     private static final String DEFAULT_WINDSPEED = "20";
 


### PR DESCRIPTION
Due to the new laser, the magnitude as per the WDBA must be changed.

I have confirmed that this does not affect GeMS.