### PR TITLE
REL-3640: Updates to PIT categories

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Proposal.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Proposal.scala
@@ -18,7 +18,7 @@ object Proposal {
   val title:Lens[Proposal, String] = Lens.lensu((a, b) => a.copy(title = b), _.title)
   val abstrakt:Lens[Proposal, String] = Lens.lensu((a, b) => a.copy(abstrakt = b), _.abstrakt)
   val scheduling:Lens[Proposal, String] = Lens.lensu((a, b) => a.copy(scheduling = b), _.scheduling)
-  val tacCategory:Lens[Proposal, Option[TacCategory]] = Lens.lensu((a, b) => a.copy(tacCategory = b), _.tacCategory)
+  val category:Lens[Proposal, Option[TacCategory]] = Lens.lensu((a, b) => a.copy(category = b), _.category)
   val keywords:Lens[Proposal, List[Keyword]] = Lens.lensu((a, b) => a.copy(keywords = b), _.keywords)
   val investigators:Lens[Proposal, Investigators] = Lens.lensu((a, b) => a.copy(investigators = b), _.investigators)
   val observations:Lens[Proposal, List[Observation]] = Lens.lensu((a, b) => a.copy(observations = clean(b)), _.observations)
@@ -97,7 +97,7 @@ case class Proposal(meta:Meta,
                     title:String,
                     abstrakt:String,
                     scheduling:String,
-                    tacCategory:Option[TacCategory],
+                    category:Option[TacCategory],
                     keywords:List[Keyword],
                     investigators:Investigators,
                     targets:List[Target],
@@ -158,7 +158,7 @@ case class Proposal(meta:Meta,
     m.setTitle(title)
     m.setAbstract(abstrakt)
     m.setScheduling(scheduling)
-    m.setTacCategory(tacCategory.orNull)
+    m.setTacCategory(category.orNull)
     m.setKeywords(Factory.createKeywords())
     m.getKeywords.getKeyword.addAll(keywords.asJavaCollection)
     m.setInvestigators(investigators.mutable(n))

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -503,7 +503,13 @@ package object immutable {
 
   type TacCategory = M.TacCategory
   object TacCategory extends EnumObject[M.TacCategory] {
-    val GALACTIC = M.TacCategory.GALACTIC
+    val PLANETARY_SYSTEMS                                   = M.TacCategory.PLANETARY_SYSTEMS
+    val STAR_AND_PLANET_FORMATION                           = M.TacCategory.STAR_AND_PLANET_FORMATION
+    val STARS_AND_STELLAR_EVOLUTION                         = M.TacCategory.STARS_AND_STELLAR_EVOLUTION
+    val FORMATION_AND_EVOLUTION_OF_COMPACT_OBJECTS          = M.TacCategory.FORMATION_AND_EVOLUTION_OF_COMPACT_OBJECTS
+    val RESOLVED_STELLAR_POPULATIONS_AND_THEIR_ENVIRONMENTS = M.TacCategory.RESOLVED_STELLAR_POPULATIONS_AND_THEIR_ENVIRONMENTS
+    val GALAXY_EVOLUTION                                    = M.TacCategory.GALAXY_EVOLUTION
+    val COSMOLOGY_AND_FUNDAMENTAL_PHYSICS                   = M.TacCategory.COSMOLOGY_AND_FUNDAMENTAL_PHYSICS
   }
 
   type TimeUnit = M.TimeUnit

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -173,7 +173,20 @@ case object SemesterConverter2019BTo2020A extends SemesterConverter {
       val addGender = ns :+ <gender>None selected</gender>
       StepResult(genderMessage, <coi id={p.attribute("id")}>{addGender}</coi>).successNel
   }
-  override val transformers: List[TransformFunction] = List(subaruSuprimeTransform, genderTransform)
+
+  lazy val solarSystemCategoryMessage: String = "The Solar System category is now classified as Planetary systems."
+  lazy val galacticCategoryMessage: String = "The Galactic category is now classified as Stars and stellar evolution."
+  lazy val extragalacticCategoryMessage: String = "The Extragalactic category is now classified as Galaxy evolution."
+  val categoryUpdateTransform: TransformFunction = {
+    case p @ <proposal>{ns @ _*}</proposal> if (p \ "@tacCategory").exists(_.text == "Solar System") =>
+      StepResult(solarSystemCategoryMessage, <proposal tacCategory={TacCategory.PLANETARY_SYSTEMS.value()} schemaVersion={Proposal.currentSchemaVersion}>{ns}</proposal>).successNel
+    case p @ <proposal>{ns @ _*}</proposal> if (p \ "@tacCategory").exists(_.text == "Galactic") =>
+      StepResult(galacticCategoryMessage, <proposal tacCategory={TacCategory.STARS_AND_STELLAR_EVOLUTION.value()} schemaVersion={Proposal.currentSchemaVersion}>{ns}</proposal>).successNel
+    case p @ <proposal>{ns @ _*}</proposal> if (p \ "@tacCategory").exists(_.text == "Extragalactic") =>
+      StepResult(extragalacticCategoryMessage, <proposal tacCategory={TacCategory.GALAXY_EVOLUTION.value()} schemaVersion={Proposal.currentSchemaVersion}>{ns}</proposal>).successNel
+  }
+
+  override val transformers: List[TransformFunction] = List(subaruSuprimeTransform, genderTransform, categoryUpdateTransform)
 }
 
 

--- a/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/CHANGELOG
@@ -5,6 +5,19 @@ Gemini Phase I Schema Changes
 * Added "Multi-messenger astrophysics" keyword
 * Hide "Suprime Cam" for subaru
 * Add gender field to Investigator
+* Changed TAC Category (now just Category) entries to:
+  1. Planetary systems
+  2. Star and planet formation
+  3. Stars and stellar evolution
+  4. Formation and evolution of compact objects
+  5. Resolved stellar populations and their environments
+  6. Galaxy evolution
+  7.Cosmology and fundamental physics
+  
+  Old entries are mapped as follows:
+  1. Solar System  -> Planetary systems
+  2. Galactic      -> Stars and stellar evolution
+  3. Extragalactic -> Galaxy evolution
 
 # Version 2019.2.1 - 2019B
 ##########################

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Proposal.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Proposal.xsd
@@ -54,7 +54,7 @@
 
             </xsd:sequence>
             <xsd:attribute name="schemaVersion" type="SchemaVersion" use="required"/>
-            <xsd:attribute name="tacCategory"   type="TacCategory"   use="optional"/>
+            <xsd:attribute name="tacCategory" type="TacCategory" use="optional"/>
         </xsd:complexType>
     </xsd:element>
 
@@ -88,13 +88,18 @@
 
 
     <!--
-      A proposal has a TAC category of Solar System, Galactic, or Extragalactic.
+      A proposal has a category of one of the following.
+      This has been changed to Category in the UI, but a Category class clashes with scalaz.
     -->
     <xsd:simpleType name="TacCategory">
         <xsd:restriction base="xsd:token">
-            <xsd:enumeration value="Solar System"/>
-            <xsd:enumeration value="Galactic"/>
-            <xsd:enumeration value="Extragalactic"/>
+            <xsd:enumeration value="Planetary systems"/>
+            <xsd:enumeration value="Star and planet formation"/>
+            <xsd:enumeration value="Stars and stellar evolution"/>
+            <xsd:enumeration value="Formation and evolution of compact objects"/>
+            <xsd:enumeration value="Resolved stellar populations and their environments"/>
+            <xsd:enumeration value="Galaxy evolution"/>
+            <xsd:enumeration value="Cosmology and fundamental physics"/>
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_extragalactic.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_extragalactic.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2019.2.1" tacCategory="Extragalactic">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2019" half="B"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints/>
+    <observations/>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_galactic.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_galactic.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2019.2.1" tacCategory="Galactic">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2019" half="B"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints/>
+    <observations/>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_solarsystem.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_solarsystem.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2019.2.1" tacCategory="Solar System">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2019" half="B"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints/>
+    <observations/>
+    <proposalClass>
+        <queue tooOption="None"/>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -124,17 +124,6 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           proposal.schemaVersion must beEqualTo(Proposal.currentSchemaVersion)
       }
     }
-    "retain the tacCategory attribute" in {
-      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_ver_1.0.14.xml")))
-      val converted = UpConverter.convert(xml)
-      converted must beSuccessful.like {
-        case StepResult(changes, result) =>
-          changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
-
-          val proposal = ProposalIo.read(result.toString())
-          proposal.tacCategory must beSome(TacCategory.GALACTIC)
-      }
-    }
     "create a band3Option missing attribute from 1.0.0" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_ver_1.0.0_no_band3option.xml")))
       val converted = UpConverter.convert(xml)
@@ -773,6 +762,39 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           changes must contain("Subaru proposal with Suprime Cam has been migrated to Hyper Suprime Cam")
           result \\ "subaru" must \\("name") \> "Subaru (Hyper Suprime Cam)"
           result \\ "subaru" must \\("instrument") \> "Hyper Suprime Cam"
+      }
+    }
+    "update the tacCategory Solar System attribute" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_solarsystem.xml")))
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must contain(SemesterConverter2019BTo2020A.solarSystemCategoryMessage)
+
+          val proposal = ProposalIo.read(result.toString())
+          proposal.category must beSome(TacCategory.PLANETARY_SYSTEMS)
+      }
+    }
+    "update the tacCategory Galactic attribute" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_galactic.xml")))
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must contain(SemesterConverter2019BTo2020A.galacticCategoryMessage)
+
+          val proposal = ProposalIo.read(result.toString())
+          proposal.category must beSome(TacCategory.STARS_AND_STELLAR_EVOLUTION)
+      }
+    }
+    "update the tacCategory Extragalactic attribute" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_extragalactic.xml")))
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, result) =>
+          changes must contain(SemesterConverter2019BTo2020A.extragalacticCategoryMessage)
+
+          val proposal = ProposalIo.read(result.toString())
+          proposal.category must beSome(TacCategory.GALAXY_EVOLUTION)
       }
     }
   }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -58,7 +58,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have size 5
