### PR TITLE
REL-3661: F2 template updates

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.txt
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.txt
@@ -54,22 +54,22 @@ IF SPECTROSCOPY MODE = LONGSLIT
 IF SPECTROSCOPY MODE = MOS
 
     IF PRE-IMAGING REQUIRED = YES
-        INCLUDE {21}
+        INCLUDE {31}
 
-    INCLUDE {29}                           # Mask daytime image
+    INCLUDE {32}                           # Mask daytime image
 
-    INCLUDE {22,23}                           # Telluric std
-    INCLUDE {24,25,28}                           # Science
-    INCLUDE {26,27}                           # Telluric std
+    INCLUDE {33,34}                           # Telluric std
+    INCLUDE {35,36,37}                           # Science
+    INCLUDE {38,39}                           # Telluric std
 
-    FOR {23,25,27,28}:                           # Science and Tellurics
+    FOR {34,36,37,39}:                           # Science and Tellurics
         SET DISPERSER FROM PI
             Put FILTERS from PI into F2 ITERATOR
         
-    FOR {21,22,23,24,25,26,27,28,29}:
+    FOR {31,32,33,34,35,36,37,38,39}:
         SET CONDITIONS FROM PI
 
-    FOR {24,25,28,29}:                              # MOS science
+    FOR {32,35,36,37}:                              # MOS science
         SET "Custom MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN 
             where: 
             (N/S) is the site 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
@@ -1600,7 +1600,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e15ce507-371b-4d67-aaf8-15ddaa6c1374" name="F2-BP-12">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS Pre-imaging - sparse field"/>
-          <param name="libraryId" value="21"/>
+          <param name="libraryId" value="31"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -1710,7 +1710,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="99e952d4-4df0-4939-b2cf-ca23552ef3eb" name="F2-BP-13">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS Mask daytime image"/>
-          <param name="libraryId" value="29"/>
+          <param name="libraryId" value="32"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -1791,7 +1791,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="bc2199e1-68cd-436e-8e6a-c9f0f6f92ac5" name="F2-BP-14">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Telluric Acquisition"/>
-          <param name="libraryId" value="22"/>
+          <param name="libraryId" value="33"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -1924,7 +1924,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="1bd0aeef-f95c-4c89-b7ed-0b10ccaf112e" name="F2-BP-15">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Telluric Observation"/>
-          <param name="libraryId" value="23"/>
+          <param name="libraryId" value="34"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -2031,7 +2031,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="2fdd604a-d8ca-49a2-abe6-d4da74fafaa5" name="F2-BP-16">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS Acquisition"/>
-          <param name="libraryId" value="24"/>
+          <param name="libraryId" value="35"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -2153,7 +2153,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="f58f0991-9ba0-484c-a193-8c872ab84812" name="F2-BP-17">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS Science - Sparse field"/>
-          <param name="libraryId" value="25"/>
+          <param name="libraryId" value="36"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -2258,7 +2258,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="45f027ad-bba5-4ad3-a97b-62af5dbdf911" name="F2-BP-18">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="MOS Science - Crowded field or Extended object"/>
-          <param name="libraryId" value="28"/>
+          <param name="libraryId" value="37"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -2363,7 +2363,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="1a918186-7fc2-4057-a5db-e08d08c9f34a" name="F2-BP-20">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Telluric Acquisition"/>
-          <param name="libraryId" value="26"/>
+          <param name="libraryId" value="38"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -2496,7 +2496,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="a1172ce6-ad9e-48d9-b577-5b4a57799a3a" name="F2-BP-21">
         <paramset name="Observation" kind="dataObj">
           <param name="title" value="Telluric Observation"/>
