### PR TITLE
REL-3550: use CWFS3 to evaluate guide star suitability for GeMS TPE plot

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -10,10 +10,11 @@ import edu.gemini.catalog.api._
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.shared.util.immutable.{None => JNone}
 import edu.gemini.shared.util.immutable.ScalaConverters._
-import edu.gemini.spModel.ags.AgsStrategyKey.{ Pwfs1NorthKey, Pwfs2NorthKey, Pwfs1SouthKey, Pwfs2SouthKey }
+import edu.gemini.spModel.ags.AgsStrategyKey.{ Pwfs1NorthKey, Pwfs2NorthKey, Pwfs1SouthKey, Pwfs2SouthKey, GemsKey }
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.altair.{AltairParams, InstAltair}
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
+import edu.gemini.spModel.gemini.gems.Canopus
 import edu.gemini.spModel.gemini.gmos.{InstGmosNorth, InstGmosSouth}
 import edu.gemini.spModel.gemini.gnirs.{GNIRSConstants, InstGNIRS}
 import edu.gemini.spModel.gemini.gpi.Gpi
@@ -76,9 +77,14 @@ case class ObservationInfo(ctx: Option[ObsContext],
    * Attempts to find the guide probe for the selected strategy
    */
   def guideProbe: Option[ValidatableGuideProbe] =
-    strategy.flatMap(_.strategy.guideProbes.headOption.collect {
-      case v: ValidatableGuideProbe => v
-    })
+    strategy.map(_.strategy).flatMap { s =>
+      s.key match {
+        case GemsKey => Some(Canopus.Wfs.cwfs3)
+        case _       => s.guideProbes.headOption.collect {
+          case v: ValidatableGuideProbe => v
+        }
+      }
+    }
 
   /**
    * An obscontext is required for guide quality calculation. The method below will attempt to create a context out of the information on the query form


### PR DESCRIPTION
The TPE plot for AGS guide star candidates needs a guide probe to evaluate guide stars.  Using the probe's magnitude limits it can determine whether the guide star is too faint or requires slower guiding, etc. and hence color the candidate accordingly.

At least in theory, for GeMS multiple guide probes can be involved and unfortunately only one can be used for the plot colors.  In reality we only use Canopus now for GeMS so this PR tweaks the catalog UI to ensure that we evaluate GeMS candidates wrt to Canopus.  Before it would select the first one [which happens to be F2 OIWFS](https://github.com/gemini-hlsw/ocs/blob/develop/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GemsStrategy.scala#L191)!