### PR TITLE
REL-3520: GNIRS Observing Wavelength in SmartGcal

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -966,17 +966,6 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         final Config[] configs = in.getAllSteps();
 
         for (Config c : configs) {
-            // Override the observing wavelength for acquisition steps.  It must
-            // match the filter wavelength in this case (unless this is an old
-            // executed pre-2017A observation in which case we must continue to
-            // use the old method for calculating the observing wavelength).
-            final AcquisitionMirror am = (AcquisitionMirror) c.getItemValue(GNIRSConstants.ACQUISITION_MIRROR_KEY);
-            if (isOverrideAcqObsWavelength() && (am == AcquisitionMirror.IN)) {
-                final Option<Filter> f  = ImOption.apply((Filter) c.getItemValue(GNIRSConstants.FILTER_KEY));
-                final Option<Double> wl = f.flatMap(f0 -> ImOption.apply(f0.wavelength()));
-                // Sorry, yes observing wavelength stored as a String for GNRIS.
-                wl.foreach(d -> c.putItem(GNIRSConstants.OBSERVING_WAVELENGTH_KEY, String.format("%.2f", d)));
-            }
 
             if (isCalStep(c)) {
                 final Double expTime = calExposureTime(c);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/SeqConfigGNIRSCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/SeqConfigGNIRSCB.java
@@ -2,13 +2,25 @@ package edu.gemini.spModel.gemini.gnirs;
 
 import edu.gemini.pot.sp.ISPSeqComponent;
 
-import edu.gemini.spModel.obscomp.InstConstants;
-import edu.gemini.spModel.seqcomp.SeqConfigNames;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
+
+import static edu.gemini.spModel.obscomp.InstConstants.INSTRUMENT_NAME_PROP;
+import static edu.gemini.spModel.obscomp.InstConstants.OBSERVING_WAVELENGTH_PROP;
+import static edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_CONFIG_NAME;
 import edu.gemini.spModel.config.HelperSeqCompCB;
-import edu.gemini.spModel.data.config.StringParameter;
 import edu.gemini.spModel.data.config.IConfig;
 import edu.gemini.spModel.data.config.IParameter;
 import edu.gemini.spModel.data.config.ISysConfig;
+import edu.gemini.spModel.data.config.StringParameter;
+import static edu.gemini.spModel.gemini.gnirs.GNIRSConstants.ACQUISITION_MIRROR_PROP;
+import static edu.gemini.spModel.gemini.gnirs.GNIRSConstants.CENTRAL_WAVELENGTH_PROP;
+import static edu.gemini.spModel.gemini.gnirs.GNIRSConstants.FILTER_PROP;
+import edu.gemini.spModel.gemini.gnirs.GNIRSParams.AcquisitionMirror;
+import edu.gemini.spModel.gemini.gnirs.GNIRSParams.Filter;
+import edu.gemini.spModel.util.SPTreeUtil;
+
+import java.util.Map;
 
 /**
  * A configuration builder for the GNIRS iterator.
@@ -22,6 +34,101 @@ public final class SeqConfigGNIRSCB extends HelperSeqCompCB {
         super(seqComp);
     }
 
+    private boolean overrideAcqObsWavelength = false;
+
+    @Override
+    protected void thisReset(Map<String, Object> options) {
+
+        // Pre 2017A programs are treated differently when it comes to
+        // calculating the observing wavelength.  The `overrideAcqObsWavelength`
+        // flag kept in the static component tells us which way to go so we
+        // record its value upon reset.
+        overrideAcqObsWavelength =
+            ImOption.apply(getSeqComponent())
+                    .flatMap(c -> ImOption.apply(c.getContextObservation()))
+                    .flatMap(o -> ImOption.apply(SPTreeUtil.findInstrument(o)))
+                    .flatMap(i -> ImOption.apply(i.getDataObject()))
+                    .filter(d -> d instanceof InstGNIRS)
+                    .map(d -> ((InstGNIRS) d).isOverrideAcqObsWavelength())
+                    .getOrElse(true);
+
+        super.thisReset(options);
+    }
+
+    private static Option<Object> getInstrumentParameterValue(String n, Option<IConfig> oc) {
+        return oc.flatMap(c -> ImOption.apply(c.getSysConfig(INSTRUMENT_CONFIG_NAME)))
+                 .flatMap(s -> ImOption.apply(s.getParameterValue(n)));
+    }
+
+    private static Option<Object> getInstrumentParameterValue(String n, Option<IConfig> oc, Option<IConfig> op) {
+        return getInstrumentParameterValue(n, oc)
+                 .orElse(() -> getInstrumentParameterValue(n, op));
+    }
+
+    private static Option<Object> getInstrumentParameterValue(String n, IConfig c, IConfig p) {
+        return getInstrumentParameterValue(n, ImOption.apply(c), ImOption.apply(p));
+    }
+
+    private static AcquisitionMirror getAcquisitionMirror(IConfig c, IConfig p) {
+        return getInstrumentParameterValue(ACQUISITION_MIRROR_PROP, c, p)
+                 .filter(o -> o instanceof AcquisitionMirror)
+                 .map(o -> (AcquisitionMirror) o)
+                 .getOrElse(AcquisitionMirror.OUT);
+    }
+
+    private static Option<Filter> getFilter(IConfig c, IConfig p) {
+        return getInstrumentParameterValue(FILTER_PROP, c, p)
+                 .filter(o -> o instanceof Filter)
+                 .map(o -> (Filter) o);
+    }
+
+    private static Option<String> getObservingWavelength(IConfig c, IConfig p) {
+        return getInstrumentParameterValue(OBSERVING_WAVELENGTH_PROP, c, p)
+                 .filter(o -> o instanceof String)
+                 .map(o -> (String) o);
+    }
+
+    private static Option<String> getCentralWavelength(IConfig c, IConfig p) {
+        return getInstrumentParameterValue(CENTRAL_WAVELENGTH_PROP, c, p)
+                 .filter(o -> o instanceof String)
+                 .map(o -> (String) o);
+    }
+
+    // Override the observing wavelength for acquisition steps.  It must
+    // match the filter wavelength in this case (unless this is an old
+    // executed pre-2017A observation in which case we must continue to
+    // use the old method for calculating the observing wavelength).
+
+    private void addObservingWavelength(IConfig c, IConfig p) {
+
+        // Get the filter wavelength if there is a filter and if this is an
+        // acquisition.
+        final Option<String> fLambda;
+        if (overrideAcqObsWavelength && getAcquisitionMirror(c, p) == AcquisitionMirror.IN) {
+            fLambda = getFilter(c, p)
+                        .flatMap(f -> ImOption.apply(f.wavelength()))
+                        .map(d -> String.format("%.2f", d));
+        } else {
+            fLambda = ImOption.<String>empty();
+        }
+
+        // The observing wavelength is the filter wavelength if defined at this
+        // point, or else the central wavelength.
+        final Option<String> obsLambda = fLambda.orElse(() -> getCentralWavelength(c, p));
+
+        // If the observing wavelength value is changing in this step, add it to
+        // the current configuration.
+        if (!obsLambda.equals(getObservingWavelength(c, p))) {
+            obsLambda.foreach(l ->
+                ImOption.apply(c).foreach(c0 ->
+                    c0.putParameter(
+                        INSTRUMENT_CONFIG_NAME,
+                        StringParameter.getInstance(OBSERVING_WAVELENGTH_PROP, l)
+                    )
+                )
+            );
+        }
+    }
 
     /**
      * This thisApplyNext overrides the HelperSeqCompCB
@@ -32,19 +139,11 @@ public final class SeqConfigGNIRSCB extends HelperSeqCompCB {
         super.thisApplyNext(config, prevFull);
 
         // Insert the instrument name
-        config.putParameter(SeqConfigNames.INSTRUMENT_CONFIG_NAME,
-                StringParameter.getInstance(InstConstants.INSTRUMENT_NAME_PROP, GNIRSConstants.INSTRUMENT_NAME_PROP));
+        config.putParameter(
+            INSTRUMENT_CONFIG_NAME,
+            StringParameter.getInstance(INSTRUMENT_NAME_PROP, GNIRSConstants.INSTRUMENT_NAME_PROP)
+        );
 
-        ISysConfig sysConfig = config.getSysConfig(SeqConfigNames.INSTRUMENT_CONFIG_NAME);
-        for (IParameter param : sysConfig.getParameters()) {
-            String name = param.getName();
-
-            if ((name != null) && name.equals(GNIRSConstants.CENTRAL_WAVELENGTH_PROP)) {
-                GNIRSParams.Wavelength w = (GNIRSParams.Wavelength) param.getValue();
-                String obsWave = (w == null) ? "" : w.getStringValue();
-                config.putParameter(SeqConfigNames.INSTRUMENT_CONFIG_NAME,
-                        StringParameter.getInstance(GNIRSConstants.OBSERVING_WAVELENGTH_PROP, obsWave));
-            }
-        }
+        addObservingWavelength(config, prevFull);
     }
 }


### PR DESCRIPTION
Fixes a bug in SmartGcal lookup for GNIRS.  In particular, a change to the way that the observing wavelength is set in the sequence is required in order to have the correct observing wavelength value at the time it is used by the SmartGcal lookup.  Instead of post-processing the sequence to add observing wavelength, it needs to be written into each step where it changes.

__CAUTION:__ This PR plumbs the depths of the current sequence model and may burn your eyes.