-          <param name="libraryId" value="27"/>
+          <param name="libraryId" value="39"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
@@ -2732,7 +2732,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="bc2199e1-68cd-436e-8e6a-c9f0f6f92ac5"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="5"/>
-      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="50d2b9c3-5c09-4d87-b009-19ee2676fe3c"/>
@@ -2886,7 +2886,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="1bd0aeef-f95c-4c89-b7ed-0b10ccaf112e"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
-      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="4b3fe28e-6db1-4684-b64e-db228791f6c1"/>
@@ -2907,7 +2907,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="2fdd604a-d8ca-49a2-abe6-d4da74fafaa5"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
-      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="d2578fee-0a32-4ef6-83b6-c8b7a32d604c"/>
@@ -2945,7 +2945,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <param name="key" value="45f027ad-bba5-4ad3-a97b-62af5dbdf911"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="7"/>
       <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="2"/>
-      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="6891cf03-2ba5-4ffa-8b3b-fa16bb8d5e06"/>
@@ -2959,7 +2959,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <param name="key" value="99e952d4-4df0-4939-b2cf-ca23552ef3eb"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="7"/>
       <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="12"/>
-      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="d8bd935d-4c00-4d75-aa3a-3a8ebcc0f695"/>
@@ -3090,7 +3090,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <param name="key" value="1a918186-7fc2-4057-a5db-e08d08c9f34a"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="3"/>
       <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="6"/>
-      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="63034954-6892-4c56-9b20-5c2ae9a7a23c"/>
@@ -3200,7 +3200,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="f58f0991-9ba0-484c-a193-8c872ab84812"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
-      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="6710fc7a-d4dd-4b39-a2c7-abc701f5a006"/>
@@ -3469,7 +3469,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <param name="key" value="a1172ce6-ad9e-48d9-b577-5b4a57799a3a"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="3"/>
       <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="6"/>
-      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="0955698a-ba2f-4746-a3d9-880eb9cc6703"/>
@@ -3625,7 +3625,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="e15ce507-371b-4d67-aaf8-15ddaa6c1374"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
-      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="3"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="4eafc9fd-368e-4ed5-9f04-ed2922dcfe3d"/>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/F2_BP.xml
@@ -140,6 +140,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="d5b3c10e-482f-4521-affa-55f9fea0a6f2" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -249,6 +250,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="fccd292a-dee4-4b53-bc05-cddb7afcf9db" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -376,6 +378,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="54cc9eb2-1998-47aa-b290-112187ecf5ae" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
@@ -569,6 +572,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="acb451c1-0343-4541-8f1c-140ead74ea4c" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -585,18 +589,6 @@ Additional calibration targets and resources are located at the webpage http://w
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="LONG_SLIT"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="35cab660-6943-4749-aaf3-e54a7210f18c" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="698a4b60-c21f-4d79-9a94-396154a014b1" name="Observing Log">
@@ -713,6 +705,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="7c01bdce-0507-4c38-aa72-e6812e1292fc" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -729,18 +722,6 @@ Additional calibration targets and resources are located at the webpage http://w
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="LONG_SLIT"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="041d9a43-0d03-482e-8791-c832bc6041dd" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="dc2b8cc8-ab3c-4c3f-b0e7-f88461eddd27" name="Observing Log">
@@ -821,6 +802,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="76031020-18b6-44aa-b746-a352e89b0cc0" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -953,6 +935,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="3292e6a4-cd09-4c25-adf8-c935c01ea671" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -1095,6 +1078,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="062f2b37-35fb-478b-bf5e-2e4c97d76047" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -1197,6 +1181,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="5817bb5d-3c6f-4335-bd24-ed32bee341fc" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -1299,6 +1284,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="3659bdd4-0fe1-42da-ab22-453c19047703" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -1315,18 +1301,6 @@ Additional calibration targets and resources are located at the webpage http://w
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="LONG_SLIT"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="04a1e4b6-b886-4492-a085-ab44a30559ca" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="bbca5cdf-cb55-459a-b891-2b69e60c47b1" name="Observing Log">
@@ -1443,6 +1417,7 @@ Additional calibration targets and resources are located at the webpage http://w
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="19f284e5-2320-4812-84da-70903e8f6c5f" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -1459,18 +1434,6 @@ Additional calibration targets and resources are located at the webpage http://w
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="LONG_SLIT"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="4dd7c622-4e9f-451d-877e-6426e04f9db7" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="bf6a8c0d-c231-4b5c-a0f1-583a2f84545f" name="Observing Log">
@@ -1581,7 +1544,7 @@ Additional calibration targets and resources are located at the webpage http://w
       </container>
       <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="6fe6fd80-f197-4cbc-849e-69aa1e075283" name="Note">
         <paramset name="Note" kind="dataObj">
