### PR TITLE
REL-3609: addendum

### DIFF
--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/www/HttpTooUpdate.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/www/HttpTooUpdate.java
@@ -31,7 +31,7 @@ public final class HttpTooUpdate implements TooUpdate {
     public static final String READY_PARAM          = "ready";
 
     public static final Duration MIN_EXPOSURE_TIME  = Duration.ofSeconds(1L);
-    public static final Duration MAX_EXPOSURE_TIME  = Duration.ofSeconds(300L);
+    public static final Duration MAX_EXPOSURE_TIME  = Duration.ofSeconds(1200L);
 
     private final TooIdentity _id;
     private final TooTarget _target;
@@ -75,7 +75,7 @@ public final class HttpTooUpdate implements TooUpdate {
             try {
                 expTime = Duration.ofSeconds(Integer.parseInt(expTimeString));
             } catch (NumberFormatException ex) {
-                throw new BadRequestException("cannot parse " + EXPOSURE_TIME_PARAM + " value `" + expTimeString + "`");
+                throw new BadRequestException("cannot parse " + EXPOSURE_TIME_PARAM + " value `" + expTimeString + "` as an integral number of seconds");
             }
 
             if (expTime.compareTo(MIN_EXPOSURE_TIME) < 0) {

--- a/bundle/edu.gemini.oodb.too.url/src/test/scala/edu/gemini/spdb/rapidtoo/www/HttpUpdateSpec.scala
+++ b/bundle/edu.gemini.oodb.too.url/src/test/scala/edu/gemini/spdb/rapidtoo/www/HttpUpdateSpec.scala
@@ -4,6 +4,7 @@ package edu.gemini.spdb.rapidtoo.www
 import edu.gemini.shared.util.immutable.ImOption
 import edu.gemini.spdb.rapidtoo.www.HttpTargetSpec._
 
+import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
@@ -28,31 +29,24 @@ object HttpUpdateSpec extends Specification with ScalaCheck with Arbitraries wit
     "dec"      -> "-52:41:44.39"
   )
 
+  val minSec = HttpTooUpdate.MIN_EXPOSURE_TIME.getSeconds.toInt
+  val maxSec = HttpTooUpdate.MAX_EXPOSURE_TIME.getSeconds.toInt
+
   "HttpTooUpdate" should {
 
     def mustFail(req: HttpServletRequest) =
       new HttpTooUpdate(req) must throwA[BadRequestException]
 
-    "exptime: fail if out of range" ! forAll { (e: Int) =>
-      val req2 = req.modifiedWith("exptime" -> e.toString)
-      if (e < 1 || e > 300) mustFail(req2)
-      else (new HttpTooUpdate(req2)).getExposureTime() must_== ImOption.apply(Duration.ofSeconds(e))
+    "exptime: fail if out of range" ! forAll(Gen.oneOf(Gen.choose(Int.MinValue, minSec-1), Gen.choose(maxSec+1, Int.MaxValue))) { (e: Int) =>
+      mustFail(req.modifiedWith("exptime" -> e.toString))
+    }
+
+    "exptime: succeed if in range" ! forAll(Gen.choose(minSec, maxSec)) { (e: Int) =>
+       (new HttpTooUpdate(req.modifiedWith("exptime" -> e.toString))).getExposureTime() must_== ImOption.apply(Duration.ofSeconds(e))
     }
 
     "exptime: fail if not parseable" in {
       mustFail(req.modifiedWith("exptime" -> "1.4"))
-    }
-
-    "exptime: fail if too small" in {
-      mustFail(req.modifiedWith("exptime" -> "0"))
-    }
-
-    "exptime: fail if too big" in {
-      mustFail(req.modifiedWith("exptime" -> "301"))
-    }
-
-    "exptime: succeed if 1 <= exptime <= 300" in {
-       (new HttpTooUpdate(req.modifiedWith("exptime" -> "6"))).getExposureTime() must_== ImOption.apply(Duration.ofSeconds(6L))
     }
 
     "exptime: succeed if not specified" in {


### PR DESCRIPTION
Changes an error message when the exposure time cannot be parsed as an integer and raises the maximum exposure time to 1200 seconds.