### PR TITLE
REL-3661: F2 blueprint update fix

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
@@ -511,7 +511,7 @@ Additional calibration targets and resources are located at the webpage http://w
       </container>
       <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="06cc7674-7c8c-4f3d-b392-c58ed7f1755f" name="Note">
         <paramset name="Note" kind="dataObj">
-          <param name="title" value="Use the same PA for science target and telluric."/>
+          <param name="title" value="Use the same PA for science target and telluric"/>
           <param name="NoteText" value="This will save telescope time, and will also diminish the effect of flexure."/>
         </paramset>
       </container>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
@@ -500,7 +500,7 @@ Additional calibration targets and resources are located at the webpage http://w
 
 9. At the NIR wavelength range, for a given brightness we usually face an uncertainty of factor 2-3 in BG plus target level per pixel just within any single bin of conditions CC/IQ/BG/WV. For a single CDS read ("bright target" mode) the science target peak signal should not surpass 22k ADUs.  For 4 and 8 reads ("medium" and "faint") should not surpass 88k and 172k ADUs.
 
-10. Please attach fintder charts via the OT "File Attachment" tab.
+10. Please attach finder charts via the OT "File Attachment" tab.
 
 11. Darks are now taken weekly.
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
@@ -500,7 +500,7 @@ Additional calibration targets and resources are located at the webpage http://w
 
 9. At the NIR wavelength range, for a given brightness we usually face an uncertainty of factor 2-3 in BG plus target level per pixel just within any single bin of conditions CC/IQ/BG/WV. For a single CDS read ("bright target" mode) the science target peak signal should not surpass 22k ADUs.  For 4 and 8 reads ("medium" and "faint") should not surpass 88k and 172k ADUs.
 
-10. Please attach finder charts via the OT "File Attachment" tab.
+10. Please attach fintder charts via the OT "File Attachment" tab.
 
 11. Darks are now taken weekly.
 
@@ -509,16 +509,12 @@ Additional calibration targets and resources are located at the webpage http://w
           </param>
         </paramset>
       </container>
-
       <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="06cc7674-7c8c-4f3d-b392-c58ed7f1755f" name="Note">
         <paramset name="Note" kind="dataObj">
-          <param name="title" value="Use the same PA for science target and telluric"/>
-          <param name="NoteText">
-            <value>This will save telescope time, and will also diminish the effect of flexure.</value>
-          </param>
+          <param name="title" value="Use the same PA for science target and telluric."/>
+          <param name="NoteText" value="This will save telescope time, and will also diminish the effect of flexure."/>
         </paramset>
       </container>
-
       <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="255efbef-a1be-4011-a28c-2fae0c7306f8" name="Note">
         <paramset name="Note" kind="dataObj">
           <param name="title" value="Repeats contain the ABBA offsets"/>
@@ -532,12 +528,11 @@ Any offset strategy must take into account that the sky emission lines can vary 
           </param>
         </paramset>
       </container>
-
       <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="2fd4adbf-6226-40bd-a5c1-e418999a4756" name="Note">
         <paramset name="Note" kind="dataObj">
           <param name="title" value="Detector readout modes"/>
           <param name="NoteText">
-            <value>When choosing the detector readout modes or changing the exposure times, please have in mind:
+            <value>When choosing the detecotr readout modes or changing the exposure times, please have in mind:
 
 Single CDS read (Bright Object Mode) can be used for any exposure time (Minimum possible 2 seconds).  
 In imaging applications, the FLAMINGOS-2 detector is always sky-noise limited using single reads.
@@ -554,7 +549,6 @@ When modifying the exposure times set at the library example sequences, or on-th
           </param>
         </paramset>
       </container>
-
       <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="7e5794f2-320d-4181-8fe6-860c31dce8b1" name="Note">
         <paramset name="Note" kind="dataObj">
           <param name="title" value="Libraries"/>
@@ -1764,7 +1758,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="99e952d4-4df0-4939-b2cf-ca23552ef3eb" name="F2-BP-13">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS Mask daytime image"/>
-          <param name="libraryId" value="30"/>
+          <param name="libraryId" value="29"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -3094,7 +3088,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="99e952d4-4df0-4939-b2cf-ca23552ef3eb"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="7"/>
-      <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="8"/>
+      <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="12"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="d8bd935d-4c00-4d75-aa3a-3a8ebcc0f695"/>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
@@ -532,7 +532,7 @@ Any offset strategy must take into account that the sky emission lines can vary 
         <paramset name="Note" kind="dataObj">
           <param name="title" value="Detector readout modes"/>
           <param name="NoteText">