-          <param name="title" value="Use the same PA for the MOS science target and telluric."/>
+          <param name="title" value="Use the same PA for the MOS science target and telluric"/>
           <param name="NoteText" value="This will save telescope time, and will also diminish the effect of flexure."/>
         </paramset>
       </container>
@@ -1630,7 +1593,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       </container>
       <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="82967823-b3f3-4c5a-89a4-d909d7b31df1" name="Note">
         <paramset name="Note" kind="dataObj">
-          <param name="title" value="MOS slits: only use slit widths of 4 pixels (0.72 arcsec) or larger. Slit lenght no less than 5 arcsec."/>
+          <param name="title" value="MOS slits: only use slit widths of 4 pixels (0.72 arcsec) or larger. Slit length no less than 5 arcsec."/>
           <param name="NoteText" value=""/>
         </paramset>
       </container>
@@ -1643,6 +1606,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="4a2885cd-a9a0-4670-a7dd-b34ae85490cc" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -1659,18 +1623,6 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
             <param name="mosPreimaging" value="YES"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="IMAGING"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="d6cc8929-cea7-48ac-8ee6-abe7a58a5239" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="61d98d08-e8e5-4732-95dd-c310d5bd8d55" name="Observing Log">
@@ -1764,6 +1716,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="56bafe71-5cab-4724-bb1c-e85967231632" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -1782,18 +1735,6 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="MOS"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="28a4b125-47ce-44f7-abdb-f3b8d2c56d17" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="7cd603ef-ff52-4a52-87ad-a7f0945e5ac3" name="Observing Log">
@@ -1856,6 +1797,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="688c29c4-eef0-4f35-8983-d3dce66a3a9e" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -1872,18 +1814,6 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="LONG_SLIT"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="4daef654-2e85-4c40-bd5e-cae4ae9257ac" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="d2935eb4-93eb-407e-afbb-ee941bb6d6c7" name="Observing Log">
@@ -2000,6 +1930,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="5d5d47eb-005d-4c84-a6ad-2c9878e0e7f5" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -2016,18 +1947,6 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="LONG_SLIT"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="93403353-fdc6-45e2-84f5-2b02c66e8306" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="f70f54af-d4e3-4c6a-acbc-1283e91b71bb" name="Observing Log">
@@ -2118,6 +2037,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="8878432e-1b56-40f7-9f28-6a70b3fc8970" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -2136,18 +2056,6 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="MOS"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="4e56d4ae-a001-4fac-874d-ee1764c2694c" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="08757dd9-93d2-4be8-a133-7660d560fbcc" name="Observing Log">
@@ -2251,6 +2159,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="5443c1cd-330a-48e2-b1c7-6136ad75a7cc" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -2269,18 +2178,6 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="MOS"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="454590ed-8187-4f13-9d2e-8e8a7158dda4" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="4c335ca9-b966-45b4-814e-4e0d145c094e" name="Observing Log">
@@ -2367,6 +2264,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="c61eca19-1bc2-4838-9d3f-69db0f394bcd" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -2385,18 +2283,6 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="MOS"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="228f4837-459c-4823-af30-a1beee9501be" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="b5205806-17d4-49cf-b049-52b315a0ac57" name="Observing Log">
@@ -2483,6 +2369,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="d7ad305d-ab21-491d-81cd-c53502757757" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -2499,18 +2386,6 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="LONG_SLIT"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="60581641-3d6f-455b-a195-1670a69dfec5" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="7634e8a9-f0cd-431b-8a88-4a90ed55d3a1" name="Observing Log">
@@ -2627,6 +2502,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
           <param name="phase2Status" value="PI_TO_COMPLETE"/>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Flamingos2" key="e271ab6c-d182-4c5c-b972-3f47c45b89c0" name="Flamingos2">
           <paramset name="Flamingos2" kind="dataObj">
