### PR TITLE
REL-3695: NonSidereal Phase 2 Checks

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameEditor.scala
@@ -20,6 +20,10 @@ import jsky.util.gui.{DialogUtil, TextBoxWidget, TextBoxWidgetWatcher}
 import scala.swing.Swing
 import scalaz._, Scalaz._, effect.IO, concurrent.Task
 
+/**
+ * Edits a non-sidereal target name, resolving it to a unique HorizonsDesignation
+ * using NonSiderealNameResolver and then looking up the associated ephemeris.
+ */
 final class NonSiderealNameEditor extends TelescopePosEditor[SPTarget] with ReentrancyHack {
   import HorizonsService2.{ Search, Row }, Search._
 
@@ -27,103 +31,31 @@ final class NonSiderealNameEditor extends TelescopePosEditor[SPTarget] with Reen
   private[this] var start = Option.empty[Long]
   private[this] var spt   = new SPTarget // never null
 
-  // A module of actions for displaying status in the GlassPane
-  val ui = EphemerisUpdater.UI(name)
-
-  val askSearch: HS2[Option[Search[_ <: HorizonsDesignation]]] =
-    HS2.delay {
-      case class Wrapper(unwrap: Search[_ <: HorizonsDesignation]) {
-        override def toString = unwrap.productPrefix
-      }
-      Option {
-        JOptionPane.showInputDialog(
-          name,
-          "Select the HORIZONS target type:",
-          "Horizons Search",
-          JOptionPane.QUESTION_MESSAGE,
-          null, // TODO: icon
-          List(Comet, Asteroid, MajorBody).map(f => Wrapper(f(name.getText))).toArray[Object],
-          null)
-      } .map(_.asInstanceOf[Wrapper].unwrap)
-    }
-
   def lookup(d: HorizonsDesignation, site: Site): HS2[Ephemeris] =
     start.fold(Ephemeris.empty.point[HS2]) { when =>
-      ui.show(s"Fetching Ephemeris ...") *> EphemerisUpdater.lookup(d, site, when)
-    }
-
-  // Given designation and name from horizons, along with the current target name, provide a new
-  // target name. We try to find a match, and if there is none we just return the old name.
-  def modifyName(hd: HorizonsDesignation, hn: String)(n: String): String =
-    List(hn, hd.des).find(s => s.toLowerCase.indexOf(n.toLowerCase) >= 0).getOrElse(n)
-
-  def updateDesignation(hd: HorizonsDesignation, name: String, rename: Boolean): HS2[Unit] =
-    ui.onEDT {
-      val t0 = if (rename) Target.name.mod(modifyName(hd, name), spt.getTarget) else spt.getTarget
-      Target.horizonsDesignation.set(t0, Some(hd)).foreach(spt.setTarget)
+      resolver.ui.show(s"Fetching Ephemeris ...") *> EphemerisUpdater.lookup(d, site, when)
     }
 
   def updateEphem(e: Ephemeris): HS2[Unit] =
-    ui.onEDT(Target.ephemeris.set(spt.getTarget, e).foreach(spt.setTarget))
+    resolver.ui.onEDT(Target.ephemeris.set(spt.getTarget, e).foreach(spt.setTarget))
 
-  def manyResults(rs: List[Row[_ <: HorizonsDesignation]]): HS2[Unit] =
-    HS2.delay {
-      case class Wrapper(unwrap: Row[_ <: HorizonsDesignation]) {
-        override def toString = unwrap.name + " - " + unwrap.a.des
-      }
-      Option {
-        JOptionPane.showInputDialog(
-          name,
-          "Multiple results were found. Please disambiguate:",
-          "Horizons Search",
-          JOptionPane.QUESTION_MESSAGE,
-          null, // TODO: icon
-          rs.map(Wrapper).sortBy(_.toString).toArray[Object],
-          null)
-      } .map(_.asInstanceOf[Wrapper].unwrap)
-    } >>= {
-      case Some(r) => oneResult(r, true)
-      case None    => ().point[HS2]
-    }
+  def handleResult(r: Row[_ <: HorizonsDesignation], rename: Boolean): HS2[Unit] =
+    handleResult(r.a, r.name, rename)
 
-  def oneResult(r: Row[_ <: HorizonsDesignation], rename: Boolean): HS2[Unit] =
-    updateDesignation(r.a, r.name, rename).as(site) >>= {
-      case Some(site) => lookup(r.a, site) <* ui.hide >>= updateEphem
+  def handleResult(d: HorizonsDesignation, n: String, rename: Boolean): HS2[Unit] =
+    resolver.updateDesignationAction(d, n, rename, spt).as(site) >>= {
+      case Some(site) => lookup(d, site) <* resolver.ui.hide >>= updateEphem
       case None       => HS2.delay(Swing.onEDT(DialogUtil.error(name, "Cannot determine site for this observation; this is needed for ephemeris lookup.")))
     }
 
-  val noResults: HS2[Unit] =
-    HS2.delay(DialogUtil.message(name, "No results found."))
-
-  val search: HS2[Unit] =
-    ui.show("Searching...") *>
-    askSearch >>= {
-      case None => ().point[HS2] // user hit cancel
-      case Some(s) =>
-        (HorizonsService2.search(s) <* ui.hide) >>= {
-          case Nil     => noResults
-          case List(r) => oneResult(r, true)
-          case rs      => manyResults(rs)
-        }
-    }
-
-  // run this action on another thread, ensuring that the glasspane is always hidden, and log any failures
-  def unsafeRun[A](hs2: HS2[A]): Unit = {
-    val action = hs2.withResultLogging(NonSiderealNameEditor.Log) ensuring ui.hide
-    Task(action.run.unsafePerformIO).unsafePerformAsync {
-      case -\/(t) => Swing.onEDT(DialogUtil.error(name, t))
-      case \/-(_) => () // done!
-    }
-  }
-
-  def lookup(site: Option[Site]): Unit =
-    unsafeRun(search)
+  def lookup(): Unit =
+    resolver.lookup()
 
   def horizonsDesignation: Option[HorizonsDesignation] =
     spt.getNonSiderealTarget.flatMap(Target.horizonsDesignation.get).flatten
 
   def refreshEphemeris(): Unit =
-    horizonsDesignation.map(hd => oneResult(Row(hd, spt.getName), false)).foreach(unsafeRun)
+    horizonsDesignation.map(hd => handleResult(Row(hd, spt.getName), false)).foreach(resolver.unsafeRun)
 
   val name = new TextBoxWidget <| { w =>
     w.setMinimumSize(w.getPreferredSize)
@@ -135,13 +67,16 @@ final class NonSiderealNameEditor extends TelescopePosEditor[SPTarget] with Reen
         }
 
       override def textBoxAction(tbwe: TextBoxWidget): Unit =
-        lookup(site)
+        lookup()
 
     })
   }
 
