### PR TITLE
REL-3625: add serialVersionUID

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisit.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisit.java
@@ -28,6 +28,8 @@ import java.util.List;
  * a few methods for working with them.
  */
 final class PrivateVisit implements Serializable {
+    private static final long serialVersionUID = -7796307171519915226L;
+
     List<ObsExecEvent> _events = new ArrayList<ObsExecEvent>();
 
     PrivateVisit() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisitList.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisitList.java
@@ -21,6 +21,8 @@ import java.util.*;
  * ordering, etc.
  */
 final class PrivateVisitList implements Serializable {
+    private static final long serialVersionUID = -2686488059242714341L;
+    
     private List<PrivateVisit> _visits;
 
     PrivateVisitList() {


### PR DESCRIPTION
Adds `serialVersionUID` to a couple of classes to avoid spurious serialization incompatibilities. The `PrivateVisitList` and `PrivateVisit` API changes slightly but not the data itself.

I've confirmed that with these changes the current production version of programs containing observations with an observation log will open fine in either version of the ODB or OT.