### PR TITLE
REL-3698: more logging

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/AbortObserveEvent.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/AbortObserveEvent.java
@@ -5,6 +5,7 @@
 package edu.gemini.spModel.event;
 
 import edu.gemini.pot.sp.SPObservationID;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioParseException;
 import edu.gemini.spModel.pio.Pio;
@@ -17,7 +18,7 @@ public final class AbortObserveEvent extends ObsExecEvent {
 
     public static final String REASON_PARAM = "reason";
 
-    private String _reason;
+    private final String _reason;
 
     public AbortObserveEvent(long time, SPObservationID obsId, String reason) {
         super(time, obsId);
@@ -75,5 +76,14 @@ public final class AbortObserveEvent extends ObsExecEvent {
 
     public String getName() {
         return "Abort Observe";
+    }
+
+    @Override
+    public String toStringProperties() {
+        return String.format(
+            "%s, reason=%s",
+            super.toStringProperties(),
+            ImOption.apply(_reason).map(s -> String.format("'%s'", s)).getOrNull()
+        );
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/EndDatasetEvent.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/EndDatasetEvent.java
@@ -88,11 +88,11 @@ public final class EndDatasetEvent extends ObsExecEvent {
     }
 
     @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("EndDatasetEvent{");
-        sb.append("timestamp=").append(getTimestamp()).append(", ");
-        sb.append("datasetLabel=").append(_datasetLabel);
-        sb.append('}');
-        return sb.toString();
+    public String toStringProperties() {
+        return String.format(
+            "%s, datasetLabel=%s",
+            super.toStringProperties(),
+            _datasetLabel
+        );
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/EndIdleEvent.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/EndIdleEvent.java
@@ -32,4 +32,9 @@ public final class EndIdleEvent extends ExecEvent {
         return "End Idle";
     }
 
+    @Override
+    public String toStringProperties() {
+        return "";
+    }
+
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/ExecEvent.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/ExecEvent.java
@@ -7,6 +7,8 @@ import edu.gemini.spModel.pio.PioParseException;
 import edu.gemini.shared.util.GeminiRuntimeException;
 
 import java.io.Serializable;
+import java.time.Instant;
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import java.util.Comparator;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -148,4 +150,20 @@ public abstract class ExecEvent implements Serializable {
      * Returns a human-readable name for the event.
      */
     public abstract String getName();
+
+    @Override
+    public String toString() {
+        final String subProps          = toStringProperties();
+        final String formattedSubProps = "".equals(subProps) ? "" : ", " + subProps;
+
+        return String.format(
+            "%s {timestamp=%d (%s)%s}",
+            getName(),
+            _timestamp,
+            ISO_INSTANT.format(Instant.ofEpochMilli(_timestamp)),
+            formattedSubProps
+        );
+    }
+
+    protected abstract String toStringProperties();
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/ObsExecEvent.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/ObsExecEvent.java
@@ -80,4 +80,9 @@ public abstract class ObsExecEvent extends ExecEvent {
         return 37 * res + _obsId.hashCode();
     }
 
+    @Override
+    protected String toStringProperties() {
+        return String.format("obsId=%s", _obsId);
+    }
+
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/PauseObserveEvent.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/PauseObserveEvent.java
@@ -5,6 +5,7 @@
 package edu.gemini.spModel.event;
 
 import edu.gemini.pot.sp.SPObservationID;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioParseException;
 import edu.gemini.spModel.pio.Pio;
@@ -17,7 +18,7 @@ public final class PauseObserveEvent extends ObsExecEvent {
 
     public static final String REASON_PARAM = "reason";
 
-    private String _reason;
+    private final String _reason;
 
     public PauseObserveEvent(long time, SPObservationID obsId, String reason) {
         super(time, obsId);
@@ -75,6 +76,15 @@ public final class PauseObserveEvent extends ObsExecEvent {
 
     public String getName() {
         return "Pause Observe";
+    }
+
+    @Override
+    public String toStringProperties() {
+        return String.format(
+            "%s, reason=%s",
+            super.toStringProperties(),
+            ImOption.apply(_reason).map(s -> String.format("'%s'", s)).getOrNull()
+        );
     }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/StartDatasetEvent.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/StartDatasetEvent.java
@@ -73,11 +73,11 @@ public final class StartDatasetEvent extends ObsExecEvent {
     }
 
     @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("StartDatasetEvent{");
-        sb.append("timestamp=").append(getTimestamp()).append(", ");
-        sb.append("dataset=").append(_dataset);
-        sb.append('}');
-        return sb.toString();
+    public String toStringProperties() {
+        return String.format(
+            "%s, dataset=%s",
+            super.toStringProperties(),
+            _dataset
+        );
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/StartIdleEvent.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/event/StartIdleEvent.java
@@ -4,6 +4,7 @@
 
 package edu.gemini.spModel.event;
 
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioParseException;
 import edu.gemini.spModel.pio.Pio;
@@ -16,7 +17,7 @@ public final class StartIdleEvent extends ExecEvent {
 
     public static final String REASON_PARAM = "reason";
 
-    private String _reason;
+    private final String _reason;
 
     public StartIdleEvent(long time, String reason) {
         super(time);
@@ -75,4 +76,13 @@ public final class StartIdleEvent extends ExecEvent {
     public String getName() {
         return "Start Idle";
     }
+
+    @Override
+    public String toStringProperties() {
+        return String.format(
+            "reason=%s",
+            ImOption.apply(_reason).map(s -> String.format("'%s'", s)).getOrNull()
+        );
+    }
+
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsExecEventHandler.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/ObsExecEventHandler.java
@@ -66,8 +66,8 @@ public final class ObsExecEventHandler {
         }
 
         @Override public void endDataset(ExecEvent event) { updateObsLog(); }
-        
-        private void updateObsLog() { updateObsLog(None.<DatasetLabel>instance()); }
+
+        private void updateObsLog() { updateObsLog(None.instance()); }
 
         private void updateObsLog(Option<DatasetLabel> label) {
             ObsExecLog.updateObsLog(db, obs.getObservationID(), label, new Some<ObsExecEvent>(evt));

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obslog/ObsExecLog.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obslog/ObsExecLog.java
@@ -261,6 +261,7 @@ public final class ObsExecLog extends AbstractDataObject implements ISPMergeable
                 seqData.foreach(sd -> log.execLogDataObject.setCompletedSteps(sd.seq, sd.label));
 
             } catch (Exception ex) {
+                LOG.log(Level.WARNING, String.format("Could not update %s ObsLog for event: %s", obsId, evt.getOrNull()), ex);
                 throw new RuntimeException(ex);
             }
         });

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/ObsExecRecord.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/ObsExecRecord.java
@@ -257,10 +257,12 @@ public final class ObsExecRecord implements Serializable {
     private synchronized void _handleStartDataset(Dataset dataset, Config config) {
         _cleanupTentativeDataset();
 
-        DatasetLabel label = dataset.getLabel();
+        final DatasetLabel label = dataset.getLabel();
         _tentativeDataset = dataset;
         if (config == null) config = new DefaultConfig();
         _tentativeConfig  = config;
+
+        LOG.info(String.format("Now expecting end dataset for '%s'.", label));
 
         // Add the dataset to the map, creating the DatasetRecord wrapper
         // for it.  Only do this for new datasets though. It would be best
@@ -303,6 +305,7 @@ public final class ObsExecRecord implements Serializable {
         _configStore.addConfigAndLabel(_tentativeConfig, label);
         _tentativeDataset = null;
         _tentativeConfig  = null;
+        LOG.info(String.format("Processed end dataset for '%s'.", label));
     }
 
     // Called to cleanup data structures when we don't receive the events

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/DatasetCompleteEvent.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/DatasetCompleteEvent.java
@@ -10,11 +10,13 @@ import edu.gemini.pot.sp.SPObservationID;
  * Specialized <tt>{@link SessionEvent}</tt> used to indicate that a dataset
  * has been collected and completed.
  */
-public class DatasetCompleteEvent extends SessionEvent {
+public final class DatasetCompleteEvent extends SessionEvent {
+
     // The dataset label
-    private String _dataLabel;
+    private final String _dataLabel;
+
     // The matching filename
-    private String _fileName;
+    private final String _fileName;
 
     /**
      * Specialized <tt>{@link SessionEvent}</tt> used to indicate that a dataset

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/DatasetStartEvent.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/DatasetStartEvent.java
@@ -10,11 +10,12 @@ import edu.gemini.pot.sp.SPObservationID;
  * Specialized <tt>{@link SessionEvent}</tt> used to indicate that a dataset
  * has been started.
  */
-public class DatasetStartEvent extends SessionEvent {
+public final class DatasetStartEvent extends SessionEvent {
+
     // The dataset label
-    private String _dataLabel;
+    private final String _dataLabel;
     // The matching filename
-    private String _fileName;
+    private final String _fileName;
 
     /**
      * Specialized <tt>{@link SessionEvent}</tt> used to indicate that a dataset
@@ -29,7 +30,7 @@ public class DatasetStartEvent extends SessionEvent {
         super(src, observationID, EventMsg.DATASET_START);
         if (dataLabel == null) throw new NullPointerException();
         _dataLabel = dataLabel;
-        _fileName = fileName;
+        _fileName  = fileName;
     }
 
     /**

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/ObservationAbortEvent.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/ObservationAbortEvent.java
@@ -11,9 +11,10 @@ import edu.gemini.pot.sp.SPObservationID;
  * observation has aborted with a reason why.
  *
  */
-public class ObservationAbortEvent extends SessionEvent {
+public final class ObservationAbortEvent extends SessionEvent {
+
     // The optional reason for the abort
-    private String _reason;
+    private final String _reason;
 
     /**
      * Specialized <tt>{@link SessionEvent}</tt> used to indicate that a session

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/ObservationPauseEvent.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/ObservationPauseEvent.java
@@ -11,9 +11,10 @@ import edu.gemini.pot.sp.SPObservationID;
  * observation has aborted with a reason why.
  *
  */
-public class ObservationPauseEvent extends SessionEvent {
+public final class ObservationPauseEvent extends SessionEvent {
+
     // The optional reason for the abort
-    private String _reason;
+    private final String _reason;
 
     /**
      * Specialized <tt>{@link SessionEvent}</tt> used to indicate that a session

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/ObservationStopEvent.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/ObservationStopEvent.java
@@ -5,15 +5,17 @@
 package edu.gemini.wdba.session;
 
 import edu.gemini.pot.sp.SPObservationID;
+import edu.gemini.shared.util.immutable.ImOption;
 
 /**
  * Specialized <tt>{@link SessionEvent}</tt> used to indicate that a session
  * observation has stopped with a reason why.
  *
  */
-public class ObservationStopEvent extends SessionEvent {
+public final class ObservationStopEvent extends SessionEvent {
+
     // The optional reason for the stopping
-    private String _reason;
+    private final String _reason;
 
     /**
      * Specialized <tt>{@link SessionEvent}</tt> used to indicate that a session

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/SequenceStartEvent.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/SequenceStartEvent.java
@@ -10,9 +10,10 @@ import edu.gemini.pot.sp.SPObservationID;
  * Specialized <tt>{@link SessionEvent}</tt> used to indicate the start of an
  * observation's sequence.
  */
-public class SequenceStartEvent extends SessionEvent {
+public final class SequenceStartEvent extends SessionEvent {
+
     // The starting filename
-    private String _startFileName;
+    private final String _startFileName;
 
     /**
      * Specialized <tt>{@link SessionEvent}</tt> used to indicate that a dataset

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/SessionEvent.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/SessionEvent.java
@@ -16,11 +16,10 @@ import java.util.EventObject;
  * that require more information.
  */
 public class SessionEvent extends EventObject {
-    // Used when the observation id isn't needed
 
-    private EventMsg _msg;
-    private SPObservationID _observationID;
-    private long _time;
+    private final EventMsg _msg;
+    private final SPObservationID _observationID;
+    private final long _time;
 
     /**
      * Creates with the source the state itself, the sessionId, and the observationId.
@@ -34,22 +33,10 @@ public class SessionEvent extends EventObject {
      */
     public SessionEvent(Object source, SPObservationID observationID, EventMsg msg) {
         super(source);
-        _observationID = observationID;
-        _msg = msg;
-        _time = System.currentTimeMillis();
-    }
 
-    /**
-     * A copy constructor that takes a current event and a new message.  Used for creating new events
-     * from ones that have been received.  Note the time is that of the current event.
-     * @param evt A <code>SessionEvent</code> or subclass
-     * @param msg An <code>EventMsg</code>
-     */
-    public SessionEvent(SessionEvent evt, EventMsg msg) {
-        super(evt.getSource());
-        //_observationID = evt.getObservationID();
-        _time = evt.getTime();
-        _msg = msg;
+        _observationID = observationID;
+        _msg           = msg;
+        _time          = System.currentTimeMillis();
     }
 
     /**

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/SessionXmlRpcHandler.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/SessionXmlRpcHandler.java
@@ -11,8 +11,36 @@ import edu.gemini.wdba.glue.api.WdbaContext;
 import edu.gemini.wdba.xmlrpc.ISessionXmlRpc;
 import edu.gemini.wdba.xmlrpc.ServiceException;
 
+import java.util.logging.Logger;
 import java.util.List;
 import java.util.Map;
+
+//
+// Note, you can run these interactively from the command line via curl.  To do
+// so start your ODB and create an XML file that corresponds to the request.
+// Then just send it with
+//
+//    curl curl --data @req.xml http://localhost:8442/wdba
+//
+// An example request:
+//
+//<?xml version="1.0"?>
+//<methodCall>
+//  <methodName>WDBA_Session.sequenceStart</methodName>
+//  <params>
+//    <param>
+//      <value>session-0</value>
+//    </param>
+//    <param>
+//      <value>GS-2019A-Q-600-1</value>
+//    </param>
+//    <param>
+//      <value>S20190627S0001</value>
+//    </param>
+//  </params>
+//</methodCall>
+//
+//
 
 /**
  * Implementation of the OCS Session functionality.
@@ -21,6 +49,23 @@ import java.util.Map;
  * @author K.Gillies
  */
 public final class SessionXmlRpcHandler implements ISessionXmlRpc {
+
+    private static final Logger LOG = Logger.getLogger(SessionXmlRpcHandler.class.getName());
+
+    // SessionXmlRpcHandler appears to be an entry point for receiving events
+    // from the SeqExec so we'll log each call here.
+    private static void log(String method, String... args) {
+        final List<String> as = new java.util.ArrayList<>();
+        for (int i=0; i<args.length; i+=2) {
+            final String rhs = args[i];
+            final String lhs = (args[i+1] == null) ? "null" : "'" + args[i+1] + "'";
+            as.add(rhs + "=" + lhs);
+        }
+        LOG.info(as.stream().collect(
+            java.util.stream.Collectors.joining(", ", method + "(", ")")
+        ));
+    }
+
 
     // Create the "SessionManagement" instance when we have the WdbaContext.
     // Unfortunately SessionXmlRpcHandler has to have a no-args constructor so
@@ -152,6 +197,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * Sender indicates that an observation has started.
      */
     public boolean observationStart(String sessionId, String observationId) throws ServiceException {
+        log("observationStart", "sessionId", sessionId, "observationId", observationId);
         return sm().observationStart(sessionId, observationId);
     }
 
@@ -160,6 +206,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * the idle state.
      */
     public boolean observationEnd(String sessionId, String observationId) throws ServiceException {
+        log("observationEnd", "sessionId", sessionId, "observationId", observationId);
         return sm().observationEnd(sessionId, observationId);
     }
 
@@ -168,6 +215,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * a category for why it is idle.
      */
     public boolean setIdleCause(String sessionId, String category, String comment) throws ServiceException {
+        log("setIdleCause", "sessionId", sessionId, "category", category, "comment", comment);
         return sm().setIdleCause(sessionId, category, comment);
     }
 
@@ -175,6 +223,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * Indicate that the sequence of the observation in the session is started.
      */
     public boolean sequenceStart(String sessionId, String observationId, String startFileName) throws ServiceException {
+        log("sequenceStart", "sessionId", sessionId, "observationId", observationId, "startFileName", startFileName);
         return sm().sequenceStart(sessionId, observationId, startFileName);
     }
 
@@ -182,6 +231,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * Indicates that the sequence for the observation has ended.
      */
     public boolean sequenceEnd(String sessionId, String observationId) throws ServiceException {
+        log("sequenceEnd", "sessionId", sessionId, "observationId", observationId);
         return sm().sequenceEnd(sessionId, observationId);
     }
 
@@ -189,6 +239,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * Indicate that the sequence or observation has been abandoned for a specific reason.
      */
     public boolean observationAbort(String sessionId, String observationId, String reason) throws ServiceException {
+        log("observationAbort", "sessionId", sessionId, "observationId", observationId, "reason", reason);
         return sm().observationAbort(sessionId, observationId, reason);
     }
 
@@ -196,6 +247,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * Indicate that the sequence or observation has been paused for a specific reason.
      */
     public boolean observationPause(String sessionId, String observationId, String reason) throws ServiceException {
+        log("observationPause", "sessionId", sessionId, "observationId", observationId, "reason", reason);
         return sm().observationPause(sessionId, observationId, reason);
     }
 
@@ -203,6 +255,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * Indicate that the sequence or observation has been stopped for a specific reason.
      */
     public boolean observationStop(String sessionId, String observationId, String reason) throws ServiceException {
+        log("observationStop", "sessionId", sessionId, "observationId", observationId, "reason", reason);
         return sm().observationStop(sessionId, observationId, reason);
     }
 
@@ -210,6 +263,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * Indicate that the sequence or observation has been paused for a specific reason.
      */
     public boolean observationContinue(String sessionId, String observationId) throws ServiceException {
+        log("observationContinue", "sessionId", sessionId, "observationId", observationId);
         return sm().observationContinue(sessionId, observationId);
     }
 
@@ -217,6 +271,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * Indicates that the observe to collect a dataset has started
      */
     public boolean datasetStart(String sessionId, String observationId, String datasetId, String fileName) throws ServiceException {
+        log("datasetStart", "sessionId", sessionId, "observationId", observationId, "datasetId", datasetId, "fileName", fileName);
         return sm().datasetStart(sessionId, observationId, datasetId, fileName);
     }
 
@@ -224,6 +279,7 @@ public final class SessionXmlRpcHandler implements ISessionXmlRpc {
      * Indicates that one of the datasets for the observation has been completed.
      */
     public boolean datasetComplete(String sessionId, String observationId, String datasetId, String fileName) throws ServiceException {
+        log("datasetComplete", "sessionId", sessionId, "observationId", observationId, "datasetId", datasetId, "fileName", fileName);
         return sm().datasetComplete(sessionId, observationId, datasetId, fileName);
     }
 }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/dbup/AllEventsLoggingService.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/dbup/AllEventsLoggingService.java
@@ -118,6 +118,10 @@ public class AllEventsLoggingService extends AbstractSessionEventConsumer implem
         }
     }
 
+    public String getName() {
+        return "AllEventsLoggingService";
+    }
+
     public void doMsgUpdate(ExecEvent evt) throws WdbaGlueException {
         try {
             evt.doAction(_action);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/dbup/DBUpdateService.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/session/dbup/DBUpdateService.java
@@ -82,18 +82,20 @@ public class DBUpdateService extends AbstractSessionEventConsumer {
         nightlyRecord.addObservation(obsId);
         nightlyRecordNode.setDataObject(nightlyRecord);
 
-        LOG.info("Added observation ID to nightly plan: " + obsId.stringValue());
+        LOG.info("Added observation ID to nightly record: " + obsId.stringValue());
+    }
+
+    public String getName() {
+        return "DBUpdateService";
     }
 
     public void doMsgUpdate(ExecEvent evt) throws WdbaGlueException {
         try {
             if (evt instanceof StartSequenceEvent) {
-                ObsExecEvent oevt = (ObsExecEvent) evt;
-                SPObservationID obsId = oevt.getObsId();
-                _addToNightlyRecord(obsId);
+                _addToNightlyRecord(((ObsExecEvent) evt).getObsId());
             }
             if (evt instanceof ObsExecEvent) {
-                WdbaDatabaseAccessService dbAccess = _context.getWdbaDatabaseAccessService();
+                final WdbaDatabaseAccessService dbAccess = _context.getWdbaDatabaseAccessService();
                 ObsExecEventFunctor.handle((ObsExecEvent) evt, dbAccess.getDatabase(), _context.user);
             }
         } catch (Throwable ex) {


### PR DESCRIPTION
REL-3698 concerns an end dataset event that was apparently received but not processed.  It isn't clear from the logs what happened.  This PR simply tightens a few loose screws, removes some unused code, and adds more logging that might help diagnose the issue or at least narrow the search space if it comes up again.