### PR TITLE
REL-3632: Fix OT ITC interface which is double-counting coadds

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTable.scala
@@ -262,7 +262,7 @@ class ItcImagingTable(val parameters: ItcParametersProvider) extends ItcTable {
 
     } yield {
       val uniqueConfigs = ItcUniqueConfig.imagingConfigs(seq)
-      val inputs        = uniqueConfigs.map(uc => extractInputs(instrument, parameters.schedulingBlockStart, uc, frac => ImagingS2N(uc.count * uc.coadds.getOrElse(1), uc.coadds, uc.singleExposureTime, frac, 0.0)))
+      val inputs        = uniqueConfigs.map(uc => extractInputs(instrument, parameters.schedulingBlockStart, uc, frac => ImagingS2N(uc.count, uc.coadds, uc.singleExposureTime, frac, 0.0)))
       val results       = uniqueConfigs.zip(inputs).map { case (uc, i) => doServiceCall(peer, i) }
 
       instrument.getType match {
@@ -298,7 +298,7 @@ class ItcSpectroscopyTable(val parameters: ItcParametersProvider) extends ItcTab
 
     } yield {
       val uniqueConfigs = ItcUniqueConfig.spectroscopyConfigs(seq)
-      val inputs        = uniqueConfigs.map(uc => extractInputs(instrument, parameters.schedulingBlockStart, uc, frac => SpectroscopyS2N(uc.count * uc.coadds.getOrElse(1), uc.coadds, uc.singleExposureTime, frac, 0.0)))
+      val inputs        = uniqueConfigs.map(uc => extractInputs(instrument, parameters.schedulingBlockStart, uc, frac => SpectroscopyS2N(uc.count, uc.coadds, uc.singleExposureTime, frac, 0.0)))
       val results       = uniqueConfigs.zip(inputs).map { case (uc, i) => doServiceCall(peer, i) }
 
       instrument.getType match {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcTableModel.scala
@@ -38,8 +38,8 @@ sealed trait ItcTableModel extends AbstractTableModel {
   val PeakPixelColumn     = Column("Peak\n(e-)",       (_, _, r) => maxPeakPixelFlux(r),          tooltip = ItcTableModel.PeakPixelETooltip)
   val PeakADUColumn       = Column("Peak\n(ADU)",      (_, _, r) => maxImgAdu(r),                 tooltip = ItcTableModel.PeakPixelAduTooltip)
   val PeakFullWellColumn  = Column("Peak\n(%FW)",      (_, _, r) => maxImgPercentWell(r),         tooltip = ItcTableModel.PeakPixelFWTooltip)
-  val SNSingleColumn      = Column("S/N Single Coadd", (_, _, r) => maxSingleSNRatio(r),            tooltip = "Signal / Noise for one exposure with one coadd")
-  val SNTotalColumn       = Column("S/N Total",        (_, _, r) => maxTotalSNRatio(r),            tooltip = "Total Signal / Noise for all exposures and coadds")
+  val SNSingleColumn      = Column("S/N Single",       (_, _, r) => maxSingleSNRatio(r),          tooltip = "Signal / Noise for one exposure")
+  val SNTotalColumn       = Column("S/N Total",        (_, _, r) => maxTotalSNRatio(r),           tooltip = "Total Signal / Noise for all exposures")
 
   // Define different sets of columns as headers
   val PeakColumns       = List(PeakPixelColumn, PeakADUColumn, PeakFullWellColumn)


### PR DESCRIPTION
Send the correct number of exposures (without coadds since they are now separate).