### PR TITLE
REL-3625: time accounting rule update

### DIFF
--- a/bundle/edu.gemini.auxfile.workflow/build.sbt
+++ b/bundle/edu.gemini.auxfile.workflow/build.sbt
@@ -29,3 +29,5 @@ OsgiKeys.exportPackage := Seq(
   "edu.gemini.auxfile.client",
   "edu.gemini.auxfile.server",
   "edu.gemini.auxfile.copier")
+
+parallelExecution in Test := false

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObsRecordDatasetFactory.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObsRecordDatasetFactory.java
@@ -1,6 +1,7 @@
 package edu.gemini.obslog.transfer;
 
 
+import edu.gemini.pot.sp.Instrument;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentType;
@@ -81,7 +82,7 @@ public final class ObsRecordDatasetFactory implements Serializable {
 
         List<EObslogVisit> eObslogVisits = new ArrayList<EObslogVisit>();
 
-        for (ObsVisit visit : obsLog.getVisits()) {
+        for (ObsVisit visit : obsLog.getVisits(Instrument.fromComponentType(type))) {
             if (visit.getAllDatasetLabels().length == 0) {
                 LOG.fine("Skipping  empty visit");
                 continue;

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObservationObsVisitTimeFactory.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObservationObsVisitTimeFactory.java
@@ -2,9 +2,11 @@ package edu.gemini.obslog.transfer;
 
 
 import edu.gemini.obslog.obslog.OlLogOptions;
+import edu.gemini.pot.sp.Instrument;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentType;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.skycalc.ObservingNight;
 import edu.gemini.spModel.dataset.DatasetLabel;
 import edu.gemini.spModel.dataset.DatasetRecord;
@@ -86,12 +88,13 @@ public final class ObservationObsVisitTimeFactory implements Serializable {
         List<EChargeObslogVisit> obslogVisits = new ArrayList<EChargeObslogVisit>();
         OlLogOptions options = _obsLogOptions;
 
+        final Option<Instrument> inst = Instrument.fromComponentType(type);
         ObsVisit[] visits;
         if (options.getLimitConfigDatesByNight() == null) {
-            visits = obsLog.getVisits();
+            visits = obsLog.getVisits(inst);
         } else {
             ObservingNight night = options.getLimitConfigDatesByNight();
-            visits = obsLog.getVisits(night.getStartTime(), night.getEndTime());
+            visits = obsLog.getVisits(inst, night.getStartTime(), night.getEndTime());
         }
 
         for (ObsVisit visit : visits) {

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObservationObsVisitsFactory.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObservationObsVisitsFactory.java
@@ -2,9 +2,11 @@ package edu.gemini.obslog.transfer;
 
 
 import edu.gemini.obslog.obslog.OlLogOptions;
+import edu.gemini.pot.sp.Instrument;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.SPComponentType;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.skycalc.ObservingNight;
 import edu.gemini.spModel.dataset.DatasetLabel;
 import edu.gemini.spModel.dataset.DatasetRecord;
@@ -89,12 +91,14 @@ public final class ObservationObsVisitsFactory implements Serializable {
         List<EObslogVisit> eObslogVisits = new ArrayList<EObslogVisit>();
         OlLogOptions options = _obsLogOptions;
 
+        final Option<Instrument> inst = Instrument.fromComponentType(type);
+
         ObsVisit[] visits;
         if (options.getLimitConfigDatesByNight() == null) {
-            visits = obsLog.getVisits();
+            visits = obsLog.getVisits(inst);
         } else {
             ObservingNight night = options.getLimitConfigDatesByNight();
-            visits = obsLog.getVisits(night.getStartTime(), night.getEndTime());
+            visits = obsLog.getVisits(inst, night.getStartTime(), night.getEndTime());
         }
 
         for (ObsVisit visit : visits)  {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/InstrumentService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/InstrumentService.java
@@ -1,0 +1,52 @@
+package edu.gemini.spModel.obs;
+
+import edu.gemini.pot.sp.Instrument;
+import edu.gemini.pot.sp.ISPObservation;
+import edu.gemini.pot.sp.SPComponentBroadType;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
+
+/**
+ * A service used to determine the instrument used by an observation.  Examines
+ * the static components until it finds an instrument component, then extracts
+ * the instrument from the `SPComponentType`.
+ */
+public final class InstrumentService {
+
+    private InstrumentService() {
+    }
+
+    /**
+     * Determines the instrument for the given observation by examining the
+     * observation's components to find the first one that is an instrument, if
+     * any.
+     *
+     * @param obs the observation whose instrument is sought
+     *
+     * @return the instrument in use in the observation, if any
+     */
+    public static Option<Instrument> lookupInstrument(ISPObservation obs) {
+
+        // First check the cache.
+        Option<Instrument> inst = SPObsCache.getInstrument(obs);
+        if (inst.isEmpty()) {
+
+            // Compute the value.
+            inst = SPObsCache.getInstrument(obs).orElse(() ->
+                       ImOption.fromOptional(
+                           obs.getObsComponents()
+                              .stream()
+                              .filter(c -> c.getType().broadType == SPComponentBroadType.INSTRUMENT)
+                              .flatMap(c -> Instrument.fromComponentType(c.getType()).toStream())
+                              .findFirst()
+                       )
+            );
+
+            // Cache the results.
+            if (inst.isDefined()) SPObsCache.setInstrument(obs, inst);
+        }
+
+        return inst;
+    }
+
+}

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/NightObsTimesService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/NightObsTimesService.java
@@ -6,7 +6,9 @@ package edu.gemini.spModel.obs;
 
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.obsclass.ObsClass;
+import edu.gemini.pot.sp.Instrument;
 import edu.gemini.pot.sp.ISPObservation;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.obslog.ObsLog;
 import edu.gemini.spModel.obsrecord.ObsVisit;
 import edu.gemini.spModel.time.ChargeClass;
@@ -46,8 +48,11 @@ public class NightObsTimesService {
         ObsClass obsClass = ObsClassService.lookupObsClass(obs);
         ChargeClass chargeClass = obsClass.getDefaultChargeClass();
 
+        // Figure out the instrument in use, if any.
+        final Option<Instrument> inst = InstrumentService.lookupInstrument(obs);
+
         // Get the visits for the obs, if any.
-        ObsVisit[] visits = nodes.getExecRecord().getVisits(nodes.getQaRecord());
+        ObsVisit[] visits = nodes.getExecRecord().getVisits(inst, nodes.getQaRecord());
         if ((visits == null) || (visits.length == 0)) return res;
 
         // Start with the first visit, and figure out the ObservingNight and

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
@@ -3,8 +3,10 @@ package edu.gemini.spModel.obs;
 import edu.gemini.pot.sp.ISPProgram;
 import edu.gemini.shared.util.TimeValue;
 import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
 import edu.gemini.spModel.obsclass.ObsClass;
+import edu.gemini.pot.sp.Instrument;
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.ISPObservationContainer;
 import edu.gemini.spModel.obslog.ObsLog;
@@ -39,8 +41,10 @@ public final class ObsTimesService {
         // Ask the ObsRecord for the raw observation times.
         final ObsLog nodes = ObsLog.getIfExists(obs);
         if (nodes != null) {
+            final Option<Instrument> inst = InstrumentService.lookupInstrument(obs);
+
             final ObsClass obsClass = ObsClassService.lookupObsClass(obs);
-            res = nodes.getExecRecord().getTimes(nodes.getQaRecord(), obsClass.getDefaultChargeClass());
+            res = nodes.getExecRecord().getTimes(inst, nodes.getQaRecord(), obsClass.getDefaultChargeClass());
         }
 
         // Cache and return the results.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObsCache.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObsCache.java
@@ -185,7 +185,7 @@ public final class SPObsCache implements ISPEventMonitor, ISPCloneable, Serializ
     private Option<TargetCalculator> _targetCalculator;
 
     // The observation's instrument, if any.
-    private Option<Instrument> _instrument;
+    private Option<Instrument> _instrument = ImOption.empty();
 
     // The observation class (The value is determined by examining the sequence
     // and is cached here)
@@ -334,6 +334,7 @@ public final class SPObsCache implements ISPEventMonitor, ISPCloneable, Serializ
 //        _configSequence     = null;
         _stepCount          = null;
         _targetCalculator   = null;
+        _instrument         = ImOption.empty();
     }
 
     public void structureChanged(SPStructureChange change) {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObsCache.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObsCache.java
@@ -6,6 +6,7 @@ package edu.gemini.spModel.obs;
 
 import edu.gemini.pot.sp.*;
 import edu.gemini.shared.util.GeminiRuntimeException;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.dataset.DataflowStatus;
@@ -47,6 +48,16 @@ public final class SPObsCache implements ISPEventMonitor, ISPCloneable, Serializ
         if (cache == null) cache = new SPObsCache();
         cache.setTargetCalculator(targetCalculator);
         setObsCache(obs, cache);
+    }
+
+    public static Option<Instrument> getInstrument(ISPObservation obs) {
+        return ImOption.apply(getObsCache(obs)).flatMap(c -> c.getInstrument());
+    }
+
+    public static void setInstrument(ISPObservation obs, Option<Instrument> instrument) {
+        final SPObsCache c = ImOption.apply(getObsCache(obs)).getOrElse(() -> new SPObsCache());
+        c.setInstrument(instrument);
+        setObsCache(obs, c);
     }
 
     public static ObsClass getObsClass(ISPObservation obs) {
@@ -173,6 +184,9 @@ public final class SPObsCache implements ISPEventMonitor, ISPCloneable, Serializ
     // The target calculator.
     private Option<TargetCalculator> _targetCalculator;
 
+    // The observation's instrument, if any.
+    private Option<Instrument> _instrument;
+
     // The observation class (The value is determined by examining the sequence
     // and is cached here)
     private ObsClass _obsClass;
@@ -235,6 +249,14 @@ public final class SPObsCache implements ISPEventMonitor, ISPCloneable, Serializ
 
     public void setTargetCalculator(Option<TargetCalculator> targetCalculator) {
         _targetCalculator = targetCalculator;
+    }
+
+    public Option<Instrument> getInstrument() {
+        return _instrument;
+    }
+
+    public void setInstrument(Option<Instrument> instrument) {
+        _instrument = instrument;
     }
 
     public ObsTimes getCorrectedObsTimes() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obslog/ObsLog.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obslog/ObsLog.java
@@ -2,6 +2,7 @@ package edu.gemini.spModel.obslog;
 
 import edu.gemini.pot.sp.*;
 import edu.gemini.pot.spdb.IDBDatabaseService;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.dataset.*;
 import edu.gemini.spModel.obsrecord.ObsQaRecord;
 import edu.gemini.spModel.obsrecord.ObsExecRecord;
@@ -133,12 +134,12 @@ public final class ObsLog {
         return execLogDataObject.getRecord();
     }
 
-    public ObsVisit[] getVisits() {
-        return getExecRecord().getVisits(getQaRecord());
+    public ObsVisit[] getVisits(Option<Instrument> instrument) {
+        return getExecRecord().getVisits(instrument, getQaRecord());
     }
 
-    public ObsVisit[] getVisits(long startTime, long endTime) {
-        return getExecRecord().getVisits(getQaRecord(), startTime, endTime);
+    public ObsVisit[] getVisits(Option<Instrument> instrument, long startTime, long endTime) {
+        return getExecRecord().getVisits(instrument, getQaRecord(), startTime, endTime);
     }
 
     public scala.Option<DataflowStatus> getMinimumDisposition() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/ObsExecRecord.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/ObsExecRecord.java
@@ -1,5 +1,7 @@
 package edu.gemini.spModel.obsrecord;
 
+import edu.gemini.pot.sp.Instrument;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.GeminiRuntimeException;
 import edu.gemini.spModel.config2.Config;
 import edu.gemini.spModel.config2.DefaultConfig;
@@ -348,8 +350,8 @@ public final class ObsExecRecord implements Serializable {
      * @return array of ObsVisit corresponding to the visits that this
      * observation has seen
      */
-    public synchronized ObsVisit[] getVisits(ObsQaRecord qa) {
-        return _visits.getObsVisits(qa, _configStore);
+    public synchronized ObsVisit[] getVisits(Option<Instrument> instrument, ObsQaRecord qa) {
+        return _visits.getObsVisits(instrument, qa, _configStore);
     }
 
     /**
@@ -362,8 +364,8 @@ public final class ObsExecRecord implements Serializable {
      * @return {@link ObsVisit}s whose start time falls between
      * <code>startTime</code> (inclusive) and <code>endTime</code> exclusive
      */
-    public synchronized ObsVisit[] getVisits(ObsQaRecord qa, long startTime, long endTime) {
-        return _visits.getObsVisits(qa, _configStore, startTime, endTime);
+    public synchronized ObsVisit[] getVisits(Option<Instrument> instrument, ObsQaRecord qa, long startTime, long endTime) {
+        return _visits.getObsVisits(instrument, qa, _configStore, startTime, endTime);
     }
 
     /**
@@ -398,8 +400,12 @@ public final class ObsExecRecord implements Serializable {
      * @return total times which should be charged to the various categories
      * (see {@link ChargeClass})
      */
-    public ObsTimeCharges getTimeCharges(ObsQaRecord qa, ChargeClass mainChargeClass) {
-        return _visits.getTimeCharges(mainChargeClass, qa, _configStore);
+    public ObsTimeCharges getTimeCharges(
+        Option<Instrument> instrument,
+        ObsQaRecord        qa,
+        ChargeClass        mainChargeClass
+    ) {
+        return _visits.getTimeCharges(instrument, mainChargeClass, qa, _configStore);
     }
 
     /**
@@ -412,8 +418,12 @@ public final class ObsExecRecord implements Serializable {
      *
      * @return calculated (uncorrected) observing times for this observation
      */
-    public ObsTimes getTimes(ObsQaRecord qa, ChargeClass mainChargeClass) {
-        return new ObsTimes(getTotalTime(), getTimeCharges(qa, mainChargeClass));
+    public ObsTimes getTimes(
+        Option<Instrument> instrument,
+        ObsQaRecord        qa,
+        ChargeClass        mainChargeClass
+    ) {
+        return new ObsTimes(getTotalTime(), getTimeCharges(instrument, qa, mainChargeClass));
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisit.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisit.java
@@ -4,7 +4,9 @@
 
 package edu.gemini.spModel.obsrecord;
 
+import edu.gemini.pot.sp.Instrument;
 import edu.gemini.pot.sp.SPObservationID;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.skycalc.Night;
 import edu.gemini.skycalc.ObservingNight;
 import edu.gemini.skycalc.TwilightBoundType;
@@ -88,11 +90,11 @@ final class PrivateVisit implements Serializable {
         return null;
     }
 
-    VisitTimes getTimeCharges(ObsQaRecord qa, ConfigStore store) {
-        return TimeAccounting.calcAsJava(_events, qa, store);
+    VisitTimes getTimeCharges(Option<Instrument> instrument, ObsQaRecord qa, ConfigStore store) {
+        return TimeAccounting.calcAsJava(instrument, _events, qa, store);
     }
 
-    ObsVisit toObsVisit(ObsQaRecord qa, ConfigStore store) {
+    ObsVisit toObsVisit(Option<Instrument> instrument, ObsQaRecord qa, ConfigStore store) {
         List<UniqueConfig> uniqueConfigs = new ArrayList<UniqueConfig>();
 
         Config lastConfig = null;
@@ -152,7 +154,7 @@ final class PrivateVisit implements Serializable {
         UniqueConfig[] uconfigs;
         uconfigs = uniqueConfigs.toArray(UniqueConfig.EMPTY_ARRAY);
 
-        return new ObsVisit(getEvents(), uconfigs, getTimeCharges(qa, store));
+        return new ObsVisit(getEvents(), uconfigs, getTimeCharges(instrument, qa, store));
     }
 
     // Implement as done in 2013B June release.  StartSequence is the only

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisitList.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisitList.java
@@ -4,6 +4,8 @@
 
 package edu.gemini.spModel.obsrecord;
 
+import edu.gemini.pot.sp.Instrument;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.event.ExecEvent;
 import edu.gemini.spModel.event.ObsExecEvent;
@@ -108,26 +110,30 @@ final class PrivateVisitList implements Serializable {
         return 0;
     }
 
-    ObsTimeCharges getTimeCharges(ChargeClass mainChargeClass,
-                                  ObsQaRecord qa, ConfigStore store) {
+    ObsTimeCharges getTimeCharges(
+        Option<Instrument> instrument,
+        ChargeClass        mainChargeClass,
+        ObsQaRecord        qa,
+        ConfigStore        store
+    ) {
 
         VisitTimes vt = new VisitTimes();
         for (PrivateVisit pv : _visits) {
-            vt.addVisitTimes(pv.getTimeCharges(qa, store));
+            vt.addVisitTimes(pv.getTimeCharges(instrument, qa, store));
         }
 
         return vt.getTimeCharges(mainChargeClass);
     }
 
-    ObsVisit[] getObsVisits(ObsQaRecord qa, ConfigStore store) {
+    ObsVisit[] getObsVisits(Option<Instrument> instrument, ObsQaRecord qa, ConfigStore store) {
         List<ObsVisit> obsVisitList = new ArrayList<ObsVisit>();
         for (PrivateVisit pv : _visits) {
-            obsVisitList.add(pv.toObsVisit(qa, store));
+            obsVisitList.add(pv.toObsVisit(instrument, qa, store));
         }
         return obsVisitList.toArray(ObsVisit.EMPTY_ARRAY);
     }
 
-    ObsVisit[] getObsVisits(ObsQaRecord qa, ConfigStore store, long startTime, long endTime) {
+    ObsVisit[] getObsVisits(Option<Instrument> instrument, ObsQaRecord qa, ConfigStore store, long startTime, long endTime) {
         List<ObsVisit> obsVisitList = null;
         for (PrivateVisit pv : _visits) {
             ObsExecEvent evt = pv.getFirstEvent();
@@ -136,7 +142,7 @@ final class PrivateVisitList implements Serializable {
             long visitStart = evt.getTimestamp();
             if ((startTime <= visitStart) && (visitStart < endTime)) {
                 if (obsVisitList == null) obsVisitList = new ArrayList<ObsVisit>();
-                obsVisitList.add(pv.toObsVisit(qa, store));
+                obsVisitList.add(pv.toObsVisit(instrument, qa, store));
             }
         }
         if (obsVisitList == null) return ObsVisit.EMPTY_ARRAY;

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/ObsVisitService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/ObsVisitService.scala
@@ -3,6 +3,7 @@ package edu.gemini.spModel.obsrecord
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.gemini.plan.NightlyRecord
+import edu.gemini.spModel.obs.InstrumentService
 import edu.gemini.spModel.obslog.ObsLog
 
 import scala.collection.JavaConverters._
@@ -20,7 +21,8 @@ object ObsVisitService {
       (for {
         obs <- Option(db.lookupObservationByID(oid))
         log <- Option(ObsLog.getIfExists(obs))
-      } yield log.getVisits(night.getStartTime, night.getEndTime).toList).getOrElse(Nil)
+        inst = InstrumentService.lookupInstrument(obs)
+      } yield log.getVisits(inst, night.getStartTime, night.getEndTime).toList).getOrElse(Nil)
     }.sorted(comparatorToOrdering(ObsVisit.START_TIME_COMPARATOR))
   }
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
@@ -2,6 +2,7 @@ package edu.gemini.spModel.obsrecord
 
 import java.time.Instant
 
+import edu.gemini.pot.sp.Instrument
 import edu.gemini.skycalc.TwilightBoundType.NAUTICAL
 import edu.gemini.skycalc.{Interval, ObservingNight, Union}
 import edu.gemini.spModel.core.{Semester, Site}
@@ -37,9 +38,10 @@ private[obsrecord] sealed trait VisitCalculator {
    * individual dataset.
    */
   def calc(
-    events: VisitEvents,
-    qa:     DatasetLabel => DatasetQaState,
-    oc:     DatasetLabel => ObsClass
+    instrument: Option[Instrument],
+    events:     VisitEvents,
+    qa:         DatasetLabel => DatasetQaState,
+    oc:         DatasetLabel => ObsClass
   ): VisitTimes
 
 }
@@ -67,9 +69,10 @@ private[obsrecord] object VisitCalculator {
       Instant.MIN
 
     override def calc(
-      events: VisitEvents,
-      qa:     DatasetLabel => DatasetQaState,
-      oc:     DatasetLabel => ObsClass
+      instrument: Option[Instrument], // ignored here
+      events:     VisitEvents,
+      qa:         DatasetLabel => DatasetQaState,
+      oc:         DatasetLabel => ObsClass
     ): VisitTimes =
       PrimordialVisitCalculator.instance.calc(events.sorted.toList.asJava, qa.asJava, oc.asJava)
 
@@ -148,9 +151,10 @@ private[obsrecord] object VisitCalculator {
       Instant.ofEpochMilli(semester.getStartDate(s).getTime)
 
     override def calc(
-      events: VisitEvents,
-      qa:     DatasetLabel => DatasetQaState,
-      oc:     DatasetLabel => ObsClass
+      instrument: Option[Instrument],
+      events:     VisitEvents,
+      qa:         DatasetLabel => DatasetQaState,
+      oc:         DatasetLabel => ObsClass
     ): VisitTimes = {
 
       val total = events.total

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obs/InstrumentServiceSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obs/InstrumentServiceSpec.scala
@@ -1,0 +1,147 @@
+package edu.gemini.spModel.obs
+
+import edu.gemini.pot.sp._
+import edu.gemini.pot.sp.SPComponentBroadType.INSTRUMENT
+import edu.gemini.pot.spdb.DBLocalDatabase
+import edu.gemini.pot.spdb.IDBDatabaseService
+import edu.gemini.spModel.core.SPProgramID
+
+import org.specs2.matcher.MatchResult
+import org.specs2.mutable.Specification
+
+import scala.collection.JavaConverters._
+
+object InstrumentServiceSpec extends Specification {
+
+  private val Key = new SPNodeKey
+  private val Pid = SPProgramID.toProgramID("GS-2019A-Q-1")
+
+  private def withTestObservation[A](f: (ISPObservation, IDBDatabaseService) => MatchResult[A]): MatchResult[A] = {
+
+    val odb = DBLocalDatabase.createTransient
+
+    try {
+      val p = odb.getFactory.createProgram(Key, Pid)
+      odb.put(p)
+
+      val o = odb.getFactory.createObservation(p, Instrument.none, null)
+      p.addObservation(o)
+
+      f(o, odb)
+
+    } finally {
+      odb.getDBAdmin.shutdown
+    }
+
+  }
+
+  private def addInstrument(i: Instrument, o: ISPObservation, odb: IDBDatabaseService): Unit = {
+
+    val oc = odb.getFactory.createObsComponent(o.getProgram, i.componentType, null)
+    o.addObsComponent(oc)
+
+  }
+
+  private def replaceInstrument(oi: Option[Instrument], o: ISPObservation, odb: IDBDatabaseService): Unit = {
+
+    val c0 = o.getObsComponents.asScala.filterNot(_.getType.broadType == INSTRUMENT).toList
+
+    val c1 = oi.fold(c0) { i =>
+      odb.getFactory.createObsComponent(o.getProgram, i.componentType, null) :: c0
+    }
+
+    o.setObsComponents(c1.asJava)
+
+  }
+
+
+  "InstrumentService" should {
+
+    "find nothing if there is no instrument" in {
+      withTestObservation { (o, odb) =>
+        InstrumentService.lookupInstrument(o) shouldEqual Instrument.none
+      }
+    }
+
+    "find the correct instrument when available" in {
+      withTestObservation { (o, odb) =>
+        addInstrument(Instrument.GmosSouth, o, odb)
+        InstrumentService.lookupInstrument(o) shouldEqual Instrument.GmosSouth.some
+      }
+    }
+
+    "track instrument changes" in {
+      withTestObservation { (o, odb) =>
+        addInstrument(Instrument.GmosSouth, o, odb)
+        val i0 = InstrumentService.lookupInstrument(o)
+        replaceInstrument(Some(Instrument.Flamingos2), o, odb)
+        val i1 = InstrumentService.lookupInstrument(o)
+
+        (i0 shouldEqual Instrument.GmosSouth.some) and (i1 shouldEqual Instrument.Flamingos2.some)
+      }
+    }
+
+  }
+
+  "SPObsCache" should {
+
+    "find nothing after initialization" in {
+      withTestObservation { (o, odb) =>
+        SPObsCache.setObsCache(o, new SPObsCache)
+        SPObsCache.getObsCache(o).getInstrument shouldEqual Instrument.none
+      }
+    }
+
+    "find the instrument after InstrumentService stores it" in {
+      withTestObservation { (o, odb) =>
+        addInstrument(Instrument.GmosSouth, o, odb)
+        InstrumentService.lookupInstrument(o)
+        SPObsCache.getObsCache(o).getInstrument shouldEqual Instrument.GmosSouth.some
+      }
+    }
+
+    def updateTest(mod: (ISPObservation, IDBDatabaseService) => Unit): MatchResult[Any] =
+      withTestObservation { (o, odb) =>
+        addInstrument(Instrument.GmosSouth, o, odb)
+        InstrumentService.lookupInstrument(o)
+
+        val i0 = SPObsCache.getObsCache(o).getInstrument
+
+        mod(o, odb)
+
+        val i1 = SPObsCache.getObsCache(o).getInstrument
+        val i2 = InstrumentService.lookupInstrument(o)
+        val i3 = SPObsCache.getObsCache(o).getInstrument
+
+        (i0 shouldEqual Instrument.GmosSouth.some)   and
+          (i1 shouldEqual Instrument.none)           and
+          (i2 shouldEqual Instrument.GmosSouth.some) and
+          (i3 shouldEqual Instrument.GmosSouth.some)
+      }
+
+    "be reset if an observation property changes" in {
+      updateTest { (o, odb) =>
+        val d = o.getDataObject
+        d.setTitle("Foo")
+        o.setDataObject(d)
+      }
+    }
+
+    "be reset if a child observation component property changes" in {
+      updateTest { (o, odb) =>
+        val oc = o.getObsComponents.asScala.head
+        val d  = oc.getDataObject
+        d.setTitle("Foo")
+        oc.setDataObject(d)
+      }
+    }
+
+    "be reset if the observation structure changes" in {
+      updateTest { (o, odb) =>
+        val sc = odb.getFactory.createSeqComponent(o.getProgram, SPComponentType.OBSERVER_OBSERVE, null)
+        o.getSeqComponent.addSeqComponent(sc)
+      }
+    }
+  }
+
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obsrecord/TimeAccountingSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obsrecord/TimeAccountingSpec.scala
@@ -1,5 +1,6 @@
 package edu.gemini.spModel.obsrecord
 
+import edu.gemini.pot.sp.Instrument
 import edu.gemini.pot.sp.SPObservationID
 import edu.gemini.skycalc.{ Interval, ObservingNight, TwilightBoundType, Union }
 import edu.gemini.spModel.config2.Config
@@ -60,14 +61,15 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
   def genEvent(at: Long): Gen[ObsExecEvent] =
     Gen.oneOf(eventConstructors).map(c => c(at))
 
-  case class Test(
-    events: VisitEvents,
-    qa:     Map[DatasetLabel, DatasetQaState],
-    oc:     Map[DatasetLabel, ObsClass]
+  final case class Test(
+    instrument: Option[Instrument],
+    events:     VisitEvents,
+    qa:         Map[DatasetLabel, DatasetQaState],
+    oc:         Map[DatasetLabel, ObsClass]
   ) {
 
     def visitTimes: VisitTimes =
-      TimeAccounting.calc(events.sorted, qa, oc)
+      TimeAccounting.calc(instrument, events.sorted, qa, oc)
 
     def show: String = {
       def format(evt: ObsExecEvent): String = {
@@ -93,6 +95,7 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
     val timeGen = Gen.choose(start.toEpochMilli, end.toEpochMilli)
 
     for {
+      inst   <- Gen.option(Gen.oneOf(Instrument.values.toList))
       dstart <- Gen.choose(0, 100)
       dcount <- Gen.choose(0,  50)
       qas    <- Gen.listOfN(dcount, arbitrary[DatasetQaState])
@@ -110,13 +113,15 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
       val qaMap = labs.zip(qas).toMap
       val ocMap = labs.zip(ocs).toMap
 
-      Test(VisitEvents((es ::: des).toVector), qaMap, ocMap)
+      Test(inst, VisitEvents((es ::: des).toVector), qaMap, ocMap)
     }
 
   }
 
+  val GmosSouth     = Some(Instrument.GmosSouth)
   val Semester2019A = new Semester(2019, Semester.Half.A)
   val GS19AStart    = Instant.ofEpochMilli(Semester2019A.getStartDate(GS).getTime)
+  val GS19AUpdate1  = VisitCalculator.Update2019A1.validAt(GS)
   val GS19AEnd      = Instant.ofEpochMilli(Semester2019A.getEndDate(GS).getTime)
   val DayInMs       = Duration.ofDays(1l).toMillis
 
@@ -157,20 +162,66 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
         // Union of the dataset intervals.
         val u = new Union(t.events.datasetIntervals.unzip._2.asJava)
 
+        // All events.
+        val es: Vector[ObsExecEvent] = t.events.sorted
+
         // Use a calc assuming all datasets are PASS (because if they are all
-        // FAIL or USABLE nothing is charged).
-        val v = TimeAccounting.calc(t.events.sorted, const(PASS), t.oc)
+        // FAIL or USABLE nothing is charged in some cases).
+        val v = TimeAccounting.calc(t.instrument, es, const(PASS), t.oc)
+
+        val pre2019A1 = es.headOption.exists(e => Instant.ofEpochMilli(e.getTimestamp).isBefore(GS19AUpdate1))
+        val isVisitor = t.instrument.forall(_ == Instrument.Visitor)
 
         // If there were no datasets, then we don't charge at all.
-        if (u.sum === 0) v.getTotalTime shouldEqual v.getClassifiedTime(NONCHARGED)
-        else v.getUnclassifiedTime shouldEqual (t.events.chargeable - u).sum
+        if ((u.sum === 0) && (pre2019A1 || !isVisitor))
+          v.getTotalTime shouldEqual v.getClassifiedTime(NONCHARGED)
+        else
+          v.getUnclassifiedTime shouldEqual (t.events.chargeable - u).sum
       }
     }
 
-    "not charge if there are no passing datasets" in {
-      forAll(genTest(GS19AStart, GS19AEnd)) { (t: Test) =>
+    "not charge, even for visitor instruments, if there are no passing datasets until 19A update 1" in {
+      forAll(genTest(GS19AStart, GS19AUpdate1)) { (t: Test) =>
         t.qa.values.exists(_.isChargeable) ||
           (t.visitTimes === VisitTimes.noncharged(t.events.total.sum))
+      }
+    }
+
+    "not charge for non-visitor instruments if there are no passing datasets after 19A update 1" in {
+      forAll(genTest(GS19AUpdate1, GS19AEnd)) { (t: Test) =>
+        val tʹ = t.copy(instrument = GmosSouth)
+        tʹ.qa.values.exists(_.isChargeable) ||
+          (tʹ.visitTimes === VisitTimes.noncharged(tʹ.events.total.sum))
+      }
+    }
+
+    "charge even if there are no passing datasets for visitor instruments after 19A update 1" in {
+      forAll(genTest(GS19AUpdate1, GS19AEnd)) { (t: Test) =>
+
+        // Modify the test to use a visitor instrument and make all the
+        // datasets be failed.  This should still be charged according to the
+        // time accounting rule update in REL-3625.
+        val tʹ = t.copy(instrument = Some(Instrument.Visitor),
+                        qa         = t.qa.mapValues(_ => DatasetQaState.FAIL)
+                       )
+
+        // Of course, we only charge in this case for the time outside of the
+        // failed datasets so if there is no time outside of datasets then there
+        // is no charge here anyway.
+
+        // All potentially chargeable time (i.e., dark time that isn't
+        // overlapped by another observation).
+        val chargeable: Union[Interval] = tʹ.events.chargeable
+
+        // All potentially chargeable time that corresponds to datasets
+        val datasetChargeable: Union[Interval] =
+          new Union(tʹ.events.datasetIntervals.map(_._2).asJava) ∩ chargeable
+
+        // Either:
+        (tʹ.visitTimes.getChargedTime > 0) ||       // there is some charge
+          (chargeable.sum == 0)            ||       // there is no chargeable time anyway
+          (datasetChargeable.sum == chargeable.sum) // all the chargeable time was for failed datasets
+
       }
     }
 
@@ -189,7 +240,7 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
           // Bump the start of the interval so that the start time itself isn't
           // included.
           val i = VisitEvents(v.map(_._2)).intervalOption.get
-          i.minus(new Interval(i.getStart, i.getStart + 1))
+          if (i.getLength > 0) new Interval(i.getStart + 1, i.getEnd) else i
         }
         val union = t.events.total - new Union(intervals.asJavaCollection)
 
@@ -209,11 +260,11 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
 
         // If the new algorithm won't charge at all we can't really compare so
         // just assign noncharged to vtOld.
-        val vtOld = if (charge) VisitCalculator.Primordial.calc(events, t.qa, t.oc)
+        val vtOld = if (charge) VisitCalculator.Primordial.calc(t.instrument, events, t.qa, t.oc)
                     else VisitTimes.noncharged(events.total.sum)
 
         // Now the two methods should produce the same results.
-        val vtNew = VisitCalculator.Update2019A.calc(events, t.qa, t.oc)
+        val vtNew = VisitCalculator.Update2019A0.calc(t.instrument, events, t.qa, t.oc)
 
         vtNew shouldEqual vtOld
       }
@@ -228,7 +279,7 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
       val endEvent   = new EndDatasetEvent(startTime + 1000, label)
       val events     = Vector(startEvent, endEvent)
 
-      val actual = TimeAccounting.calc(events, const(PASS), const(SCIENCE))
+      val actual = TimeAccounting.calc(GmosSouth, events, const(PASS), const(SCIENCE))
 
       val expected = new VisitTimes()
       expected.addClassifiedTime(PROGRAM, 1000)
@@ -246,7 +297,7 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
       val endEvent     = new EndDatasetEvent(startTime + 2000, label)
       val events       = Vector(startEvent, overlapEvent, endEvent)
 
-      val actual = TimeAccounting.calc(events, const(PASS), const(SCIENCE))
+      val actual = TimeAccounting.calc(GmosSouth, events, const(PASS), const(SCIENCE))
 
       val expected = new VisitTimes()
       expected.addClassifiedTime(PROGRAM,    1000)

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
@@ -1,14 +1,17 @@
 package edu.gemini.spdb.reports.collection.table;
 
 
+import edu.gemini.pot.sp.Instrument;
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.ISPProgram;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.TimeValue;
 import edu.gemini.skycalc.ObservingNight;
 import edu.gemini.spModel.core.ProgramType;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
+import edu.gemini.spModel.obs.InstrumentService;
 import edu.gemini.spModel.obslog.ObsLog;
 import edu.gemini.spModel.obsrecord.ObsVisit;
 import edu.gemini.spModel.timeacct.TimeAcctAllocation;
@@ -152,9 +155,10 @@ public final class QueueProgramStatusExternalTable extends AbstractTable {
 		final SortedSet<String> set = new TreeSet<>();
 		final Site site = ReportUtils.getSiteDesc(progShell.getProgramID());
 		for (ISPObservation obs: progShell.getAllObservations()) {
+            final Option<Instrument> inst = InstrumentService.lookupInstrument(obs);
             final ObsLog log = ObsLog.getIfExists(obs);
 			if (log != null) {
-				for (ObsVisit visit: log.getVisits()) {
+				for (ObsVisit visit: log.getVisits(inst)) {
 					final String utc = new ObservingNight(site, visit.getStartTime()).getNightString();
 					set.add(utc);
 				}

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
@@ -5,15 +5,18 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.logging.Logger;
 
+import edu.gemini.pot.sp.Instrument;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.ISPProgram;
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.skycalc.ObservingNight;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.obsclass.ObsClass;
+import edu.gemini.spModel.obs.InstrumentService;
 import edu.gemini.spModel.obs.ObsClassService;
 import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obslog.ObsLog;
@@ -141,12 +144,11 @@ public class TimeAccountingSummaryTable extends AbstractTable {
             // Find the charge class for this observation.
             final ChargeClass defaultChargeClass = obsClass.getDefaultChargeClass();
 
-            // Find the instrument. If there is none, I'm not sure what this
-            // means. But we will keep going since it doesn't really matter.
-            final ISPObsComponent instrument = SPTreeUtil.findInstrument(obsShell);
+            // Find the instrument, if any.
+            final Option<Instrument> inst = InstrumentService.lookupInstrument(obsShell);
 
             // Collect visits and instruments per night.
-            for (final ObsVisit visit : log.getVisits()) {
+            for (final ObsVisit visit : log.getVisits(inst)) {
 
                 // Determine night and initialize map entries if needed.
                 final ObservingNight night = new ObservingNight(site, visit.getEndTime());
@@ -155,7 +157,7 @@ public class TimeAccountingSummaryTable extends AbstractTable {
 
                 // Collect information for this visit.
                 visits.add(visit);
-                if (instrument != null) instruments.add(instrument.getType());
+                inst.foreach(i -> instruments.add(i.componentType));
 
             }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/EdCompObslog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/EdCompObslog.java
@@ -1,7 +1,10 @@
 package jsky.app.ot.gemini.obslog;
 
 import edu.gemini.pot.sp.*;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.dataset.DatasetLabel;
+import edu.gemini.spModel.obs.InstrumentService;
 import edu.gemini.spModel.obslog.ObsExecLog;
 import edu.gemini.spModel.obslog.ObsLog;
 import edu.gemini.spModel.obslog.ObsQaLog;
@@ -31,7 +34,9 @@ public class EdCompObslog extends OtItemEditor<ISPObsQaLog, ObsQaLog> {
         if (SPUtil.getDataObjectPropertyName().equals(evt.getPropertyName())) {
             SwingUtilities.invokeLater(() -> {
                 final ISPObsExecLog execLogShell = (ISPObsExecLog) evt.getSource();
-                gui.setup(new ObsLog(getNode(), getDataObject(), execLogShell, (ObsExecLog) evt.getNewValue()));
+                final Option<Instrument> inst    = ImOption.apply(execLogShell.getContextObservation())
+                                                           .flatMap(o -> InstrumentService.lookupInstrument(o));
+                gui.setup(inst, new ObsLog(getNode(), getDataObject(), execLogShell, (ObsExecLog) evt.getNewValue()));
             });
         }
     };
@@ -104,7 +109,9 @@ public class EdCompObslog extends OtItemEditor<ISPObsQaLog, ObsQaLog> {
             currentLog       = incomingLog;
             currentLog.addDatasetQaRecordListener(listener);
             originalComments = incomingBaseline;
-            gui.setup(new ObsLog(getNode(), incomingLog, oel, execLog));
+
+            final Option<Instrument> inst = InstrumentService.lookupInstrument(obs);
+            gui.setup(inst, new ObsLog(getNode(), incomingLog, oel, execLog));
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
@@ -1,7 +1,10 @@
 package jsky.app.ot.gemini.obslog;
 
+import edu.gemini.pot.sp.Instrument;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.dataset.*;
 import edu.gemini.spModel.event.ObsExecEvent;
+import edu.gemini.spModel.obs.InstrumentService;
 import edu.gemini.spModel.obslog.ObsLog;
 import edu.gemini.spModel.obsrecord.ObsVisit;
 import edu.gemini.spModel.obsrecord.UniqueConfig;
@@ -95,10 +98,10 @@ class ObslogGUI extends JPanel {
     /**
      * Sets the data object, replacing or updating the content as appropriate.
      */
-    void setup(ObsLog obsLog) {
+    void setup(Option<Instrument> inst, ObsLog obsLog) {
         // And tell the tabs that the world has changed.
         tabDataAnalysis.setObsLog(obsLog);
-        tabVisits.setObsLog(obsLog);
+        tabVisits.setObsLog(inst, obsLog);
         tabComments.setObsLog(obsLog);
     }
 
@@ -706,14 +709,14 @@ class ObslogGUI extends JPanel {
             setName(name);
         }
 
-        void setObsLog(final ObsLog obsLog) {
+        void setObsLog(final Option<Instrument> inst, final ObsLog obsLog) {
             clientArea.removeAll();
-            addVisits(clientArea, obsLog);
+            addVisits(inst, clientArea, obsLog);
             revalidate();
         }
 
-        private void addVisits(Container parent, ObsLog obsLog) {
-            final ObsVisit[] visits = obsLog.getVisits();
+        private void addVisits(Option<Instrument> inst, Container parent, ObsLog obsLog) {
+            final ObsVisit[] visits = obsLog.getVisits(inst);
             for (final ObsVisit visit : visits) {
                 final String title;
                 final DatasetLabel[] labels = visit.getAllDatasetLabels();


### PR DESCRIPTION
Changes the time accounting rules to always charge for visitor instrument observations regardless of whether there are any chargeable datasets in a visit.  This change is to be retroactively applied to the start of 2019A (which is why the existing 2019A rule could be simply updated).

Time accounting has heretofore been instrument agnostic, so the bulk of this update is passing the instrument down through multiple layers of API to the `VisitCalculator` where it is needed.  Otherwise there is a new `InstrumentService` that calculates the `Instrument` associated with an `ISPObservation` (if any) and an update to the `SPObsCache` to cache the calculation. 