### PR TITLE
REL-3603: Missing ToO Target Type in OT Templates menu

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2019A", true, 1, 1, 6)
+ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2019B", true, 2, 1, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
-ocsVersion in ThisBuild := OcsVersion("2016A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2019A", true, 1, 1, 6)
 
 pitVersion in ThisBuild := OcsVersion("2019B", true, 2, 1, 0)
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateParameters.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateParameters.java
@@ -32,7 +32,7 @@ public final class TemplateParameters extends AbstractDataObject {
     public static final String PARAM_TIME = "time";
 
     public static final ISPNodeInitializer<ISPTemplateParameters, TemplateParameters> NI =
-        new SimpleNodeInitializer<>(SP_TYPE, () -> new TemplateParameters());
+        new SimpleNodeInitializer<>(SP_TYPE, TemplateParameters::new);
 
     public static TemplateParameters newEmpty() {
         return new TemplateParameters(new SPTarget(), new SPSiteQuality(), TimeValue.ZERO_HOURS);

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -38,7 +38,7 @@ object TemplateParametersEditor {
     if (s.size == 1) s.headOption else None
   }
 
-  trait Initializable {
+  sealed trait Initializable {
     def init(ps: Iterable[TemplateParameters]): Unit
   }
 
@@ -65,7 +65,7 @@ object TemplateParametersEditor {
     }
   }
 
-  abstract class ColumnPanel(hGap: Int = HGap, rowAnchor: GridBagPanel.Anchor.Value = East) extends GridBagPanel with Initializable {
+  sealed abstract class ColumnPanel(hGap: Int = HGap, rowAnchor: GridBagPanel.Anchor.Value = East) extends GridBagPanel with Initializable {
     def rows: Iterable[Row]
 
     def nextY(): Int = (-1 :: layout.values.toList.map(_.gridy)).max + 1
@@ -117,7 +117,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
   private def isToo: Boolean =
     shells.asScala.exists(Too.isToo(_))
 
-  trait BoundWidget[A] extends Initializable { self: Component =>
+  sealed trait BoundWidget[A] extends Initializable { self: Component =>
     def get: TemplateParameters => A
     def set: (TemplateParameters, A) => TemplateParameters
 
@@ -219,7 +219,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
   }
 
   object TargetPanel extends GridBagPanel with Initializable {
-    trait TargetType { def display: String }
+    sealed trait TargetType { def display: String }
     case object Sidereal extends TargetType    { val display = "Sidereal"     }
     case object NonSidereal extends TargetType { val display = "Non-Sidereal" }
     case object ToO extends TargetType { val display = "Target of Opportunity" }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -65,7 +65,7 @@ object TemplateParametersEditor {
     }
   }
 
-  sealed abstract class ColumnPanel(hGap: Int = HGap, rowAnchor: GridBagPanel.Anchor.Value = East) extends GridBagPanel with Initializable {
+  abstract class ColumnPanel(hGap: Int = HGap, rowAnchor: GridBagPanel.Anchor.Value = East) extends GridBagPanel with Initializable {
     def rows: Iterable[Row]
 
     def nextY(): Int = (-1 :: layout.values.toList.map(_.gridy)).max + 1

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -232,10 +232,10 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
       tp.copy(newTarget)
     }
 
-    def targetType(t: SPTarget): TargetType = {
-      if (t.isTooTarget) ToO
-      else if (t.isSidereal) Sidereal
-      else NonSidereal
+    def targetType(t: SPTarget): TargetType = t.getTarget match {
+      case _: SiderealTarget    => Sidereal
+      case _: NonSiderealTarget => NonSidereal
+      case _: TooTarget         => ToO
     }
 
     object CoordinatesPanel extends ColumnPanel {


### PR DESCRIPTION
The ToO target type was missing in the OT templates menu. As is visible in this screen cap, this resulted in ToO targets being labeled as non-sidereal in the template editor:

![Screen Shot 2019-04-30 at 12 49 08 PM](https://user-images.githubusercontent.com/8795653/56984999-5c831f00-6b55-11e9-8ec0-d3553c6e9a49.png)

When the templates were instantiated, they were still created as having target type ToO; however, it was not possible to create new targets with target type ToO in the template editor.

Now, in the case that a program is a ToO program, we add the target type ToO to the combo box, and ToO targets display the proper type in the template editor:

![Screen Shot 2019-04-30 at 2 32 36 PM](https://user-images.githubusercontent.com/8795653/56985109-9a804300-6b55-11e9-9b76-9d6669500936.png)

![Screen Shot 2019-04-30 at 2 32 47 PM](https://user-images.githubusercontent.com/8795653/56985137-a3711480-6b55-11e9-8b66-8da74344b491.png)


