### PR TITLE
REL-3696: fix Update from ICTD issues

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/Schedule.java
@@ -359,14 +359,15 @@ public final class Schedule extends BaseMutableBean implements PioSerializable, 
 
     @SuppressWarnings("unchecked")
     public void setIctdSummary(Option<IctdSummary> ictd) {
-        final Option<IctdSummary> prev = this.ictdSummary;
-
         invalidateAllCaches();
 
         this.ictdSummary = ictd;
         doPublicFacilitiesUpdate(() -> ictd.foreach(i -> matchFacilitiesToIctd(i.featureAvailabilityJava())));
 
-        firePropertyChange(PROP_ICTD, prev, ictd);
+        // REL-3696: always fire the ICTD update property regardless of whether
+        // anything changed (previous is `null`) so that listeners respond to
+        // the update and reset to ICTD values.
+        firePropertyChange(PROP_ICTD, null, ictd);
     }
 
     /**

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
@@ -145,7 +145,7 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
                     final Object      o = n.getUserObject();
                     if (o != null && o instanceof Enum) {
                         ImOption.apply(m.get((Enum) o)).foreach(a ->
-                            n.setSelected(a == Availability.Installed)
+                            n.setSelectedCorrectly(a == Availability.Installed)
                         );
                     }
                 }

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/OutlineNode.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/OutlineNode.java
@@ -4,19 +4,21 @@ import java.util.List;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 
-import edu.gemini.spModel.gemini.gmos.GmosCommonType;
 import edu.gemini.spModel.type.DisplayableSpType;
 
 
 @SuppressWarnings("serial")
-public class OutlineNode extends DefaultMutableTreeNode {
+public final class OutlineNode extends DefaultMutableTreeNode {
 
-    
-    public enum TriState {    SELECTED, UNSELECTED, INDEFINITE }
+    public enum TriState { SELECTED, UNSELECTED, INDEFINITE }
 
-    private TriState selected = TriState.UNSELECTED;
+    public static TriState triStateFromBoolean(boolean selected) {
+        return selected ? TriState.SELECTED : TriState.UNSELECTED;
+    }
+
+    private TriState triState = TriState.UNSELECTED;
     private boolean adjusting;
-    
+
     public OutlineNode() {
         super();
     }
@@ -26,9 +28,9 @@ public class OutlineNode extends DefaultMutableTreeNode {
     }
 
     public TriState getSelected() {
-        return selected;
+        return triState;
     }
-    
+
     /**
      * When a node is selected or deselected, the change is pushed down
      * recursively to all children, and pushed up to the parent. Setting
@@ -38,7 +40,7 @@ public class OutlineNode extends DefaultMutableTreeNode {
      */
     @SuppressWarnings("unchecked")
     public synchronized void setSelected(boolean selected) {
-        this.selected = selected ? TriState.SELECTED : TriState.UNSELECTED;
+        this.triState = triStateFromBoolean(selected);
         if (getChildCount() > 0) {
             adjusting = true;
             for (OutlineNode node: (List<OutlineNode>) children)
@@ -46,13 +48,13 @@ public class OutlineNode extends DefaultMutableTreeNode {
             adjusting = false;
         }
         if (getParent() != null)
-            ((OutlineNode) getParent()).childChanged(this.selected);
+            ((OutlineNode) getParent()).childChanged(this.triState);
     }
 
-    @SuppressWarnings("unchecked") 
-    void childChanged(TriState childSelected) {
-        if (!adjusting) {            
-            outer: switch (selected) {
+    @SuppressWarnings("unchecked")
+    private void childChanged(TriState childSelected) {
+        if (!adjusting) {
+            outer: switch (triState) {
 
             // If we are currently in a definited select state, our new state will
             // be indefinite if there is more than one child, or the same as the one
@@ -60,8 +62,13 @@ public class OutlineNode extends DefaultMutableTreeNode {
             case SELECTED:
             case UNSELECTED:
                 // REL-293: Should be able to deselect oiwfs without deselecting parent inst
+                // (SW 6/26/19: NICI has only one child, NICI OIWFS which
+                //  apparently is the source of problem. I think it should be
+                //  solved in some other way though that doesn't destroy the
+                //  plain meaning of the "tristate" selection tree. Perhaps a
+                //  separate "Guiding" branch with the guiders in it?)
 //                selected = (getChildCount() == 1) ? childSelected : TriState.INDEFINITE;
-                selected = TriState.INDEFINITE;
+                triState = TriState.INDEFINITE;
                 break;
 
             // If our current state is indefinite and the child is definite, we need
@@ -73,19 +80,91 @@ public class OutlineNode extends DefaultMutableTreeNode {
                     if (node.getSelected() != state)
                         break outer; // still indefinite
                 }
-                selected = state;
-                
+                triState = state;
+
             }
-            
+
         }
     }
-    
+
+    //
+    // The following `setSelected` implementation corrects issues with the
+    // previous version that keeps "Update from ICTD" from working as expected.
+    // Unfortunately there seems to be some, on the surface of it, odd behavior
+    // related to REL-293 that we are now relying upon?  It also doesn't
+    // continue up the entire tree updating parents when a child node is
+    // updated. I'm worried about replacing the previous version that is used by
+    // the UI and am just adding an option to do it "correctly" for the
+    // "Update from ICTD" feature.
+    //
+
+    /**
+     * When a node is selected or deselected, the change is pushed down
+     * recursively to all children, and pushed up through the ancestors. Setting
+     * the state is a boolean operation, but reading the state may return
+     * a third indefinite value.
+     */
+    public void setSelectedCorrectly(boolean selected) {
+        setSelectedCorrectly(selected, true);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setSelectedCorrectly(boolean selected, boolean updateAncestors) {
+        final TriState orig = this.triState;
+        this.triState       = triStateFromBoolean(selected);
+
+        if (orig != this.triState) {
+            if (!isLeaf()) {
+                // There's no need in this case to update the children's ancestors
+                // since we're doing it here.
+                ((List<OutlineNode>) children).forEach(n -> n.setSelectedCorrectly(selected, false));
+            }
+
+            if (updateAncestors && (getParent() != null)) {
+                // Walk up the tree updating ancestor nodes correctly.
+                ((OutlineNode) getParent()).childChangedCorrectly(this.triState);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void childChangedCorrectly(final TriState updatedChildTriState) {
+        final TriState orig = this.triState;
+
+        switch (this.triState) {
+            // Here we are only called because the child tristate changed.
+            // If we are currently in a definite select state, our new state
+            // will be indefinite if there is more than one child since we
+            // know that the child now differs from the other siblings, or
+            // the same as the one and only child if there is only one.
+            case SELECTED:
+            case UNSELECTED:
+                this.triState = (getChildCount() == 1) ? updatedChildTriState : TriState.INDEFINITE;
+                break;
+
+            // If our current state is indefinite and the child is definite,
+            // we need to look at all the children.
+            case INDEFINITE:
+                if (updatedChildTriState == TriState.INDEFINITE) break; // easy out, nothing changes
+
+                if (((List<OutlineNode>) children).stream().allMatch(n -> n.getSelected() == updatedChildTriState)) {
+                    this.triState = updatedChildTriState;
+                }
+
+        }
+
+        // Keep going up the tree all the way to the root.
+        if ((orig != this.triState) && (getParent() != null)) {
+            ((OutlineNode) getParent()).childChangedCorrectly(this.triState);
+        }
+    }
+
     @Override
     public String toString() {
         if (userObject instanceof DisplayableSpType) {
             return ((DisplayableSpType) userObject).displayValue();
-        }        
+        }
         return super.toString();
     }
-    
+
 }


### PR DESCRIPTION
The QPT "Update from ICTD" command was only working when there were in fact updates to the information in the ICTD.  The user quite naturally expected to use this feature to restore the values from the ICTD after they had been manipulated in the QPT "Instrument" feature tree.  That wasn't working because:

* Since the ICTD information didn't update no event was triggered and no updates to the selected features were done.
* The `OutlineNode` has some odd selection behavior in its `setSelected` implementation.  Out of extreme hubris and tempting fate, I created a new version called `setSelectedCorrectly` that is only used by the "Update from ICTD" feature. With this in place, the parent nodes are updated to reflect the state of their child nodes as expected.