@@ -2643,18 +2519,6 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
             <param name="mosPreimaging" value="NO"/>
             <param name="useElectronicOffsetting" value="false"/>
             <param name="decker" value="LONG_SLIT"/>
-          </paramset>
-        </container>
-        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="7a223352-4927-47bd-a1f2-dfe50148df05" name="Observing Conditions">
-          <paramset name="Observing Conditions" kind="dataObj">
-            <param name="CloudCover" value="ANY"/>
-            <param name="ImageQuality" value="ANY"/>
-            <param name="SkyBackground" value="ANY"/>
-            <param name="WaterVapor" value="ANY"/>
-            <param name="ElevationConstraintType" value="NONE"/>
-            <param name="ElevationConstraintMin" value="0.0"/>
-            <param name="ElevationConstraintMax" value="0.0"/>
-            <paramset name="timing-window-list"/>
           </paramset>
         </container>
         <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="a656386f-4232-44b0-99b5-9de9dbdb89f1" name="Observing Log">
@@ -2762,6 +2626,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="ea6101f0-f34b-450c-bf7d-32136038d707"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="f1211d6b-196c-48ba-8037-f23dd3522e0e"/>
@@ -2814,6 +2679,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="82967823-b3f3-4c5a-89a4-d909d7b31df1"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="4e56d4ae-a001-4fac-874d-ee1764c2694c"/>
@@ -2866,6 +2732,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="bc2199e1-68cd-436e-8e6a-c9f0f6f92ac5"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="5"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="50d2b9c3-5c09-4d87-b009-19ee2676fe3c"/>
@@ -3019,6 +2886,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="1bd0aeef-f95c-4c89-b7ed-0b10ccaf112e"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="4b3fe28e-6db1-4684-b64e-db228791f6c1"/>
@@ -3039,6 +2907,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="2fdd604a-d8ca-49a2-abe6-d4da74fafaa5"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="d2578fee-0a32-4ef6-83b6-c8b7a32d604c"/>
@@ -3076,6 +2945,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <param name="key" value="45f027ad-bba5-4ad3-a97b-62af5dbdf911"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="7"/>
       <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="2"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="6891cf03-2ba5-4ffa-8b3b-fa16bb8d5e06"/>
@@ -3089,6 +2959,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <param name="key" value="99e952d4-4df0-4939-b2cf-ca23552ef3eb"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="7"/>
       <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="12"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="d8bd935d-4c00-4d75-aa3a-3a8ebcc0f695"/>
@@ -3219,6 +3090,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <param name="key" value="1a918186-7fc2-4057-a5db-e08d08c9f34a"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="3"/>
       <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="6"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="63034954-6892-4c56-9b20-5c2ae9a7a23c"/>
@@ -3328,6 +3200,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="f58f0991-9ba0-484c-a193-8c872ab84812"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="6710fc7a-d4dd-4b39-a2c7-abc701f5a006"/>
@@ -3596,6 +3469,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
       <param name="key" value="a1172ce6-ad9e-48d9-b577-5b4a57799a3a"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="3"/>
       <param name="ca139410-30af-4684-abfd-7d5c267a7dfd" value="6"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="0955698a-ba2f-4746-a3d9-880eb9cc6703"/>
@@ -3620,6 +3494,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="673d01e9-a308-4809-9b3f-457003d0d3a9"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="623e6c86-b326-4de4-8acd-735f118e5b61"/>
@@ -3684,6 +3559,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="a94d4216-e8c8-4302-a7a9-7820e75ff986"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="2f85a74b-9be8-46a4-b68e-0bb6209a0494"/>
@@ -3692,6 +3568,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="7c7d5c4c-ee8e-4080-9278-13a67d6b1332"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="e2429464-958f-4328-a4d7-44f1de1d67f4"/>
@@ -3748,6 +3625,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="e15ce507-371b-4d67-aaf8-15ddaa6c1374"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="4eafc9fd-368e-4ed5-9f04-ed2922dcfe3d"/>
@@ -3768,6 +3646,7 @@ For K-long and HK observations, one shutter closed flat is obtained in order to 
     <paramset name="node">
       <param name="key" value="6fe6fd80-f197-4cbc-849e-69aa1e075283"/>
       <param name="3c790c7d-6f41-40a1-8a28-6bd99934b3d6" value="1"/>
