### PR TITLE
Turn off reports by default in g[ns]odbtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ project/OcsCredentials.scala
 .metals
 .vscode
 .bloop
+
+# Vim
+*.swp

--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -427,7 +427,8 @@ def odbtest(version: Version) = AppConfig(
     "edu.gemini.dbTools.tcs.ephemeris.directory" -> "/home/software/ugemini/ephemerides",
     "edu.gemini.smartgcal.svnRootUrl"            -> "http://source.gemini.edu/gcal/branches/development/calibrations",
     "edu.gemini.spdb.dir"                        -> "/home/software/ugemini/spdb/spdb.active",
-    "edu.gemini.util.trpc.name"                  -> "Gemini ODB (Test)"
+    "edu.gemini.util.trpc.name"                  -> "Gemini ODB (Test)",
+    "org.osgi.framework.startlevel.beginning"    -> "50"
   )
 ) extending List(with_remote_gogo(version), odbtest_credentials(version))
 

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/Configuration.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/Configuration.scala
@@ -28,15 +28,16 @@ case class Configuration(
   // Default; this can be overridden in instances
   def startLevel(b: BundleSpec): Int =
     b.name.split("\\.").toList match {
-      case "edu" :: "gemini" :: "osgi" :: "main" :: Nil  => 0
-      case "org" :: "osgi"       :: _                    => 5
-      case "org" :: "scala-lang" :: _                    => 10
-      case "org" :: "scalaz"     :: _                    => 15
-      case "edu" :: "gemini"     :: "model" :: "p1" :: _ => 30
-      case "edu" :: "gemini"     :: "dataman" :: _       => 100
-      case "edu" :: "gemini"     :: _                    => 50
-      case "org" :: "jsky"       :: _                    => 50
-      case _                                             => 40
+      case "edu" :: "gemini"     :: "osgi"    :: "main"    :: Nil                 =>   0
+      case "org" :: "osgi"       :: _                                             =>   5
+      case "org" :: "scala-lang" :: _                                             =>  10
+      case "org" :: "scalaz"     :: _                                             =>  15
+      case "edu" :: "gemini"     :: "dataman" :: _                                => 100
+      case "edu" :: "gemini"     :: "model"   :: "p1"      :: _                   =>  30
+      case "edu" :: "gemini"     :: "spdb"    :: "reports" :: "collection" :: Nil =>  60
+      case "edu" :: "gemini"     :: _                                             =>  50
+      case "org" :: "jsky"       :: _                                             =>  50
+      case _                                                                      =>  40
     }
 
   def extending(c: Configuration) = copy(


### PR DESCRIPTION
The reports service does not run reliably in `g[ns]odbtest`.  This is apparently related to the polling of EPICS weather channels in the test environment and results in pegging the CPU and the inability to turn off either the reports bundle itself or the `spdb` process as a whole.  It would be nice to find out why the EPICS channels cannot be monitored in the test environment, but in lieu of that we can also just skip it for the test servers.  That's what this PR accomplishes.  Specifically it

* runs the reports bundle at level 60
* sets the default startlevel to 50 in the `g[ns]odbtest` configurations

Yes, this is a hack.