### PR TITLE
REL-3569: Fixed issue with base morphing.

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1390,7 +1390,7 @@ enum BasePositionType implements PositionType {
         final GuideEnvironment   genv = env.getGuideEnvironment();
         final ImList<UserTarget> user = env.getUserTargets().append(new UserTarget(UserTarget.Type.other, baseTarget));
 
-        final TargetEnvironment newEnv = TargetEnvironment.create(baseTarget, genv, user);
+        final TargetEnvironment newEnv = TargetEnvironment.create(target, genv, user);
         obsComp.setTargetEnvironment(newEnv);
     }
 


### PR DESCRIPTION
This took an embarrassingly long time to figure out, given what a simple fix it was.

The issue was that when switching target types, if the user tried to switch a target to the base, the base would not change, and the target would morph to the base and would be unselectable.

This was due to creating the asterism incorrectly, using the old base position for the new base position and the user position. This resulted in the base position never changing, and having the same reference as the user position (that was morphed from the base position), thus making the user position unselectable.

I have fixed this by setting the new base position to the user target to morph, as it should have been, and now the base position converts properly, and everything is selectable.