### PR TITLE
REL-3695: keep the name when the target type changes

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -267,12 +267,13 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
         show = _.display,
         get  = { tp => targetType(tp.getTarget) },
         set  = { setTarget((target, targetType) => {
+          val name = target.getName
           targetType match {
             case ToO         => target.setTOO()
             case Sidereal    => target.setSidereal()
             case NonSidereal => target.setNonSidereal()
           }
-          target.setName(target.getName)
+          target.setName(name)
           target.setMagnitudes(Nil)
         })}
       )
@@ -496,6 +497,8 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
     def reinitTypeSpecificWidgets(): Unit = {
       val ps = load
       CoordinatesPanel.siderealRows.foreach(_.init(ps))
+      CoordinatesPanel.nonSiderealRows.foreach(_.init(ps))
+      CoordinatesPanel.tooRows.foreach(_.init(ps))
       MagnitudesPanel.init(ps)
       showTypeSpecificWidgets(ps)
     }


### PR DESCRIPTION
Small update to #1682. When the template parameter target type is changed, keep the target name. In other words, switching from Non-Sidereal to Sidereal or vice versa shouldn't cause the target name to be reset to "Untitled".