### PR TITLE
REL-3671: Moved observing mode and TOO information as per request.

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
@@ -98,7 +98,6 @@
                     </xsl:call-template>
                 </xsl:when>
             </xsl:choose>
-
         </fo:root>
     </xsl:template>
 
@@ -227,6 +226,30 @@
                 </fo:block>
                 <!-- END keywords -->
 
+                <!-- BEGIN observing mode -->
+                <xsl:variable name="obs-mode">
+                    <xsl:choose>
+                        <xsl:when test="proposalClass/classical">Classical</xsl:when>
+                        <xsl:when test="proposalClass/queue[@tooOption != 'None']">Queue&#160;+&#160;<xsl:value-of select="proposalClass/queue/@tooOption"/>&#160;ToO</xsl:when>
+                        <xsl:when test="proposalClass/queue">Queue</xsl:when>
+                        <xsl:when test="proposalClass/exchange">Exchange</xsl:when>
+                        <xsl:when test="proposalClass/special">Special</xsl:when>
+                        <xsl:when test="proposalClass/large">Large Program</xsl:when>
+                        <xsl:when test="proposalClass/fastTurnaround[@tooOption != 'None']">Fast Turnaround&#160;+&#160;<xsl:value-of select="proposalClass/fastTurnaround/@tooOption"/>&#160;ToO</xsl:when>
+                        <xsl:when test="proposalClass/fastTurnaround">Fast Turnaround</xsl:when>
+                        <xsl:when test="proposalClass/sip[@tooOption != 'None']">Subaru Intensive Program&#160;+&#160;<xsl:value-of select="proposalclass/sip/@toooption"/>&#160;ToO</xsl:when>
+                        <xsl:when test="proposalClass/sip">Subaru Intensive Program</xsl:when>
+                        <xsl:otherwise><xsl:value-of select="name(proposalClass/*)"/></xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <fo:block space-after="12pt">
+                    <fo:inline font-weight="bold">
+                        Observing Mode:
+                    </fo:inline>
+                    <xsl:value-of select="$obs-mode"/>
+                </fo:block>
+                <!-- END observing mode -->
+
                 <!-- BEGIN time request -->
                 <fo:block space-after="12pt">
                     <fo:inline font-weight="bold">
@@ -238,15 +261,6 @@
                     <xsl:value-of select="proposalClass/*/ngo[partner=$this-partner]/request/minTime/@units"/> minimum
                 </fo:block>
                 <!-- END time request -->
-
-                <!-- observing mode -->
-                <xsl:variable name="obs-mode">
-                    <xsl:choose>
-                        <xsl:when test="proposalClass/fastTurnaround">Fast Turnaround</xsl:when>
-                        <xsl:when test="proposalClass/sip">Subaru Intensive Program</xsl:when>
-                        <xsl:otherwise><xsl:value-of select="name(proposalClass/*)"/></xsl:otherwise>
-                    </xsl:choose>
-                </xsl:variable>
 
                 <!-- BEGIN observation time summary table -->
                 <fo:table table-layout="fixed" space-before="12pt" space-after="12pt">
@@ -366,11 +380,6 @@
                                     Summary of<xsl:text>&#160;</xsl:text>
                                     <xsl:value-of select="$obs-mode"/>
                                     observations<xsl:text>&#160;</xsl:text>
-                                    <xsl:variable name="too-value"><xsl:value-of select="proposalClass/*/@tooOption"/></xsl:variable>
-                                    <xsl:choose>
-                                        <xsl:when test="$too-value='rapid'">(ToO: rapid response)</xsl:when>
-                                        <xsl:when test="$too-value='standard'">(ToO: standard)</xsl:when>
-                                    </xsl:choose>
                                 </fo:block>
                             </fo:table-cell>
                         </fo:table-row>


### PR DESCRIPTION
Images demonstrating the positioning of the observing mode after the keywords section as requested in the PR.

Queue + No TOO:
![Screen Shot 2019-08-07 at 5 16 56 PM](https://user-images.githubusercontent.com/8795653/62658770-91aec280-b937-11e9-9628-366b94757e49.png)

Queue + Rapid TOO:
![Screen Shot 2019-08-07 at 5 16 31 PM](https://user-images.githubusercontent.com/8795653/62658810-a25f3880-b937-11e9-9d98-d448d5cfce61.png)

Queue + Standard TOO:
![Screen Shot 2019-08-07 at 5 15 50 PM](https://user-images.githubusercontent.com/8795653/62658829-b1de8180-b937-11e9-9eb0-a51fcef800be.png)