+      <param name="fa526af7-3659-4a66-aa9e-9e131f746993" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="46296430-0713-4dbd-990a-2a5a18ffd9e6"/>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Base.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Base.scala
@@ -7,7 +7,7 @@ import edu.gemini.spModel.gemini.flamingos2.{SeqConfigFlamingos2, Flamingos2}
 
 trait Flamingos2Base[B <: SpFlamingos2BlueprintBase] extends GroupInitializer[B] {
 
-  implicit def pimpGmosN(obs:ISPObservation) = new {
+  implicit def f2ObsOps(obs:ISPObservation) = new {
 
     val ed = ObservationEditor[Flamingos2](obs, instrumentType, SeqConfigFlamingos2.SP_TYPE)
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Imaging.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Imaging.scala
@@ -27,7 +27,12 @@ case class Flamingos2Imaging(blueprint:SpFlamingos2BlueprintImaging) extends Fla
 
   val targetGroup = Seq(1, 2, 3)
   val baselineFolder = Seq.empty
-  val notes = Seq("F2 Imaging Notes")
+  val notes = Seq(
+    "F2 Imaging Notes",
+    "Imaging flats",
+    "Detector readout modes",
+    "Libraries"
+  )
 
   val science = Seq(1, 2)
   val cal     = Seq(3)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
@@ -44,9 +44,11 @@ case class Flamingos2Longslit(blueprint:SpFlamingos2BlueprintLongslit, exampleTa
   val baselineFolder = Seq.empty
   val notes = Seq(
     "F2 Long-Slit Notes",
-    "Repeats contain the ABBA offsets",
     "Use the same PA for science target and telluric",
-    "Detector readout modes")
+    "Repeats contain the ABBA offsets",
+    "Detector readout modes",
+    "Libraries"
+  )
 
   val scienceAndTellurics = Seq(12,15,16,18)
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Mos.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Mos.scala
@@ -1,49 +1,97 @@
 package edu.gemini.phase2.template.factory.impl.flamingos2
 
+import edu.gemini.phase2.template.factory.impl.{TemplateDb, Maybe}
 import edu.gemini.pot.sp.{ISPObservation, ISPGroup}
-import scala.collection.JavaConverters._
 import edu.gemini.spModel.gemini.flamingos2.blueprint.SpFlamingos2BlueprintMos
-import edu.gemini.phase2.template.factory.impl.TemplateDb
 
-case class Flamingos2Mos(blueprint:SpFlamingos2BlueprintMos) extends Flamingos2Base[SpFlamingos2BlueprintMos] {
+import scala.collection.JavaConverters._
+
+
+final case class Flamingos2Mos(blueprint:SpFlamingos2BlueprintMos) extends Flamingos2Base[SpFlamingos2BlueprintMos] {
 
 //  IF PRE-IMAGING REQUIRED = YES
-// 	    INCLUDE {21}
+//      INCLUDE {21}
 //
-//  INCLUDE {29}                              # Mask daytime image
+//  INCLUDE {29}                           # Mask daytime image
 //
-// 	INCLUDE {22,23}                           # Telluric std
-// 	INCLUDE {24,25,28}                        # Science
-// 	INCLUDE {26,27}                           # Telluric std
+//  INCLUDE {22,23}                           # Telluric std
+//  INCLUDE {24,25,28}                           # Science
+//  INCLUDE {26,27}                           # Telluric std
 //
-//  FOR {23,25,27,28}:                        # Science and Tellurics
-// 	    SET DISPERSER FROM PI
-//             Put FILTERS from PI into F2 ITERATOR
+//  FOR {23,25,27,28}:                           # Science and Tellurics
+//      SET DISPERSER FROM PI
+//          Put FILTERS from PI into F2 ITERATOR
 //
 //  FOR {21,22,23,24,25,26,27,28,29}:
 //      SET CONDITIONS FROM PI
 //
-//  FOR {24,25,28,29}:                         # MOS science
-//       SET "Custom MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN
-//           where:
-//           (N/S) is the site
-//           YYYYS is the semester, e.g. 2015A
-//           (Q/C/DD/SV/LP/FT) is the program type
-//           XXX is the program number, e.g. 001, or 012, or 123
-//           NN should be the string "NN" since the mask number is unknown
+//  FOR {24,25,28,29}:                              # MOS science
+//      SET "Custom MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN
+//          where:
+//          (N/S) is the site
+//          YYYYS is the semester, e.g. 2015A
+//          (Q/C/DD/SV/LP/FT) is the program type
+//          XXX is the program number, e.g. 001, or 012, or 123
+//          NN should be the string "NN" since the mask number is unknown
 
-  def preImaging = if (blueprint.preImaging) Seq(21) else Seq.empty
-  val targetGroup = preImaging ++ Seq(29,22,23,24,25,28,26,27)
-  val baselineFolder = Seq.empty
-  val notes = Seq("F2 MOS Notes")
+  def preImaging: Option[Int] =
+    if (blueprint.preImaging) Some(21) else None
 
-  val scienceAndTellurics = Seq(23,25,27,28)
+  override val targetGroup: Seq[Int] =
+    preImaging.foldRight(Seq(29,22,23,24,25,28,26,27)) { _ +: _ }
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = forObservations(grp, scienceAndTellurics, forScienceAndTellurics)
+  override val baselineFolder: Seq[Int] =
+    Seq.empty
 
-  def forScienceAndTellurics(obs:ISPObservation):Either[String, Unit] = for {
-    _ <- obs.setDisperser(blueprint.disperser).right
-    _ <- obs.setFilters(blueprint.filters.asScala).right
-  } yield ()
+  override val notes: Seq[String] =
+    Seq(
+      "F2 MOS Notes",
+      "Use the same PA for the MOS science target and telluric",
+      "Detector readout modes",
+      "Libraries",
+      "MOS Arcs and flats",
+      "MOS slits: only use slit widths of 4 pixels (0.72 arcsec) or larger. Slit length no less than 5 arcsec."
+    )
 
+  val scienceAndTellurics: Seq[Int] =
+    Seq(23,25,27,28)
+
+  override def initialize(grp:ISPGroup, db:TemplateDb): Maybe[Unit] =
+    forObservations(grp, scienceAndTellurics, forScienceAndTellurics)
+
+  /**
+    REL-3661 This will (almost) implement the feature of setting the custom
+    mask name from the program id.  The problem is that the program id is the
+    program id of the library program here (F2-BP) not the resulting science
+    program.  To fix it we need to pass the eventual program id down into
+    the `initialize` method. Basically add an SPProgramID to the parameter list
+    and bubble up as necessary.  I think there is one case where we won't have
+    it (TemplateServlet -- so it may need to be an argument to the servlet there)
+
+  val mosScience: Seq[Int] =
+    Seq(24,25,28,29)
+
+  override def initialize(grp:ISPGroup, db:TemplateDb): Maybe[Unit] =
+    for {
+      _ <- forObservations(grp, scienceAndTellurics, forScienceAndTellurics).right
+      _ <- forObservations(grp, mosScience,          forMosScience         ).right
+    } yield ()
+
+  def forScienceAndTellurics(obs:ISPObservation): Maybe[Unit] =
+    for {
+      _ <- obs.setDisperser(blueprint.disperser).right
+      _ <- obs.setFilters(blueprint.filters.asScala).right
+    } yield ()
+
+  def forMosScience(obs: ISPObservation): Maybe[Unit] =
+    obs.ed.updateInstrument { f2 =>
+      // Compute the mask name, if there is a program id.
+      val maskName = Option(obs.getProgramID).map { id =>
+        s"${id.toString.replaceAll("-", "")}-NN"
+      }.toRight("Missing program id.")
+
+      // Update the custom mask field in f2, if possible.
+      maskName.right.foreach(f2.setFpuCustomMask)
+    }
+  */
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/F2BlueprintTest.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/F2BlueprintTest.scala
@@ -35,15 +35,57 @@ class F2BlueprintTest extends TemplateSpec("F2_BP.xml") with SpecificationLike w
     } yield Flamingos2BlueprintImaging(f)
   }
 
+  implicit val ArbitraryFlamingos2BlueprintMos: Arbitrary[Flamingos2BlueprintMos] =
+    Arbitrary {
+      for {
+        d  <- arbitrary[Flamingos2Disperser]
+        fs <- Gen.nonEmptyListOf(arbitrary[Flamingos2Filter])
+        p  <- arbitrary[Boolean]
+      } yield Flamingos2BlueprintMos(d, fs, p)
+    }
+
+  "F2 Imaging" should {
+    "include all notes" in {
+      forAll { (b: Flamingos2BlueprintImaging) =>
+        expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
+          val notes = List(
+            "F2 Imaging Notes",
+            "Imaging flats",
+            "Detector readout modes",
+            "Libraries")
+          groups(sp).forall(tg => notes.forall(existsNote(tg, _)))
+        }
+      }
+    }
+  }
+
   "F2 Long-Slit" should {
-    "Include notes, REL-2628" in {
+    "include all notes" in {
       forAll { (b: Flamingos2BlueprintLongslit) =>
         expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
           val notes = List(
             "F2 Long-Slit Notes",
-            "Repeats contain the ABBA offsets",
             "Use the same PA for science target and telluric",
-            "Detector readout modes")
+            "Repeats contain the ABBA offsets",
+            "Detector readout modes",
+            "Libraries")
+          groups(sp).forall(tg => notes.forall(existsNote(tg, _)))
+        }
+      }
+    }
+  }
+
+  "F2 MOS" should {
+    "include all notes" in {
+      forAll { (b: Flamingos2BlueprintMos) =>
+        expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
+          val notes = List(
+            "F2 MOS Notes",
+            "Use the same PA for the MOS science target and telluric",
+            "Detector readout modes",
+            "Libraries",
+            "MOS Arcs and flats",
+            "MOS slits: only use slit widths of 4 pixels (0.72 arcsec) or larger. Slit length no less than 5 arcsec.")
           groups(sp).forall(tg => notes.forall(existsNote(tg, _)))
         }
       }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/F2BlueprintTest.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/F2BlueprintTest.scala
@@ -90,6 +90,19 @@ class F2BlueprintTest extends TemplateSpec("F2_BP.xml") with SpecificationLike w
         }
       }
     }
+
+    "include MOS observations" in {
+      forAll { (b: Flamingos2BlueprintMos) =>
+        val incl = Range.inclusive(if (b.preImaging) 31 else 32, 39).toSet
+        val excl = if (b.preImaging) Set.empty[Int] else Set(31)
+        expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
+          groups(sp).forall { tg =>
+            val ls = libs(tg)
+            ls.filter(incl) == incl && !ls.exists(excl)
+          }
+        }
+      }
+    }
   }
 
   // REL-3661: As of 2019B, F2 imaging can include darks.


### PR DESCRIPTION
This PR fixes a few issues with skeleton creation and template instantiation for F2.

* All notes should now be included
* The order of observations should be what is expected
* Conditions should be copied in when instantiating

Inexplicably, we sort the observations by library id so I had to renumber the ids in the XML and p-code.

I removed the explicit conditions from the XML because they were preventing the template conditions from being used.

It doesn't include the logic for setting the custom mask name since it relies on having the program id, which isn't available.  I left a bit of code commented out that may do the trick if add a parameter to initialize to pass in the program id.