+          changes must have size 6
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2013A to view the unmodified proposal")
@@ -91,7 +91,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
         case ConversionResult(transformed, from, changes, _) =>
           transformed must beTrue
           from must beEqualTo(Semester(2013, SemesterOption.A))
-          changes must have length 5
+          changes must have length 6
       }
 
     }
@@ -100,7 +100,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have size 5
+          changes must have size 6
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2013A to view the unmodified proposal")
@@ -129,7 +129,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 6
+          changes must have length 7
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -149,7 +149,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
         case ConversionResult(transformed, from, changes, root) =>
           transformed must beTrue
           from must beEqualTo(Semester(2012, SemesterOption.B))
-          changes must have length 6
+          changes must have length 7
       }
     }
     "Renamed Keyword 'Herbig-Haro stars' to 'Herbig-Haro objects' on 1.0.0" in {
@@ -157,7 +157,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 7
+          changes must have length 8
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -234,7 +234,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 9
+          changes must have length 10
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -259,7 +259,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 9
+          changes must have length 10
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")
@@ -285,7 +285,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
-          changes must have length 10
+          changes must have length 11
           changes must contain(s"Updated schema version to ${Proposal.currentSchemaVersion}")
           changes must contain(s"Updated semester to ${Semester.current.display}")
           changes must contain("Please use the PIT from semester 2012B to view the unmodified proposal")

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
@@ -282,7 +282,7 @@ object SpProgramFactory {
 
   def gsaPhase1Data(proposal: Proposal): Gsa = {
     val abstrakt = new Gsa.Abstract(proposal.abstrakt)
-    val category = new Gsa.Category(~proposal.tacCategory.map(_.value()))
+    val category = new Gsa.Category(~proposal.category.map(_.value()))
     val keywords = proposal.keywords.map(k => new Gsa.Keyword(k.value())).asJava
     val pi       = gsaPhase1DataInvestigator(proposal.investigators.pi)
     val cois     = proposal.investigators.cois.map(gsaPhase1DataInvestigator).asJava

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -74,7 +74,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
 
     lazy val all = {
       val ps =
-        List(noObs, nonUpdatedInvestigatorName, noPIPhoneNumber, invalidPIPhoneNumber, titleCheck, band3option, abstractCheck, tacCategoryCheck,
+        List(noObs, nonUpdatedInvestigatorName, noPIPhoneNumber, invalidPIPhoneNumber, titleCheck, band3option, abstractCheck, categoryCheck,
           keywordCheck, attachmentCheck, attachmentValidityCheck, attachmentSizeCheck, missingObsDetailsCheck,
           duplicateInvestigatorCheck, ftReviewerOrMentor, ftAffiliationMismatch, band3Obs).flatten ++
           TimeProblems(p, s).all ++
@@ -100,8 +100,8 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
       new Problem(Severity.Todo, "Please provide an abstract.", "Overview", s.inOverview(_.abstrakt.requestFocus()))
     }
 
-    private lazy val tacCategoryCheck = when(p.tacCategory.isEmpty) {
-      new Problem(Severity.Todo, "Please select a TAC category.", "Overview", s.inOverview(_.tacCategory.peer.setPopupVisible(true)))
+    private lazy val categoryCheck = when(p.category.isEmpty) {
+      new Problem(Severity.Todo, "Please select a science category.", "Overview", s.inOverview(_.category.peer.setPopupVisible(true)))
     }
 
     private lazy val keywordCheck = when(p.keywords.isEmpty) {

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/proposal/ProposalView.scala
@@ -26,7 +26,7 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
   implicit val boolMonoid = Monoid.instance[Boolean](_ || _,  false)
 
   // Bound
-  override def children = List(title, abstrakt, /* scheduling, */ tacCategory, keywords, attachment, investigators)
+  override def children = List(title, abstrakt, /* scheduling, */ category, keywords, attachment, investigators)
   val lens = Model.proposal
 
   // Our content, which is defined below
@@ -34,7 +34,7 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
     border = DLU4_BORDER
     addRow(new Label("Title:"), title)
     addRow(new Label("Abstract:"), new ScrollPane(abstrakt), GridBagPanel.Fill.Both, 100)
-    addRow(new Label("TAC Category:"), tacCategory)
+    addRow(new Label("Category:"), category)
     addRow(new Label("Keywords:"), keywords)
     addRow(new Label("Attachment:"), attachment)
     addSpacer()
@@ -45,7 +45,7 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
   override def refresh(m:Option[Proposal]) {
     title.enabled = canEdit
     abstrakt.enabled = canEdit
-    tacCategory.enabled = canEdit
+    category.enabled = canEdit
     attachment.select.enabled = canEdit
     attachment.remove.enabled = canEdit
   }
@@ -68,9 +68,9 @@ class ProposalView(advisor:ShellAdvisor) extends BorderPanel with BoundView[Prop
   }
 
   // TAC category
-  object tacCategory extends ComboBox[TacCategory](TacCategory.values) with BoundCombo[Proposal, TacCategory] with Uninitialized.ValueRenderer[TacCategory] {
+  object category extends ComboBox[TacCategory](TacCategory.values) with BoundCombo[Proposal, TacCategory] with Uninitialized.ValueRenderer[TacCategory] {
     val boundView = panel
-    val lens = Uninitialized.lens(Proposal.tacCategory)
+    val lens = Uninitialized.lens(Proposal.category)
   }
 
   // Keywords


### PR DESCRIPTION
This accomplishes what is laid out in REL-3640, namely:

1. Rename "TAC Category" to "Category"
2. Change the previous categories - Solar System, Galactic, Extragalactic to a list of seven categories.
3. Modify the UpConverter to convert the previous categories to the new ones that are applicable to them.

NOTES:

1. I wanted to change `TacCategory` to `Category` to reflect this, but `scalaz` contains a `Category` so this resulted in clashes.
2. The REL task specifically asks to keep the `proposal` tag attribute as `tacCategory` in order to simplify this change; hence, I did not change it.

Here is an example of up-conversion of a Zorro Galactic program and the resultant UI where you can see that the Category is now "Stars and stellar evolution."

![Screen Shot 2019-07-29 at 4 54 54 PM](https://user-images.githubusercontent.com/8795653/62082940-c928bb00-b223-11e9-91e5-3862f8b6db0c.png)

![Screen Shot 2019-07-29 at 4 55 08 PM](https://user-images.githubusercontent.com/8795653/62082953-d04fc900-b223-11e9-9bbd-05d848732f02.png)
