### PR TITLE
REL-3636: AcqCam, Phoenix and Texes exceptions

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
@@ -126,7 +126,7 @@ private[obsrecord] object VisitCalculator {
       }
 
       def isVisitor: Boolean =
-        instrument.exists(_ == Instrument.Visitor)
+        instrument.exists(_.isVisitor)
 
       def hasChargeableDataset: Boolean =
         dsets.exists { case (lab, _) => qa(lab).isChargeable }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/syntax/package.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/syntax/package.scala
@@ -2,10 +2,11 @@ package edu.gemini.spModel
 
 import edu.gemini.spModel.syntax.event.ToObsExecEventOps
 import edu.gemini.spModel.syntax.skycalc.{ToObservingNightOps, ToUnionOps}
-import edu.gemini.spModel.syntax.sp.ToNodeOps
+import edu.gemini.spModel.syntax.sp.{ToInstrumentOps, ToNodeOps}
 
 package object syntax {
-  object all extends ToNodeOps
+  object all extends ToInstrumentOps
+                with ToNodeOps
                 with ToObsExecEventOps
                 with ToObservingNightOps
                 with ToUnionOps

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/syntax/sp/Instrument.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/syntax/sp/Instrument.scala
@@ -1,0 +1,35 @@
+package edu.gemini.spModel.syntax.sp
+
+import edu.gemini.pot.sp.Instrument
+import edu.gemini.pot.sp.Instrument._
+
+// NB: it would make sense to add this to the Instrument enum itself, but that
+// would break serialization.
+
+final class InstrumentOps(val self: Instrument) extends AnyVal {
+
+  /**
+   * Is this a "visitor" instrument.  In other words, is it fully integrated
+   * with the observing system and DHS?
+   */
+  def isVisitor: Boolean =
+    self match {
+      case AcquisitionCamera | Phoenix | Texes | Visitor => true
+      case _                                             => false
+    }
+
+  /**
+   * Is this is a facility instrument that is fully integerated with the
+   * observing system and DHS?
+   */
+  def isFacility: Boolean =
+    !isVisitor
+
+}
+
+trait ToInstrumentOps {
+  implicit def ToInstrumentOps(i: Instrument): InstrumentOps =
+    new InstrumentOps(i)
+}
+
+object instrument extends ToInstrumentOps

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obsrecord/TimeAccountingSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/obsrecord/TimeAccountingSpec.scala
@@ -165,7 +165,7 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
         // FAIL or USABLE nothing is charged in some cases).
         val v = TimeAccounting.calc(t.instrument, t.events.sorted, const(PASS), t.oc)
 
-        val isVisitor = t.instrument.exists(_ == Instrument.Visitor)
+        val isVisitor = t.instrument.exists(_.isVisitor)
 
         // If there were no datasets, then we don't charge at all.
         if ((u.sum === 0) && !isVisitor)
@@ -178,7 +178,7 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
     "not charge (except for visitor instruments), if there are no passing datasets" in {
       forAll(genTest(GS19AStart, GS19AEnd)) { (t: Test) =>
         t.qa.values.exists(_.isChargeable) ||
-          t.instrument.exists(_ == Instrument.Visitor) ||
+          t.instrument.exists(_.isVisitor) ||
           (t.visitTimes === VisitTimes.noncharged(t.events.total.sum))
       }
     }
@@ -242,7 +242,7 @@ object TimeAccountingSpec extends Specification with ScalaCheck {
         // Of the remaining datasets, we need at least one to be PASS (or
         // undefined or check) because the new algorithm explicitly doesn't
         // charge if they are all failing.
-        val charge = t.instrument.exists(_ == Instrument.Visitor) ||
+        val charge = t.instrument.exists(_.isVisitor) ||
           events.datasetIntervals.exists { case (lab, _) => t.qa(lab).isChargeable }
 
         // If the new algorithm won't charge at all we can't really compare so


### PR DESCRIPTION
Adds Acquisition Camera, Phoenix and Texes to the list of instruments which should be an exception to the new Time Accounting rule of REL-1608.