-            <value>When choosing the detecotr readout modes or changing the exposure times, please have in mind:
+            <value>When choosing the detector readout modes or changing the exposure times, please have in mind:
 
 Single CDS read (Bright Object Mode) can be used for any exposure time (Minimum possible 2 seconds).  
 In imaging applications, the FLAMINGOS-2 detector is always sky-noise limited using single reads.

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
@@ -46,8 +46,7 @@ case class Flamingos2Longslit(blueprint:SpFlamingos2BlueprintLongslit, exampleTa
     "F2 Long-Slit Notes",
     "Repeats contain the ABBA offsets",
     "Use the same PA for science target and telluric",
-    "Detector readout modes"
-  )
+    "Detector readout modes")
 
   val scienceAndTellurics = Seq(12,15,16,18)
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
@@ -42,7 +42,12 @@ case class Flamingos2Longslit(blueprint:SpFlamingos2BlueprintLongslit, exampleTa
 
   val targetGroup = Seq(11,12) ++ acq ++ Seq(15,16,17,18)
   val baselineFolder = Seq.empty
-  val notes = Seq("F2 Long-Slit Notes", "Repeats contain the ABBA offsets", "Use same PA for science and Telluric")
+  val notes = Seq(
+    "F2 Long-Slit Notes",
+    "Repeats contain the ABBA offsets",
+    "Use the same PA for science target and telluric",
+    "Detector readout modes"
+  )
 
   val scienceAndTellurics = Seq(12,15,16,18)
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Mos.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Mos.scala
@@ -13,7 +13,7 @@ case class Flamingos2Mos(blueprint:SpFlamingos2BlueprintMos) extends Flamingos2B
 //  INCLUDE {29}                              # Mask daytime image
 //
 // 	INCLUDE {22,23}                           # Telluric std
-// 	INCLUDE {24,25}                           # Science
+// 	INCLUDE {24,25,28}                        # Science
 // 	INCLUDE {26,27}                           # Telluric std
 //
 //  FOR {23,25,27,28}:                        # Science and Tellurics
@@ -33,7 +33,7 @@ case class Flamingos2Mos(blueprint:SpFlamingos2BlueprintMos) extends Flamingos2B
 //           NN should be the string "NN" since the mask number is unknown
 
   def preImaging = if (blueprint.preImaging) Seq(21) else Seq.empty
-  val targetGroup = preImaging ++ Seq(29,22,23,24,25,26,27)
+  val targetGroup = preImaging ++ Seq(29,22,23,24,25,28,26,27)
   val baselineFolder = Seq.empty
   val notes = Seq("F2 MOS Notes")
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/F2BlueprintTest.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/F2BlueprintTest.scala
@@ -39,19 +39,18 @@ class F2BlueprintTest extends TemplateSpec("F2_BP.xml") with SpecificationLike w
     "Include notes, REL-2628" in {
       forAll { (b: Flamingos2BlueprintLongslit) =>
         expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
-          val notes = List("F2 Long-Slit Notes", "Repeats contain the ABBA offsets")//, "Use the same PA for science target and telluric", "Detector readout modes" /*?*/)
-//          val titles = groups(sp).map { tg => tg.getObsComponents
-//            .asScala.toList
-//            .map(_.getDataObject)
-//            .collect { case n: SPNote => n }
-//            .map(_.getTitle)}
-//          println(titles)
+          val notes = List(
+            "F2 Long-Slit Notes",
+            "Repeats contain the ABBA offsets",
+            "Use the same PA for science target and telluric",
+            "Detector readout modes")
           groups(sp).forall(tg => notes.forall(existsNote(tg, _)))
         }
       }
     }
   }
 
+  // REL-3661: As of 2019B, F2 imaging can include darks.
 //  "F2 Imaging" should {
 //    "not include darks, REL-2906" in {
 //      forAll { (b: Flamingos2BlueprintImaging) =>


### PR DESCRIPTION
There were some discrepancies between observation library IDs in the former` F2_BP.xml` file and the `F2_BP.txt` algorithm implementation, which was causing errors to be reported about nonexistence observation library IDs.

This uses the new files, which now ingest F2 blueprints correctly, and also fixes a problem where two notes were missing.