### PR TITLE
REL-3454: Add support for Zorro at GS to replace DSSI.

### DIFF
--- a/bundle/edu.gemini.ags.client.impl/src/main/scala/edu/gemini/ags/client/impl/QueryArgs.scala
+++ b/bundle/edu.gemini.ags.client.impl/src/main/scala/edu/gemini/ags/client/impl/QueryArgs.scala
@@ -56,6 +56,7 @@ object QueryArgs {
     case g: GracesBlueprint     => Right(Instrument.GmosNorth.id) // REL-3288: GRACES uses GMOS-N OI.
     case g: TexesBlueprint      => Right(Instrument.Nifs.id)      // REL-1062
     case g: VisitorBlueprint    => Right(Instrument.Niri.id)      // REL-1090
+    case g: ZorroBlueprint      => Right(Instrument.Nifs.id)      // REL-3454: treat Zorro like Alopeke and DSSI.
     case g: GeminiBlueprintBase => Right(g.instrument.id)
     case _ => Left("Not a Gemini Instrument")
   }

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/snippets/format.xml
@@ -233,6 +233,7 @@
             <xsl:when test="$inst = 'dssi'">DSSI - <xsl:value-of select="$site"/></xsl:when>
             <xsl:when test="$inst = 'texes'">Texes - <xsl:value-of select="$site"/></xsl:when>
             <xsl:when test="$inst = 'trecs'">TReCS</xsl:when>
+            <xsl:when test="$inst = 'zorro'">Zorro</xsl:when>
             <xsl:otherwise>?<xsl:value-of select="$inst"/>?</xsl:otherwise>
         </xsl:choose>
 
@@ -265,6 +266,7 @@
             <xsl:when test="$inst = 'dssi'"><xsl:value-of select="$site"/></xsl:when>
             <xsl:when test="$inst = 'texes'"><xsl:value-of select="$site"/></xsl:when>
             <xsl:when test="$inst = 'trecs'">Gemini South</xsl:when>
+            <xsl:when test="$inst = 'zorro'">Gemini South</xsl:when>
             <xsl:when test="$inst = 'subaru'">Subaru</xsl:when>
             <xsl:when test="$inst = 'keck'">Keck</xsl:when>
             <xsl:otherwise>?<xsl:value-of select="$inst"/>?</xsl:otherwise>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_zorro.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/resources/edu/gemini/model/p1/pdf/proposal_with_zorro.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2018.2.1">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2018" half="B"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets>
+       <sidereal epoch="J2000" id="target-0">
+          <name>vega</name>
+            <degDeg>
+                <ra>279.23473479</ra>
+                <dec>38.78368896</dec>
+            </degDeg>
+            <properMotion deltaDec="286.23" deltaRA="200.94"/>
+            <magnitudes>
+                <magnitude system="Vega" band="B">0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="V">0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="R">0.10000000149011612</magnitude>
+                <magnitude system="Vega" band="J">-0.18000000715255737</magnitude>
+                <magnitude system="Vega" band="H">-0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="K">0.12999999523162842</magnitude>
+            </magnitudes>
+        </sidereal>
+    </targets>
+    <conditions>
+        <condition id="condition-0">
+            <name>CC Any, IQ Any, SB Any/Bright, WV Any</name>
+            <cc>Any</cc>
+            <iq>Any</iq>
+            <sb>Any/Bright</sb>
+            <wv>Any</wv>
+        </condition>
+    </conditions>
+    <blueprints>
+        <zorro>
+            <Zorro id="blueprint-0">
+              <name>Zorro Speckle (0.0096"/pix, 6.7" FoV)</name>
+                <visitor>false</visitor>
+                <mode>Speckle (0.0096"/pix, 6.7" FoV)</mode>
+            </Zorro>
+        </zorro>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" target="target-0" condition="condition-0" blueprint="blueprint-0">
+            <progTime units="hr">1.0</progTime>
+            <partTime units="hr">0.0</partTime>
+            <time units="hr">1.0</time>
+            <meta ck="">
+                <visibility>Good</visibility>
+                <gsa>0</gsa>
+            </meta>
+        </observation>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
+++ b/bundle/edu.gemini.model.p1.pdf/src/test/scala/edu/gemini/model/p1/pdf/P1TemplatesSpec.scala
@@ -133,14 +133,13 @@ class P1TemplatesSpec extends Specification with XmlMatchers {
       // Check that we use the proper public name of Texes
       XML.loadString(result) must (\\("table-cell") \ "block" \> "Texes - Gemini North")
     }
