### PR TITLE
REL-3607: Set Zorro wavelength to be the same as Alopeke

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
@@ -10,13 +10,15 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
   val seqConfigCompType = VisitorInstrument.SP_TYPE
 
   val AlopekeWavelength: Double = 0.674
+  val ZorroWavelength: Double   = 0.674
   val DssiWavelength: Double    = 0.700
 
   private val WavelengthMapping: List[(String, Double)] =
     List(
       "alopeke" -> AlopekeWavelength,
-      "dssi"    -> DssiWavelength
-    )
+      "zorro"   -> ZorroWavelength
+  "dssi"    -> DssiWavelength
+  )
 
 
   implicit def pimpInst(obs: ISPObservation) = new {
@@ -53,7 +55,7 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
   private def wavelength: Double = {
     val inst = blueprint.name.toLowerCase
     WavelengthMapping.collectFirst { case (n, w) if inst.contains(n) => w }
-                     .getOrElse(0.0)
+      .getOrElse(0.0)
   }
 
   def setWavelength = Setter[Double](wavelength)(_.setWavelength(_))

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
@@ -16,8 +16,8 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
   private val WavelengthMapping: List[(String, Double)] =
     List(
       "alopeke" -> AlopekeWavelength,
-      "zorro"   -> ZorroWavelength
-  "dssi"    -> DssiWavelength
+      "zorro"   -> ZorroWavelength,
+      "dssi"    -> DssiWavelength
   )
 
 


### PR DESCRIPTION
When Zorro was added, it should have had the same wavelength as Alopeke, but due to not including it in `VisitorBase`, it defaulted to the visitor wavelength.

This fixes that problem so that now Alopeke and Zorro have the same wavelength.