+  val resolver: NonSiderealNameResolver =
+    new NonSiderealNameResolver(name, handleResult(_, _, true))
+
   object buttons {
-    val search  = searchButton(lookup(site))
+    val search  = searchButton(lookup())
     val refresh = refreshButton(refreshEphemeris())
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameResolver.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameResolver.scala
@@ -1,0 +1,121 @@
+package jsky.app.ot.gemini.editor.targetComponent.details2
+
+
+import java.util.logging.Logger
+
+import edu.gemini.horizons.server.backend.HorizonsService2
+import edu.gemini.horizons.server.backend.HorizonsService2.{Row, HS2, HS2Ops, Search}
+import edu.gemini.horizons.server.backend.HorizonsService2.Search._
+import edu.gemini.spModel.core.{Target, HorizonsDesignation, NonSiderealTarget}
+import edu.gemini.spModel.target.SPTarget
+import jsky.app.ot.gemini.editor.EphemerisUpdater
+
+import javax.swing.JOptionPane
+import javax.swing.text.JTextComponent
+
+import jsky.util.gui.DialogUtil
+
+import scala.swing.Swing
+import scalaz._
+import Scalaz._
+import scalaz.concurrent.Task
+
+/**
+ * An editor that resolves a non-sidereal target name into a unique
+ * HorizonsDesignation.  See NonSiderealNameEditor for a client of this code
+ * which uses the HorizonsDesignation to find and set the associated ephemeris.
+ *
+ * @param name text component where name is typed
+ * @param action action to be performed once the name is resolved
+ */
+final class NonSiderealNameResolver(
+  name:   JTextComponent,
+  action: (HorizonsDesignation, String) => HS2[Unit]
+) {
+
+  // A module of actions for displaying status in the GlassPane
+  val ui = EphemerisUpdater.UI(name)
+
+  val askSearch: HS2[Option[Search[_ <: HorizonsDesignation]]] =
+    HS2.delay {
+      case class Wrapper(unwrap: Search[_ <: HorizonsDesignation]) {
+        override def toString = unwrap.productPrefix
+      }
+      Option {
+        JOptionPane.showInputDialog(
+          name,
+          "Select the HORIZONS target type:",
+          "Horizons Search",
+          JOptionPane.QUESTION_MESSAGE,
+          null, // TODO: icon
+          List(Comet, Asteroid, MajorBody).map(f => Wrapper(f(name.getText))).toArray[Object],
+          null)
+      } .map(_.asInstanceOf[Wrapper].unwrap)
+    }
+
+  val search: HS2[Unit] =
+    ui.show("Searching...") *>
+    askSearch >>= {
+      case None    => ().point[HS2] // user hit cancel
+      case Some(s) =>
+        (HorizonsService2.search(s) <* ui.hide) >>= {
+          case Nil     => noResults
+          case List(r) => action(r.a, r.name)
+          case rs      => manyResults(rs)
+        }
+    }
+
+  val noResults: HS2[Unit] =
+    HS2.delay(DialogUtil.message(name, "No results found."))
+
+  def manyResults(rs: List[Row[_ <: HorizonsDesignation]]): HS2[Unit] =
+    HS2.delay {
+      case class Wrapper(unwrap: Row[_ <: HorizonsDesignation]) {
+        override def toString = unwrap.name + " - " + unwrap.a.des
+      }
+      Option {
+        JOptionPane.showInputDialog(
+          name,
+          "Multiple results were found. Please disambiguate:",
+          "Horizons Search",
+          JOptionPane.QUESTION_MESSAGE,
+          null, // TODO: icon
+          rs.map(Wrapper).sortBy(_.toString).toArray[Object],
+          null)
+      } .map(_.asInstanceOf[Wrapper].unwrap)
+    } >>= {
+      case Some(r) => action(r.a, r.name)
+      case None    => ().point[HS2]
+    }
+
+
+  def updateDesignationAction(hd: HorizonsDesignation, name: String, rename: Boolean, spt: SPTarget): HS2[Unit] =
+    ui.onEDT(updateDesignation(hd, name, rename, spt))
+
+  def updateDesignation(hd: HorizonsDesignation, name: String, rename: Boolean, spt: SPTarget): Unit = {
+    val t0 = if (rename) Target.name.mod(modifyName(hd, name), spt.getTarget) else spt.getTarget
+    Target.horizonsDesignation.set(t0, Some(hd)).foreach(spt.setTarget)
+  }
+
+  // Given designation and name from horizons, along with the current target name, provide a new
+  // target name. We try to find a match, and if there is none we just return the old name.
+  def modifyName(hd: HorizonsDesignation, hn: String)(n: String): String =
+    List(hn, hd.des).find(s => s.toLowerCase.indexOf(n.toLowerCase) >= 0).getOrElse(n)
+
+  // run this action on another thread, ensuring that the glasspane is always hidden, and log any failures
+  def unsafeRun[A](hs2: HS2[A]): Unit = {
+    val action = hs2.withResultLogging(NonSiderealNameResolver.Log) ensuring ui.hide
+    Task(action.run.unsafePerformIO).unsafePerformAsync {
+      case -\/(t) => Swing.onEDT(DialogUtil.error(name, t))
+      case \/-(_) => () // done!
+    }
+  }
+
+  def lookup(): Unit =
+    unsafeRun(search)
+
+}
+
+object NonSiderealNameResolver {
+  val Log = Logger.getLogger(classOf[NonSiderealNameResolver].getName)
+}


### PR DESCRIPTION
PIs are not allowed to specify better conditions at phase 2 than were declared during phase 1. To enforce this constraint we provide a "phase 2 check" that compares phase 2 observations with template parameters extracted from the phase 1 document.  In order to do the comparison, it finds matching parameters based upon the science target.

This check is only enabled for sidereal targets today, but this PR would add non-sidereal targets as well.  In order to compare non-sidereal targets we use the horizons id rather than the coordinates check used for sidereal targets.  This allows the ephemeris to differ or be missing for one or the other target and still be considered the same.

Unfortunately the template parameters are not being initialized with the horizons id from the phase 1 document.  This is a bug that should be addressed in a future release.  Regardless the template parameters editor has been updated to make it possible to do the non-sidereal name resolution so that the comparison can then be made. In other words, for now staff will have to edit template parameters for non-sidereal targets in order for the phase 2 check to work.

Finally, to add name resolution to the template parameters editor, I extracted parts of the existing `NonSiderealNameEditor` used by the target component into a new `NonSiderealNameResolver`.