-    "present the correct name when using Dssi, REL-1061" in {
-      val result = transformProposal("proposal_with_dssi.xml")
-      // Check that we use the proper public name of DSSI
-      XML.loadString(result) must (\\("table-cell") \ "block" \> "DSSI - Gemini North")
-    }
     "present the correct name when using 'Alopeke, REL-3351" in {
       val result = transformProposal("proposal_with_alopeke.xml")
       XML.loadString(result) must (\\("table-cell") \ "block" \> "'Alopeke")
+    }
+    "present the correct name when using Zorro, REL-3454" in {
+      val result = transformProposal("proposal_with_zorro.xml")
+      XML.loadString(result) must (\\("table-cell") \ "block" \> "Zorro")
     }
     "present the correct name when using Visitor GN, REL-1090" in {
       val result = transformProposal("proposal_with_visitor_gn.xml")
@@ -306,11 +305,6 @@ class P1TemplatesSpec extends Specification with XmlMatchers {
     "show that Texes is in Gemini North, REL-1062" in {
       val result = transformProposal("proposal_with_texes.xml", P1PDF.NOAONoInvestigatorsList)
       // Check that Texes is shown in Gemini North
-      XML.loadString(result) must (\\("table-cell") \ "block" \> "Gemini North")
-    }
-    "show that Dssi is in Gemini North, REL-1061" in {
-      val result = transformProposal("proposal_with_dssi.xml", P1PDF.NOAONoInvestigatorsList)
-      // Check that Speckle is shown in Gemini North
       XML.loadString(result) must (\\("table-cell") \ "block" \> "Gemini North")
     }
     "show that a GN visitor is in Gemini North, REL-1090" in {

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -8,7 +8,7 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
   var title = "Select Instrument"
   var description = s"The following instruments are available for semester ${sem.year}${sem.half}. See the Gemini website for information on instrument capabilities and configuration options."
 
-  def choices = List(Alopeke, Dssi, Flamingos2, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Phoenix, Visitor)
+  def choices = List(Alopeke, Flamingos2, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Nifs, Niri, Phoenix, Visitor, Zorro)
 
   def apply(i:Instrument) = i match {
     case Alopeke    => Left(inst.Alopeke())
@@ -28,6 +28,7 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
     case Texes      => Left(inst.Texes())
     case Trecs      => Left(inst.Trecs())
     case Visitor    => Left(inst.Visitor())
+    case Zorro      => Left(inst.Zorro())
   }
 
   def unapply = {

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Zorro.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/inst/Zorro.scala
@@ -1,0 +1,20 @@
+package edu.gemini.model.p1.dtree.inst
+
+import edu.gemini.model.p1.dtree._
+import edu.gemini.model.p1.immutable._
+
+object Zorro {
+
+  def apply() = new ModeNode
+
+  class ModeNode extends SingleSelectNode[Unit, ZorroMode, ZorroBlueprint](()) {
+    override val title = "Mode"
+    override val description = "Please select mode, pixel scale, and field of view."
+    override val choices: List[ZorroMode] = ZorroMode.values.toList
+    override def apply(m: ZorroMode) = Right(ZorroBlueprint(m))
+
+    override def unapply = {
+      case b: ZorroBlueprint => b.mode
+    }
+  }
+}

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/BlueprintBase.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/BlueprintBase.scala
@@ -68,6 +68,9 @@ object BlueprintBase {
     case b: M.TrecsBlueprintImaging         => TrecsBlueprintImaging(b)
     case b: M.TrecsBlueprintSpectroscopy    => TrecsBlueprintSpectroscopy(b)
 
+    // Zorro
+    case b: M.ZorroBlueprint                => ZorroBlueprint(b)
+
     // Exchange
     case b: M.SubaruBlueprint               => SubaruBlueprint(b)
     case b: M.KeckBlueprint                 => KeckBlueprint(b)

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
@@ -26,6 +26,7 @@ object Instrument {
   case object Phoenix    extends Instrument(GS, "Phoenix", "Phoenix", "PHOENIX")
   case object Trecs      extends Instrument(GS, "TReCS", "T-ReCS", "TReCS")
   case object Visitor    extends Instrument(GS, "Visitor")
+  case object Zorro      extends Instrument(GS, "Zorro")
 
 //  case object Keck extends Instrument(Site.Keck, "Keck")
 //  case object Subaru extends Instrument(Site.Subaru, "Subaru")

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ZorroBlueprint.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ZorroBlueprint.scala
@@ -1,0 +1,33 @@
+package edu.gemini.model.p1.immutable
+
+import edu.gemini.model.p1.{mutable => M}
+
+object ZorroBlueprint {
+  def apply(m: M.ZorroBlueprint): ZorroBlueprint = new ZorroBlueprint(m)
+}
+
+case class ZorroBlueprint(mode: ZorroMode) extends GeminiBlueprintBase {
+  def name: String = s"Zorro ${mode.value}"
+  override val visitor = true
+
+  def this(m: M.ZorroBlueprint) = this(
+    m.getMode
+  )
+
+  override def instrument: Instrument = Instrument.Zorro
+
+  override def mutable(n: Namer) = {
+    val m = Factory.createZorroBlueprint
+    m.setId(n.nameOf(this))
+    m.setName(name)
+    m.setVisitor(visitor)
+    m.setMode(mode)
+    m
+  }
+
+  override def toChoice(n: Namer) = {
+    val m = Factory.createZorroBlueprintChoice
+    m.setZorro(mutable(n))
+    m
+  }
+}

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -533,6 +533,11 @@ package object immutable {
     val WIDE_FIELD = M.AlopekeMode.WIDE_FIELD_0_0725_PIX_60_FO_V
   }
 
+  type ZorroMode = M.ZorroMode
+  object ZorroMode extends EnumObject[M.ZorroMode] {
+    val SPECKLE    = M.ZorroMode.SPECKLE_0_0096_PIX_6_7_FO_V
+    val WIDE_FIELD = M.ZorroMode.WIDE_FIELD_0_0725_PIX_60_FO_V
+  }
 }
 
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/overheads/Overheads.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/overheads/Overheads.scala
@@ -110,7 +110,7 @@ object Overheads extends (BlueprintBase => Option[Overheads]) {
     case _: DssiBlueprint               => SimpleOverheads(0.00, 10, 0.010).some
     case _: VisitorBlueprint            => SimpleOverheads(0.00, 10, 0.100).some
     case _: AlopekeBlueprint            => SimpleOverheads(0.00,  6, 0.000).some
-
+    case _: ZorroBlueprint              => SimpleOverheads(0.00,  6, 0.000).some
 
     // NIRI relies on whether or not AO is being used.
     case nbp: NiriBlueprint             => SimpleOverheads(0.10, nbp.altair.ao.toBoolean ? 10 | 6, 0.193).some

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -1,5 +1,13 @@
 Gemini Phase I Schema Changes
 
+# Version 2019.2.1 - 2019B
+##########################
+
+* Added new instrument, Zorro, with two modes, namely Speckle (0.0096"/pix, 6.7" FoV) and Wide Field (0.0725"/pix, 60" FoV). (REL-3454)
+
+# Version 2019.1.1 - 2019A
+##########################
+
 # Version 2018.2.2 - 2018B
 ##########################
 

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Proposal.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Proposal.xsd
@@ -25,6 +25,7 @@
     <xsd:include schemaLocation="ProposalClass.xsd"/>
     <xsd:include schemaLocation="Observation.xsd"/>
     <xsd:include schemaLocation="Alopeke.xsd"/>
+    <xsd:include schemaLocation="Zorro.xsd"/>
 
     <xsd:element name="proposal">
         <xsd:complexType>
@@ -135,6 +136,7 @@
             <xsd:element name="trecs"      type="TrecsBlueprintChoice"/>
             <xsd:element name="visitor"    type="VisitorBlueprintChoice"/>
             <xsd:element name="alopeke"    type="AlopekeBlueprintChoice"/>
+            <xsd:element name="zorro"      type="ZorroBlueprintChoice"/>
         </xsd:choice>
     </xsd:complexType>
 

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Zorro.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Zorro.xsd
@@ -1,0 +1,40 @@
+<!--
+  Schema definition for Zorro blueprints.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:include schemaLocation="Instrument.xsd"/>
+
+    <!-- Options for Zorro Blueprint. -->
+    <xsd:complexType name="ZorroBlueprintChoice">
+        <xsd:sequence>
+            <xsd:choice>
+                <xsd:element name="null"  type="ZorroBlueprintNull"/>
+                <xsd:element name="Zorro" type="ZorroBlueprint"/>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- Zorro null. Empty blueprint, not available in PIT. -->
+    <xsd:complexType name="ZorroBlueprintNull"/>
+
+    <!--
+      Zorro Blueprint base type.
+    -->
+    <xsd:complexType name="ZorroBlueprint">
+        <xsd:complexContent>
+            <xsd:extension base="BlueprintBase">
+                <xsd:sequence>
+                    <xsd:element name="mode" type="ZorroMode"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:simpleType name="ZorroMode">
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value='Speckle (0.0096"/pix, 6.7" FoV)'/>
+            <xsd:enumeration value='Wide Field (0.0725"/pix, 60" FoV)'/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+</xsd:schema>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_zorro.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/proposal_with_zorro.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2018.2.1">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2018" half="B"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets>
+       <sidereal epoch="J2000" id="target-0">
+          <name>vega</name>
+            <degDeg>
+                <ra>279.23473479</ra>
+                <dec>38.78368896</dec>
+            </degDeg>
+            <properMotion deltaDec="286.23" deltaRA="200.94"/>
+            <magnitudes>
+                <magnitude system="Vega" band="B">0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="V">0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="R">0.10000000149011612</magnitude>
+                <magnitude system="Vega" band="J">-0.18000000715255737</magnitude>
+                <magnitude system="Vega" band="H">-0.029999999329447746</magnitude>
+                <magnitude system="Vega" band="K">0.12999999523162842</magnitude>
+            </magnitudes>
+        </sidereal>
+    </targets>
+    <conditions>
+        <condition id="condition-0">
+            <name>CC Any, IQ Any, SB Any/Bright, WV Any</name>
+            <cc>Any</cc>
+            <iq>Any</iq>
+            <sb>Any/Bright</sb>
+            <wv>Any</wv>
+        </condition>
+    </conditions>
+    <blueprints>
+        <zorro>
+            <Zorro id="blueprint-0">
+              <name>Zorro Speckle (0.0096"/pix, 6.7" FoV)</name>
+                <visitor>false</visitor>
+                <mode>Speckle (0.0096"/pix, 6.7" FoV)</mode>
+            </Zorro>
+        </zorro>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" target="target-0" condition="condition-0" blueprint="blueprint-0">
+            <progTime units="hr">1.0</progTime>
+            <partTime units="hr">0.0</partTime>
+            <time units="hr">1.0</time>
+            <meta ck="">
+                <visibility>Good</visibility>
+                <gsa>0</gsa>
+            </meta>
+        </observation>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_dssi_gs.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_with_dssi_gs.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2013.2.1">
+    <meta band3optionChosen="false"/>
+    <semester year="2013" half="B"/>
+    <title/>
+    <abstract/>
+    <scheduling/>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email/>
+            <address>
+                <institution/>
+                <address/>
+                <country/>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints>
+        <dssi>
+            <Dssi id="blueprint-0">
+                <name>Dssi Gemini South</name>
+                <visitor>true</visitor>
+                <site>Gemini South</site>
+            </Dssi>
+        </dssi>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" blueprint="blueprint-0"/>
+    </observations>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
@@ -15,9 +15,9 @@ class RootSpec extends Specification {
       val root = new Root(Semester(2018, B))
       root.choices must not contain Instrument.Texes
     }
-    "include Speckles" in {
-      val root = new Root(Semester(2016, A))
-      root.choices must contain (Instrument.Dssi)
+    "DSSI has been removed in 2019B" in {
+      val root = new Root(Semester(2019, B))
+      root.choices must not contain Instrument.Dssi
     }
     "include Visitor" in {
       val root = new Root(Semester(2016, B))
@@ -46,6 +46,10 @@ class RootSpec extends Specification {
     "include Alopeke" in {
       val root = new Root(Semester(2018, B))
       root.choices must contain (Instrument.Alopeke)
+    }
+    "include Zorro" in {
+      val root = new Root(Semester(2019, B))
+      root.choices must contain (Instrument.Zorro)
     }
   }
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/ZorroSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/inst/ZorroSpec.scala
@@ -1,0 +1,13 @@
+package edu.gemini.model.p1.dtree.inst
+
+import org.specs2.mutable.Specification
+
+class ZorroSpec extends Specification {
+  "The Zorro decision tree" should {
+    "include Zorro modes" in {
+      val zorro = Zorro()
+      zorro.title must beEqualTo("Mode")
+      zorro.choices must have size 2
+    }
+  }
+}

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ZorroBlueprintSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ZorroBlueprintSpec.scala
@@ -1,0 +1,53 @@
+package edu.gemini.model.p1.immutable
+
+import java.io.InputStreamReader
+
+import org.specs2.matcher.XmlMatchers
+import org.specs2.mutable.Specification
+
+import scala.xml.XML
+
+class ZorroBlueprintSpec extends Specification with SemesterProperties with XmlMatchers {
+  private val blueprints = ZorroMode.values.map(m => ZorroBlueprint(m))
+
+  // A proposal for Zorro with speckle mode and visitor set to false.
+  private val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_zorro.xml")))
+
+  "The 'Zorro Blueprint" should {
+    "not use Ao" in {
+      ((_: ZorroBlueprint).ao must beEqualTo(AoNone)).forall(blueprints)
+    }
+    "be a visitor instrument" in {
+      ((_: ZorroBlueprint).visitor must beTrue).forall(blueprints)
+    }
+    "have a mode" in {
+      ZorroBlueprint(ZorroMode.SPECKLE).mode must beEqualTo(ZorroMode.SPECKLE)
+      ZorroBlueprint(ZorroMode.WIDE_FIELD).mode must beEqualTo(ZorroMode.WIDE_FIELD)
+      true must beTrue
+    }
+    "export Zorro to XML" in {
+      { (b: ZorroBlueprint) =>
+        val observation = Observation(Some(b), None, None, Band.BAND_1_2, None)
+        val proposal    = Proposal.empty.copy(observations = observation :: Nil)
+        val xml         = XML.loadString(ProposalIo.writeToString(proposal))
+
+        // Verify that this has the tags we expect.
+        xml must \\("zorro")
+        xml must \\("zorro") \\ "Zorro"
+        xml must \\("Zorro") \\ "name" \> b.name
+        xml must \\("Zorro") \\ "mode" \> b.mode.value
+        xml must \\("Zorro") \ "visitor" \> "true"
+      }.forall(blueprints)
+    }
+    "be possible to deserialize" in {
+      // This is configured with speckle mode.
+      proposal.blueprints.head must beEqualTo(ZorroBlueprint(ZorroMode.SPECKLE))
+    }
+    "overwrite visitor as true" in {
+      // Even though it is false in the XML, it should become true in the model.
+      proposal.blueprints.head.visitor must beTrue
+      val xml = XML.loadString(ProposalIo.writeToString(proposal))
+      xml must \\("Zorro") \ "visitor" \> "true"
+    }
+  }
+}

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -451,20 +451,6 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
         }
       }
     }
-    "proposal with dssi blueprints must have a site, REL-2463" in {
-      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi_no_site.xml")))
-
-      val converted = UpConverter.convert(xml)
-      converted must beSuccessful.like {
-        case StepResult(changes, result) =>
-          changes must have length 5
-          changes must contain("DSSI proposal has been assigned to Gemini South.")
-          // The dssi blueprint must remain and include a site
-          result must \\("Dssi", "id")
-          result must \\("Dssi") \\ "site" \> "Gemini South"
-          result must \\("Dssi") \\ "name" \> "DSSI Gemini South"
-      }
-    }
     "proposal with dssi blueprints at Gemini North must migrate to 'Alopeke, REL-3349" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi_gn.xml")))
 
@@ -711,29 +697,6 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           changes must have length 5
           // Check that fpu and name are replaced
           result must \\("name") \> "GMOS-N IFU None B600 i + CaT (815 nm) IFU 1 slit"
-      }
-    }
-    "remove submissions for ngo gs, REL-1918" in {
-      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gs_time_request.xml")))
-      val converted = UpConverter.convert(xml)
-      converted must beSuccessful.like {
-        case StepResult(changes, result) =>
-          changes must have length 7
-          changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
-          changes must contain(s"Updated semester to ${Semester.current.display}")
-          changes must contain("Please use the PIT from semester 2014B to view the unmodified proposal")
-          changes must contain("Gemini Staff is no longer a valid partner and this time request has been removed")
-          changes must contain("Former observation time parameter mapped to program time")
-
-          // Sanity check
-          ProposalIo.read(result.toString())
-
-          // ngo is gone
-          result \\ "queue" must not \\ "ngo"
-          // but itac is there
-          result \\ "queue" must \\("itac")
-          // Check that queue attributes are preserved
-          result must \\("queue", "key" -> "604c87d8-9bf8-96a8-0642-f70604c87d89", "tooOption" -> "None")
       }
     }
     "proposal with Graces blueprints must be preserved, REL-2200" in {

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -478,6 +478,19 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           result must \\("Alopeke") \\ "name" \> AlopekeBlueprint(AlopekeMode.SPECKLE).name
       }
     }
+    "proposal with dssi blueprints at Gemini South must migrate to Zorro, REL-3454" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_dssi_gs.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must have length 5
+          changes must contain(SemesterConverter2019ATo2019B.dssiGSToZorroMessage)
+          result must \\("Zorro", "id")
+          result must \\("Zorro") \\ "mode" \> ZorroMode.SPECKLE.value
+          result must \\("Zorro") \\ "name" \> ZorroBlueprint(ZorroMode.SPECKLE).name
+      }
+    }
     "proposal with phoenix blueprints must have them removed, REL-3233" in {
       skipped {
         val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_phoenix_no_site.xml")))

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpBlueprintFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpBlueprintFactory.scala
@@ -73,6 +73,7 @@ object SpBlueprintFactory {
       case b: VisitorBlueprint              => VisitorHandler(b)
       case b: AlopekeBlueprint              => VisitorHandler(b)
       case b: DssiBlueprint                 => VisitorHandler(b)
+      case b: ZorroBlueprint                => VisitorHandler(b)
       case b: GracesBlueprint               => Graces(b)
       case _                                => Left("Unexpected blueprint: " + base)
     }
@@ -397,6 +398,7 @@ object SpBlueprintFactory {
   object VisitorHandler {
     def apply(b: VisitorBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.customName))
     def apply(b: AlopekeBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name))
+    def apply(b: ZorroBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name))
     def apply(b: DssiBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint("DSSI"))
   }
 


### PR DESCRIPTION
Zorro is a copy of 'Alopeke that is replacing DSSI at GS just as 'Alopeke replaced DSSI at GN.

Thus, the implementation was straightforward, following the implementation that was done for 2018B when 'Alopeke replaced DSSI. Note that this also covers REL-3607, i.e. adding initial implementation for Zorro to the OT, since it was easier to just do them both at once.

Here are two screenshots of a 2017B DSSI GS program being opened in the 2019B PIT.

![screen shot 2019-02-12 at 4 06 20 pm](https://user-images.githubusercontent.com/8795653/52661682-516b0c00-2ee1-11e9-9759-170d3a7f57e1.png)

![screen shot 2019-02-12 at 4 06 32 pm](https://user-images.githubusercontent.com/8795653/52661689-56c85680-2ee1-11e9-8c94-f05bca2ea285.png)
