### PR TITLE
REL-3620: Add GNIRS Hartmann masks and focus

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSConstants.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSConstants.java
@@ -33,6 +33,10 @@ public final class GNIRSConstants extends InstConstants {
     public static final ItemKey FILTER_KEY = key(FILTER_PROP);
     public static final String ACQUISITION_MIRROR_PROP = "acquisitionMirror";
     public static final ItemKey ACQUISITION_MIRROR_KEY = key(ACQUISITION_MIRROR_PROP);
+    public static final String HARTMANN_MASK_PROP = "hartmannMask";
+    public static final ItemKey HARTMANN_MASK_KEY = key(HARTMANN_MASK_PROP);
+    public static final String FOCUS_PROP = "Focus";
+    public static final ItemKey FOCUS_KEY = key(FOCUS_PROP);
 
     public static final double DEF_EXPOSURE_TIME = 17.0; // sec (by default settings)
     public static final double DEF_CENTRAL_WAVELENGTH = 2.2; // um (band=K)

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
@@ -4,6 +4,7 @@ import edu.gemini.spModel.config2.ItemKey;
 import edu.gemini.spModel.data.SuggestibleString;
 import static edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY;
 import edu.gemini.spModel.type.*;
+import edu.gemini.shared.util.immutable.*;
 
 import java.beans.PropertyEditorManager;
 import java.beans.PropertyEditorSupport;
@@ -1020,12 +1021,12 @@ public class GNIRSParams {
     public enum HartmannMask implements DisplayableSpType, SequenceableSpType {
 
         OUT("Out"),
-        LeftMask("Left"),
-        RightMask("Right"),
+        LEFT_MASK("Left"),
+        RIGHT_MASK("Right"),
         ;
 
-        public static HartmannMask DEFAULT = OUT;
-        private String _displayValue;
+        public static final HartmannMask DEFAULT = OUT;
+        private final String _displayValue;
 
         HartmannMask(String displayValue) {
             _displayValue = displayValue;
@@ -1094,24 +1095,28 @@ public class GNIRSParams {
         public String toString() {
             return _displayValue;
         }
-
     }
 
-    public static class Focus extends SuggestibleString {
-        public Focus() {
+    public static final class Focus extends SuggestibleString {
+
+        public Focus(String value) {
             super(FocusSuggestion.class);
-            setStringValue(FocusSuggestion.DEFAULT.displayValue());
+            setStringValue(value);
+        }
+
+        public Focus() {
+            this(FocusSuggestion.DEFAULT.displayValue());
+        }
+
+        public Focus copy() {
+            return new Focus(getStringValue());
         }
     }
 
-    public static class FocusEditor extends PropertyEditorSupport {
-        public Object getValue() {
-            Focus f = (Focus) super.getValue();
-            if (f == null) return null;
+    public static final class FocusEditor extends PropertyEditorSupport {
 
-            Focus res = new Focus();
-            res.setStringValue(f.getStringValue());
-            return res;
+        public Object getValue() {
+            return ImOption.apply((Focus) super.getValue()).map(f -> f.copy()).getOrNull();
         }
 
         public void setValue(Object value) {
@@ -1125,18 +1130,11 @@ public class GNIRSParams {
         }
 
         public String getAsText() {
-            Focus val = (Focus) getValue();
-            if (val == null) return null;
-            return val.getStringValue();
+            return ImOption.apply((Focus) getValue()).map(f -> f.getStringValue()).getOrNull();
         }
 
         public void setAsText(String string) throws IllegalArgumentException {
-            Focus val = (Focus) super.getValue();
-            if (val == null) {
-                val = new Focus();
-                super.setValue(val);
-            }
-            val.setStringValue(string);
+            setValue(new Focus(string));
         }
     }
     

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/GNIRSParams.java
@@ -1014,6 +1014,132 @@ public class GNIRSParams {
         }
     }
 
+    /**
+     * Hartmann Masks
+     */
+    public enum HartmannMask implements DisplayableSpType, SequenceableSpType {
+
+        OUT("Out"),
+        LeftMask("Left"),
+        RightMask("Right"),
+        ;
+
+        public static HartmannMask DEFAULT = OUT;
+        private String _displayValue;
+
+        HartmannMask(String displayValue) {
+            _displayValue = displayValue;
+        }
+
+        public String displayValue() {
+            return _displayValue;
+        }
+
+        public String sequenceValue() {
+            return _displayValue;
+        }
+
+        public String toString() {
+            return _displayValue;
+        }
+
+        /**
+         * Return the HartmannMask by name *
+         */
+        static public HartmannMask getHartmannMask(String name) {
+            return getHartmannMask(name, DEFAULT);
+        }
+
+        /**
+         * Return the HartmannMask by index *
+         */
+        static public HartmannMask getHartmannMaskByIndex(int index) {
+            return SpTypeUtil.valueOf(HartmannMask.class, index, DEFAULT);
+        }
+
+        /**
+         * Return the HartmannMask by name giving a value to return upon error *
+         */
+        static public HartmannMask getHartmannMask(String name, HartmannMask nvalue) {
+            return SpTypeUtil.oldValueOf(HartmannMask.class, name, nvalue);
+        }
+    }
+
+    /**
+     * Focus
+     */
+    public enum FocusSuggestion implements DisplayableSpType, SequenceableSpType {
+
+        BEST_FOCUS("best focus"),;
+
+        /**
+         * The default Focus value *
+         */
+        public static final FocusSuggestion DEFAULT = BEST_FOCUS;
+
+        private final String _displayValue;
+
+        FocusSuggestion(String displayValue) {
+            _displayValue = displayValue;
+        }
+
+        public String displayValue() {
+            return _displayValue;
+        }
+
+        public String sequenceValue() {
+            return _displayValue;
+        }
+
+        public String toString() {
+            return _displayValue;
+        }
+
+    }
+
+    public static class Focus extends SuggestibleString {
+        public Focus() {
+            super(FocusSuggestion.class);
+            setStringValue(FocusSuggestion.DEFAULT.displayValue());
+        }
+    }
+
+    public static class FocusEditor extends PropertyEditorSupport {
+        public Object getValue() {
+            Focus f = (Focus) super.getValue();
+            if (f == null) return null;
+
+            Focus res = new Focus();
+            res.setStringValue(f.getStringValue());
+            return res;
+        }
+
+        public void setValue(Object value) {
+            Focus f = (Focus) value;
+            Focus cur = (Focus) super.getValue();
+            if (cur == null) {
+                cur = new Focus();
+                super.setValue(cur);
+            }
+            cur.setStringValue(f.getStringValue());
+        }
+
+        public String getAsText() {
+            Focus val = (Focus) getValue();
+            if (val == null) return null;
+            return val.getStringValue();
+        }
+
+        public void setAsText(String string) throws IllegalArgumentException {
+            Focus val = (Focus) super.getValue();
+            if (val == null) {
+                val = new Focus();
+                super.setValue(val);
+            }
+            val.setStringValue(string);
+        }
+    }
+    
     /**Well Depth Values **/
     public enum WellDepth implements DisplayableSpType, SequenceableSpType {
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -82,6 +82,8 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     public static final PropertyDescriptor FILTER_PROP;
     public static final PropertyDescriptor ACQUISITION_MIRROR_PROP;
     public static final PropertyDescriptor POS_ANGLE_CONSTRAINT_PROP;
+    public static final PropertyDescriptor HARTMANN_MASK_PROP;
+    public static final PropertyDescriptor FOCUS_PROP;
 
     // REL-2646.  This is an unfortunate requirement that falls out of REL-2646.
     // The observing wavelength for acquisition observations should be computed
@@ -139,6 +141,10 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         WELL_DEPTH_PROP = initProp("wellDepth", query_yes, iter_no);
         PORT_PROP = initProp("issPort", query_yes, iter_no);
         POS_ANGLE_CONSTRAINT_PROP = initProp("posAngleConstraint", query_no, iter_no);
+        HARTMANN_MASK_PROP = initProp("hartmannMask", query_yes, iter_yes);
+        HARTMANN_MASK_PROP.setExpert(true);
+        FOCUS_PROP = initProp("focus", query_no, iter_yes);
+        FOCUS_PROP.setExpert(true);
 
         OVERRIDE_ACQ_OBS_WAVELENGTH_PROP = initProp("overrideAcqObsWavelength", query_no, iter_no);
     }
@@ -155,6 +161,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     private Decker _decker = Decker.DEFAULT;
     private Filter _filter = Filter.DEFAULT;
     private WellDepth _wellDepth = WellDepth.DEFAULT;
+    private HartmannMask _hartmannMask = HartmannMask.DEFAULT;
 
     private IssPort port = IssPort.SIDE_LOOKING;
 
@@ -360,6 +367,41 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
 
     public void setOverrideAcqObsWavelength(boolean newValue) {
         _overrideAcqObsWavelength = newValue;
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * Get the Hartmann mask value.
+     * NOTE: these are not available in the public interface but must be present for properties and to be iterable.
+     */
+    public HartmannMask getHartmannMask() {
+        return _hartmannMask;
+    }
+
+    /**
+     * Set the Hartmann mask.
+     */
+    public void setHartmannMask(HartmannMask newValue) {
+        HartmannMask oldValue = getHartmannMask();
+        if (oldValue != newValue) {
+            _hartmannMask = newValue;
+            firePropertyChange(HARTMANN_MASK_PROP.getName(), oldValue, newValue);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+
+    /**
+     * Return the (read-only, static) value for focus.
+     */
+    public Focus getFocus() {
+        return new Focus();
+    }
+
+    public void setFocus(Focus focus) {
+        // Required for reflection
     }
 
     // ------------------------------------------------------------------------
@@ -876,6 +918,8 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         sc.putParameter(DefaultParameter.getInstance(InstConstants.POS_ANGLE_PROP, getPosAngleDegrees()));
         sc.putParameter(DefaultParameter.getInstance(InstConstants.COADDS_PROP, getCoadds()));
         sc.putParameter(DefaultParameter.getInstance(PORT_PROP, getIssPort()));
+        sc.putParameter(DefaultParameter.getInstance(HARTMANN_MASK_PROP, getHartmannMask()));
+        sc.putParameter(DefaultParameter.getInstance(FOCUS_PROP.getName(), getFocus()));
 
         return sc;
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -392,16 +392,23 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
 
     // ------------------------------------------------------------------------
 
-
     /**
-     * Return the (read-only, static) value for focus.
+     * Get and set the focus
      */
+
+    private Focus _focus = new Focus();
+
     public Focus getFocus() {
-        return new Focus();
+        return _focus.copy();
     }
 
-    public void setFocus(Focus focus) {
-        // Required for reflection
+    public void setFocus(Focus newValue) {
+        final Focus oldValue = getFocus();
+
+        if (!oldValue.equals(newValue) && newValue.getStringValue() != null) {
+            _focus = newValue.copy();
+            firePropertyChange(FOCUS_PROP.getName(), oldValue, newValue);
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -427,8 +434,6 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
 
     // ------------------------------------------------------------------------
 
-    // ------------------------------------------------------------------------
-
     /**
      * Get the well depth  value.
      */
@@ -437,7 +442,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     }
 
     /**
-     * Set the decker
+     * Set the well depth
      */
     public void setWellDepth(WellDepth newValue) {
         WellDepth oldValue = getWellDepth();
@@ -809,6 +814,8 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         Pio.addParam(factory, paramSet, DECKER_PROP, getDecker().name());
         Pio.addParam(factory, paramSet, FILTER_PROP, getFilter().name());
         Pio.addParam(factory, paramSet, POS_ANGLE_CONSTRAINT_PROP.getName(), getPosAngleConstraint().name());
+        Pio.addParam(factory, paramSet, HARTMANN_MASK_PROP, getHartmannMask().name());
+        Pio.addParam(factory, paramSet, FOCUS_PROP.getName(), _focus.getStringValue());
 
         Pio.addBooleanParam(factory, paramSet, OVERRIDE_ACQ_OBS_WAVELENGTH_PROP.getName(), isOverrideAcqObsWavelength());
 
@@ -855,7 +862,6 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         if (v != null) {
             setWellDepth(WellDepth.valueOf(v));
         }
-
         v = Pio.getValue(paramSet, ACQUISITION_MIRROR_PROP);
         if (v != null) {
             setAcquisitionMirror(AcquisitionMirror.getAcquisitionMirror(v));
@@ -872,6 +878,13 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         if (v != null) {
             setFilter(Filter.getFilter(v));
         }
+        v = Pio.getValue(paramSet, HARTMANN_MASK_PROP);
+        if (v != null) {
+            setHartmannMask(HartmannMask.getHartmannMask(v));
+        }
+        v = ImOption.apply(Pio.getValue(paramSet, FOCUS_PROP.getName()))
+                .getOrElse(FocusSuggestion.DEFAULT.displayValue());
+            setFocus(new Focus(v));
 
         // REL-2090: Special workaround for elimination of former PositionAngleMode, since functionality has been
         // merged with PosAngleConstraint but we still need legacy code.


### PR DESCRIPTION
This adds an engineering item to the GNIRS iterator to select one of the Hartmann masks, and another engineering item to manually set the focus.  This seems to work as expected from the UI, but please check that it makes sense.  One complication is that the Hartmann masks are *not* in a separate mechanism, but rather installed in filter wheel #1.