### PR TITLE
REL-3628: time accounting update for GPI acquisitions

### DIFF
--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObsRecordDatasetFactory.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObsRecordDatasetFactory.java
@@ -82,7 +82,7 @@ public final class ObsRecordDatasetFactory implements Serializable {
 
         List<EObslogVisit> eObslogVisits = new ArrayList<EObslogVisit>();
 
-        for (ObsVisit visit : obsLog.getVisits(Instrument.fromComponentType(type))) {
+        for (ObsVisit visit : obsLog.getVisits(Instrument.fromComponentType(type), obsClass)) {
             if (visit.getAllDatasetLabels().length == 0) {
                 LOG.fine("Skipping  empty visit");
                 continue;

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObservationObsVisitTimeFactory.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObservationObsVisitTimeFactory.java
@@ -91,10 +91,10 @@ public final class ObservationObsVisitTimeFactory implements Serializable {
         final Option<Instrument> inst = Instrument.fromComponentType(type);
         ObsVisit[] visits;
         if (options.getLimitConfigDatesByNight() == null) {
-            visits = obsLog.getVisits(inst);
+            visits = obsLog.getVisits(inst, obsClass);
         } else {
             ObservingNight night = options.getLimitConfigDatesByNight();
-            visits = obsLog.getVisits(inst, night.getStartTime(), night.getEndTime());
+            visits = obsLog.getVisits(inst, obsClass, night.getStartTime(), night.getEndTime());
         }
 
         for (ObsVisit visit : visits) {

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObservationObsVisitsFactory.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/transfer/ObservationObsVisitsFactory.java
@@ -95,10 +95,10 @@ public final class ObservationObsVisitsFactory implements Serializable {
 
         ObsVisit[] visits;
         if (options.getLimitConfigDatesByNight() == null) {
-            visits = obsLog.getVisits(inst);
+            visits = obsLog.getVisits(inst, obsClass);
         } else {
             ObservingNight night = options.getLimitConfigDatesByNight();
-            visits = obsLog.getVisits(inst, night.getStartTime(), night.getEndTime());
+            visits = obsLog.getVisits(inst, obsClass, night.getStartTime(), night.getEndTime());
         }
 
         for (ObsVisit visit : visits)  {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/NightObsTimesService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/NightObsTimesService.java
@@ -52,7 +52,7 @@ public class NightObsTimesService {
         final Option<Instrument> inst = InstrumentService.lookupInstrument(obs);
 
         // Get the visits for the obs, if any.
-        ObsVisit[] visits = nodes.getExecRecord().getVisits(inst, nodes.getQaRecord());
+        ObsVisit[] visits = nodes.getExecRecord().getVisits(inst, obsClass, nodes.getQaRecord());
         if ((visits == null) || (visits.length == 0)) return res;
 
         // Start with the first visit, and figure out the ObservingNight and

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsTimesService.java
@@ -44,7 +44,7 @@ public final class ObsTimesService {
             final Option<Instrument> inst = InstrumentService.lookupInstrument(obs);
 
             final ObsClass obsClass = ObsClassService.lookupObsClass(obs);
-            res = nodes.getExecRecord().getTimes(inst, nodes.getQaRecord(), obsClass.getDefaultChargeClass());
+            res = nodes.getExecRecord().getTimes(inst, obsClass, nodes.getQaRecord(), obsClass.getDefaultChargeClass());
         }
 
         // Cache and return the results.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obslog/ObsLog.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obslog/ObsLog.java
@@ -4,6 +4,7 @@ import edu.gemini.pot.sp.*;
 import edu.gemini.pot.spdb.IDBDatabaseService;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.dataset.*;
+import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obsrecord.ObsQaRecord;
 import edu.gemini.spModel.obsrecord.ObsExecRecord;
 import edu.gemini.spModel.obsrecord.ObsVisit;
@@ -134,12 +135,12 @@ public final class ObsLog {
         return execLogDataObject.getRecord();
     }
 
-    public ObsVisit[] getVisits(Option<Instrument> instrument) {
-        return getExecRecord().getVisits(instrument, getQaRecord());
+    public ObsVisit[] getVisits(Option<Instrument> instrument, ObsClass obsClass) {
+        return getExecRecord().getVisits(instrument, obsClass, getQaRecord());
     }
 
-    public ObsVisit[] getVisits(Option<Instrument> instrument, long startTime, long endTime) {
-        return getExecRecord().getVisits(instrument, getQaRecord(), startTime, endTime);
+    public ObsVisit[] getVisits(Option<Instrument> instrument, ObsClass obsClass, long startTime, long endTime) {
+        return getExecRecord().getVisits(instrument, obsClass, getQaRecord(), startTime, endTime);
     }
 
     public scala.Option<DataflowStatus> getMinimumDisposition() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/ObsExecRecord.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/ObsExecRecord.java
@@ -350,8 +350,8 @@ public final class ObsExecRecord implements Serializable {
      * @return array of ObsVisit corresponding to the visits that this
      * observation has seen
      */
-    public synchronized ObsVisit[] getVisits(Option<Instrument> instrument, ObsQaRecord qa) {
-        return _visits.getObsVisits(instrument, qa, _configStore);
+    public synchronized ObsVisit[] getVisits(Option<Instrument> instrument, ObsClass oc, ObsQaRecord qa) {
+        return _visits.getObsVisits(instrument, oc, qa, _configStore);
     }
 
     /**
@@ -364,8 +364,8 @@ public final class ObsExecRecord implements Serializable {
      * @return {@link ObsVisit}s whose start time falls between
      * <code>startTime</code> (inclusive) and <code>endTime</code> exclusive
      */
-    public synchronized ObsVisit[] getVisits(Option<Instrument> instrument, ObsQaRecord qa, long startTime, long endTime) {
-        return _visits.getObsVisits(instrument, qa, _configStore, startTime, endTime);
+    public synchronized ObsVisit[] getVisits(Option<Instrument> instrument, ObsClass oc, ObsQaRecord qa, long startTime, long endTime) {
+        return _visits.getObsVisits(instrument, oc, qa, _configStore, startTime, endTime);
     }
 
     /**
@@ -402,10 +402,11 @@ public final class ObsExecRecord implements Serializable {
      */
     public ObsTimeCharges getTimeCharges(
         Option<Instrument> instrument,
+        ObsClass           oc,
         ObsQaRecord        qa,
         ChargeClass        mainChargeClass
     ) {
-        return _visits.getTimeCharges(instrument, mainChargeClass, qa, _configStore);
+        return _visits.getTimeCharges(instrument, oc, mainChargeClass, qa, _configStore);
     }
 
     /**
@@ -420,10 +421,11 @@ public final class ObsExecRecord implements Serializable {
      */
     public ObsTimes getTimes(
         Option<Instrument> instrument,
+        ObsClass           oc,
         ObsQaRecord        qa,
         ChargeClass        mainChargeClass
     ) {
-        return new ObsTimes(getTotalTime(), getTimeCharges(instrument, qa, mainChargeClass));
+        return new ObsTimes(getTotalTime(), getTimeCharges(instrument, oc, qa, mainChargeClass));
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisit.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisit.java
@@ -92,11 +92,16 @@ final class PrivateVisit implements Serializable {
         return null;
     }
 
-    VisitTimes getTimeCharges(Option<Instrument> instrument, ObsQaRecord qa, ConfigStore store) {
-        return TimeAccounting.calcAsJava(instrument, _events, qa, store);
+    VisitTimes getTimeCharges(
+        Option<Instrument> instrument,
+        ObsClass           oc,
+        ObsQaRecord        qa,
+        ConfigStore        store
+    ) {
+        return TimeAccounting.calcAsJava(instrument, oc, _events, qa, store);
     }
 
-    ObsVisit toObsVisit(Option<Instrument> instrument, ObsQaRecord qa, ConfigStore store) {
+    ObsVisit toObsVisit(Option<Instrument> instrument, ObsClass oc, ObsQaRecord qa, ConfigStore store) {
         List<UniqueConfig> uniqueConfigs = new ArrayList<UniqueConfig>();
 
         Config lastConfig = null;
@@ -156,7 +161,7 @@ final class PrivateVisit implements Serializable {
         UniqueConfig[] uconfigs;
         uconfigs = uniqueConfigs.toArray(UniqueConfig.EMPTY_ARRAY);
 
-        return new ObsVisit(getEvents(), uconfigs, getTimeCharges(instrument, qa, store));
+        return new ObsVisit(getEvents(), uconfigs, getTimeCharges(instrument, oc, qa, store));
     }
 
     // Implement as done in 2013B June release.  StartSequence is the only

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisitList.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisitList.java
@@ -10,6 +10,7 @@ import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.event.ExecEvent;
 import edu.gemini.spModel.event.ObsExecEvent;
 import edu.gemini.spModel.event.StartVisitEvent;
+import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.time.ChargeClass;
 import edu.gemini.spModel.time.ObsTimeCharges;
 
@@ -22,7 +23,7 @@ import java.util.*;
  */
 final class PrivateVisitList implements Serializable {
     private static final long serialVersionUID = -2686488059242714341L;
-    
+
     private List<PrivateVisit> _visits;
 
     PrivateVisitList() {
@@ -114,6 +115,7 @@ final class PrivateVisitList implements Serializable {
 
     ObsTimeCharges getTimeCharges(
         Option<Instrument> instrument,
+        ObsClass           oc,
         ChargeClass        mainChargeClass,
         ObsQaRecord        qa,
         ConfigStore        store
@@ -121,21 +123,21 @@ final class PrivateVisitList implements Serializable {
 
         VisitTimes vt = new VisitTimes();
         for (PrivateVisit pv : _visits) {
-            vt.addVisitTimes(pv.getTimeCharges(instrument, qa, store));
+            vt.addVisitTimes(pv.getTimeCharges(instrument, oc, qa, store));
         }
 
         return vt.getTimeCharges(mainChargeClass);
     }
 
-    ObsVisit[] getObsVisits(Option<Instrument> instrument, ObsQaRecord qa, ConfigStore store) {
+    ObsVisit[] getObsVisits(Option<Instrument> instrument, ObsClass oc, ObsQaRecord qa, ConfigStore store) {
         List<ObsVisit> obsVisitList = new ArrayList<ObsVisit>();
         for (PrivateVisit pv : _visits) {
-            obsVisitList.add(pv.toObsVisit(instrument, qa, store));
+            obsVisitList.add(pv.toObsVisit(instrument, oc, qa, store));
         }
         return obsVisitList.toArray(ObsVisit.EMPTY_ARRAY);
     }
 
-    ObsVisit[] getObsVisits(Option<Instrument> instrument, ObsQaRecord qa, ConfigStore store, long startTime, long endTime) {
+    ObsVisit[] getObsVisits(Option<Instrument> instrument, ObsClass oc, ObsQaRecord qa, ConfigStore store, long startTime, long endTime) {
         List<ObsVisit> obsVisitList = null;
         for (PrivateVisit pv : _visits) {
             ObsExecEvent evt = pv.getFirstEvent();
@@ -144,7 +146,7 @@ final class PrivateVisitList implements Serializable {
             long visitStart = evt.getTimestamp();
             if ((startTime <= visitStart) && (visitStart < endTime)) {
                 if (obsVisitList == null) obsVisitList = new ArrayList<ObsVisit>();
-                obsVisitList.add(pv.toObsVisit(instrument, qa, store));
+                obsVisitList.add(pv.toObsVisit(instrument, oc, qa, store));
             }
         }
         if (obsVisitList == null) return ObsVisit.EMPTY_ARRAY;

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/ObsVisitService.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/ObsVisitService.scala
@@ -3,7 +3,7 @@ package edu.gemini.spModel.obsrecord
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.gemini.plan.NightlyRecord
-import edu.gemini.spModel.obs.InstrumentService
+import edu.gemini.spModel.obs.{ InstrumentService, ObsClassService }
 import edu.gemini.spModel.obslog.ObsLog
 
 import scala.collection.JavaConverters._
@@ -20,9 +20,10 @@ object ObsVisitService {
     oidSet.toList.flatMap { oid =>
       (for {
         obs <- Option(db.lookupObservationByID(oid))
+        oc   = ObsClassService.lookupObsClass(obs)
         log <- Option(ObsLog.getIfExists(obs))
         inst = InstrumentService.lookupInstrument(obs)
-      } yield log.getVisits(inst, night.getStartTime, night.getEndTime).toList).getOrElse(Nil)
+      } yield log.getVisits(inst, oc, night.getStartTime, night.getEndTime).toList).getOrElse(Nil)
     }.sorted(comparatorToOrdering(ObsVisit.START_TIME_COMPARATOR))
   }
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/TimeAccounting.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/TimeAccounting.scala
@@ -20,9 +20,10 @@ object TimeAccounting {
    */
   def calc(
     instrument: Option[Instrument],
+    obsClass:   ObsClass,
     events:     Vector[ObsExecEvent],
-    qa:         DatasetLabel => DatasetQaState,
-    oc:         DatasetLabel => ObsClass
+    datasetQa:  DatasetLabel => DatasetQaState,
+    datasetOc:  DatasetLabel => ObsClass
   ): VisitTimes = {
 
     val ve = VisitEvents(events)
@@ -37,7 +38,7 @@ object TimeAccounting {
       c <- VisitCalculator.all.find(_.validAt(s).isBefore(h.instant))
     } yield c
 
-    calculator.fold(new VisitTimes()) { _.calc(instrument, ve, qa, oc) }
+    calculator.fold(new VisitTimes()) { _.calc(instrument, obsClass, ve, datasetQa, datasetOc) }
   }
 
   /**
@@ -46,10 +47,11 @@ object TimeAccounting {
    */
   def calcAsJava(
     instrument: GOption[Instrument],
+    obsClass:   ObsClass,
     events:     java.util.List[ObsExecEvent],
     qa:         ObsQaRecord,
     store:      ConfigStore
   ): VisitTimes =
-    calc(instrument.asScalaOpt, events.asScala.toVector, qa.qaState, store.getObsClass)
+    calc(instrument.asScalaOpt, obsClass, events.asScala.toVector, qa.qaState, store.getObsClass)
 
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
@@ -137,7 +137,12 @@ private[obsrecord] object VisitCalculator {
       def hasChargeableDataset: Boolean =
         dsets.exists { case (lab, _) => datasetQa(lab).isChargeable }
 
-      if (isVisitor || hasChargeableDataset) normalCharges
+      // REL-3628: many GPI acquisitions don't produce datasets so charge for
+      //           them regardless
+      def isGpiAcquisition: Boolean =
+        instrument.exists(_ == Instrument.Gpi) && (obsClass == ObsClass.ACQ)
+
+      if (isVisitor || hasChargeableDataset || isGpiAcquisition) normalCharges
       else VisitTimes.noncharged(total.sum)
 
     }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/obsrecord/VisitCalculator.scala
@@ -39,9 +39,10 @@ private[obsrecord] sealed trait VisitCalculator {
    */
   def calc(
     instrument: Option[Instrument],
+    obsClass:   ObsClass,
     events:     VisitEvents,
-    qa:         DatasetLabel => DatasetQaState,
-    oc:         DatasetLabel => ObsClass
+    datasetQa:  DatasetLabel => DatasetQaState,
+    datasetOc:  DatasetLabel => ObsClass
   ): VisitTimes
 
 }
@@ -70,11 +71,15 @@ private[obsrecord] object VisitCalculator {
 
     override def calc(
       instrument: Option[Instrument], // ignored here
+      obsClass:   ObsClass,           // ignored here
       events:     VisitEvents,
-      qa:         DatasetLabel => DatasetQaState,
-      oc:         DatasetLabel => ObsClass
+      datasetQa:  DatasetLabel => DatasetQaState,
+      datasetOc:  DatasetLabel => ObsClass
     ): VisitTimes =
-      PrimordialVisitCalculator.instance.calc(events.sorted.toList.asJava, qa.asJava, oc.asJava)
+      PrimordialVisitCalculator.instance.calc(
+        events.sorted.toList.asJava,
+        datasetQa.asJava,
+        datasetOc.asJava)
 
   }
 
@@ -98,9 +103,10 @@ private[obsrecord] object VisitCalculator {
 
     override def calc(
       instrument: Option[Instrument],
+      obsClass:   ObsClass,
       events:     VisitEvents,
-      qa:         DatasetLabel => DatasetQaState,
-      oc:         DatasetLabel => ObsClass
+      datasetQa:  DatasetLabel => DatasetQaState,
+      datasetOc:  DatasetLabel => ObsClass
     ): VisitTimes = {
 
       val total = events.total
@@ -112,7 +118,7 @@ private[obsrecord] object VisitCalculator {
 
         val charge: ChargeClass => Union[Interval] =
           dsets.groupBy { case (label, interval) =>
-            if (qa(label).isChargeable) oc(label).getDefaultChargeClass else NONCHARGED
+            if (datasetQa(label).isChargeable) datasetOc(label).getDefaultChargeClass else NONCHARGED
           }.mapValues(v => new Union(v.map(_._2).asJava) ∩ chargeable)
            .withDefaultValue(new Union())
 
@@ -129,7 +135,7 @@ private[obsrecord] object VisitCalculator {
         instrument.exists(_.isVisitor)
 
       def hasChargeableDataset: Boolean =
-        dsets.exists { case (lab, _) => qa(lab).isChargeable }
+        dsets.exists { case (lab, _) => datasetQa(lab).isChargeable }
 
       if (isVisitor || hasChargeableDataset) normalCharges
       else VisitTimes.noncharged(total.sum)

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
@@ -12,6 +12,8 @@ import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.gemini.obscomp.SPProgram;
 import edu.gemini.spModel.obs.InstrumentService;
+import edu.gemini.spModel.obs.ObsClassService;
+import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obslog.ObsLog;
 import edu.gemini.spModel.obsrecord.ObsVisit;
 import edu.gemini.spModel.timeacct.TimeAcctAllocation;
@@ -156,9 +158,10 @@ public final class QueueProgramStatusExternalTable extends AbstractTable {
 		final Site site = ReportUtils.getSiteDesc(progShell.getProgramID());
 		for (ISPObservation obs: progShell.getAllObservations()) {
             final Option<Instrument> inst = InstrumentService.lookupInstrument(obs);
-            final ObsLog log = ObsLog.getIfExists(obs);
+            final ObsClass             oc = ObsClassService.lookupObsClass(obs);
+            final ObsLog              log = ObsLog.getIfExists(obs);
 			if (log != null) {
-				for (ObsVisit visit: log.getVisits(inst)) {
+				for (ObsVisit visit: log.getVisits(inst, oc)) {
 					final String utc = new ObservingNight(site, visit.getStartTime()).getNightString();
 					set.add(utc);
 				}

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
@@ -148,7 +148,7 @@ public class TimeAccountingSummaryTable extends AbstractTable {
             final Option<Instrument> inst = InstrumentService.lookupInstrument(obsShell);
 
             // Collect visits and instruments per night.
-            for (final ObsVisit visit : log.getVisits(inst)) {
+            for (final ObsVisit visit : log.getVisits(inst, obsClass)) {
 
                 // Determine night and initialize map entries if needed.
                 final ObservingNight night = new ObservingNight(site, visit.getEndTime());

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/EdCompObslog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/EdCompObslog.java
@@ -5,6 +5,8 @@ import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.dataset.DatasetLabel;
 import edu.gemini.spModel.obs.InstrumentService;
+import edu.gemini.spModel.obs.ObsClassService;
+import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obslog.ObsExecLog;
 import edu.gemini.spModel.obslog.ObsLog;
 import edu.gemini.spModel.obslog.ObsQaLog;
@@ -34,9 +36,10 @@ public class EdCompObslog extends OtItemEditor<ISPObsQaLog, ObsQaLog> {
         if (SPUtil.getDataObjectPropertyName().equals(evt.getPropertyName())) {
             SwingUtilities.invokeLater(() -> {
                 final ISPObsExecLog execLogShell = (ISPObsExecLog) evt.getSource();
-                final Option<Instrument> inst    = ImOption.apply(execLogShell.getContextObservation())
-                                                           .flatMap(o -> InstrumentService.lookupInstrument(o));
-                gui.setup(inst, new ObsLog(getNode(), getDataObject(), execLogShell, (ObsExecLog) evt.getNewValue()));
+                final Option<ISPObservation> obs = ImOption.apply(execLogShell.getContextObservation());
+                final Option<Instrument>    inst = obs.flatMap(o -> InstrumentService.lookupInstrument(o));
+                final ObsClass                oc = obs.map(o -> ObsClassService.lookupObsClass(o)).getOrElse(ObsClass.SCIENCE);
+                gui.setup(inst, oc, new ObsLog(getNode(), getDataObject(), execLogShell, (ObsExecLog) evt.getNewValue()));
             });
         }
     };
@@ -111,7 +114,8 @@ public class EdCompObslog extends OtItemEditor<ISPObsQaLog, ObsQaLog> {
             originalComments = incomingBaseline;
 
             final Option<Instrument> inst = InstrumentService.lookupInstrument(obs);
-            gui.setup(inst, new ObsLog(getNode(), incomingLog, oel, execLog));
+            final ObsClass             oc = ObsClassService.lookupObsClass(obs);
+            gui.setup(inst, oc, new ObsLog(getNode(), incomingLog, oel, execLog));
         }
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/obslog/ObslogGUI.java
@@ -5,6 +5,7 @@ import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.dataset.*;
 import edu.gemini.spModel.event.ObsExecEvent;
 import edu.gemini.spModel.obs.InstrumentService;
+import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obslog.ObsLog;
 import edu.gemini.spModel.obsrecord.ObsVisit;
 import edu.gemini.spModel.obsrecord.UniqueConfig;
@@ -98,10 +99,10 @@ class ObslogGUI extends JPanel {
     /**
      * Sets the data object, replacing or updating the content as appropriate.
      */
-    void setup(Option<Instrument> inst, ObsLog obsLog) {
+    void setup(Option<Instrument> inst, ObsClass oc, ObsLog obsLog) {
         // And tell the tabs that the world has changed.
         tabDataAnalysis.setObsLog(obsLog);
-        tabVisits.setObsLog(inst, obsLog);
+        tabVisits.setObsLog(inst, oc, obsLog);
         tabComments.setObsLog(obsLog);
     }
 
@@ -709,14 +710,14 @@ class ObslogGUI extends JPanel {
             setName(name);
         }
 
-        void setObsLog(final Option<Instrument> inst, final ObsLog obsLog) {
+        void setObsLog(final Option<Instrument> inst, final ObsClass oc, final ObsLog obsLog) {
             clientArea.removeAll();
-            addVisits(inst, clientArea, obsLog);
+            addVisits(inst, oc, clientArea, obsLog);
             revalidate();
         }
 
-        private void addVisits(Option<Instrument> inst, Container parent, ObsLog obsLog) {
-            final ObsVisit[] visits = obsLog.getVisits(inst);
+        private void addVisits(Option<Instrument> inst, ObsClass oc, Container parent, ObsLog obsLog) {
+            final ObsVisit[] visits = obsLog.getVisits(inst, oc);
             for (final ObsVisit visit : visits) {
                 final String title;
                 final DatasetLabel[] labels = visit.getAllDatasetLabels();


### PR DESCRIPTION
Updates the 2019A time accounting rule to always charge for GPI acquisitions, since they often do not produce datasets.  The bulk of the work was adding the observation `ObsClass` as a parameter since it is needed to make the determination.