### PR TITLE
REL-3667: Change the number of QVis repeated windows to N+1

### DIFF
--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/ConstraintsCache.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/ConstraintsCache.scala
@@ -252,7 +252,7 @@ case class TimingWindowConstraint(windows: Seq[TimingWindow]) extends Constraint
           } else tw.getRepeat match {
             case REPEAT_NEVER => Solution(Seq(new Interval(tw.getStart, tw.getStart + tw.getDuration)))           // single window
             case REPEAT_FOREVER => Solution(createIntervals(tw.getStart, interval.end, Int.MaxValue, tw, Seq()))  // repeat forever, use interval end as limiter
-            case n => Solution(createIntervals(tw.getStart, interval.end, n, tw, Seq()))                          // repeat n times
+            case n => Solution(createIntervals(tw.getStart, interval.end, n+1, tw, Seq()))                        // repeat n times
           }
         })
       solutions.

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/ConstraintsCache.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/util/ConstraintsCache.scala
@@ -252,7 +252,7 @@ case class TimingWindowConstraint(windows: Seq[TimingWindow]) extends Constraint
           } else tw.getRepeat match {
             case REPEAT_NEVER => Solution(Seq(new Interval(tw.getStart, tw.getStart + tw.getDuration)))           // single window
             case REPEAT_FOREVER => Solution(createIntervals(tw.getStart, interval.end, Int.MaxValue, tw, Seq()))  // repeat forever, use interval end as limiter
-            case n => Solution(createIntervals(tw.getStart, interval.end, n+1, tw, Seq()))                        // repeat n times
+            case n => Solution(createIntervals(tw.getStart, interval.end, n+1, tw, Seq()))                        // repeat n times for a total of n+1 windows
           }
         })
       solutions.


### PR DESCRIPTION
Timing windows may be defined with a number of "Repeats". The OT elevation plot and the QPT interpret this to mean there are Nrepeat + 1 windows, i.e. if a window repeats once there are two total.  This change updates QVis to have the same interpretation.