### PR TITLE
REL-3654: Increasing max heap size for ITC.

### DIFF
--- a/app/itc/build.sbt
+++ b/app/itc/build.sbt
@@ -40,7 +40,7 @@ def common(version: Version) = AppConfig(
     "-Dnetworkaddress.cache.ttl=60",
     "-Duser.language=en",
     "-Duser.country=US",
-    "-Xmx1024M"
+    "-Xmx2048M"
   ),
   props = Map(
     "org.osgi.service.http.port"                 -> "9080",


### PR DESCRIPTION
The production ITC is experiencing `OutOfMemoryException`s, and thus I am increasing the max heap size. I have submitted a help desk ticket to increase the amount of RAM to the VM to 4 GB as well, as it is currently set at 2 GB.