### PR TITLE
REL-3676: add Gaia to VoTableClient

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
@@ -73,7 +73,7 @@ case class GemsVoTableCatalog(backend: VoTableBackend = ConeSearchBackend, catal
       (CatalogQuery(basePosition, c.criterion.radiusConstraint, c.criterion.magConstraint, catalog), c)
     }
     val qm = queryArgs.toMap
-    VoTableClient.catalogs(queryArgs.map(_._1), backend)(ec).map(l => l.map { qr => GemsCatalogSearchResults(qm.get(qr.query).get, qr.result.targets.rows)})
+    VoTableClient.catalogs(queryArgs.map(_._1), Some(backend))(ec).map(l => l.map { qr => GemsCatalogSearchResults(qm.get(qr.query).get, qr.result.targets.rows)})
   }
 
   /**
@@ -96,7 +96,7 @@ case class GemsVoTableCatalog(backend: VoTableBackend = ConeSearchBackend, catal
       magLimits    <- magConstraints
     } yield CatalogQuery(basePosition, radiusLimits, magLimits, catalog)
 
-    VoTableClient.catalogs(queries, backend)(ec).flatMap {
+    VoTableClient.catalogs(queries, Some(backend))(ec).flatMap {
       case l if l.exists(_.result.containsError) =>
         Future.failed(CatalogException(l.map(_.result.problems).suml))
       case l =>

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -50,7 +50,7 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
     val empty = Future.successful(List((params.guideProbe: GuideProbe, List.empty[SiderealTarget])))
 
     // We cannot let VoTableClient to filter targets as usual, instead we provide an empty magnitude constraint and filter locally
-    catalogQueries(withCorrectedSite(ctx), mt).strengthR(backend).headOption.map { case (a, b) => VoTableClient.catalog(a, b)(ec) }.map(_.flatMap {
+    catalogQueries(withCorrectedSite(ctx), mt).strengthR(Some(backend)).headOption.map { case (a, b) => VoTableClient.catalog(a, b)(ec) }.map(_.flatMap {
         case r if r.result.containsError => Future.failed(CatalogException(r.result.problems))
         case r                           => Future.successful(List((params.guideProbe, r.result.targets.rows)))
     }).getOrElse(empty)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
@@ -247,7 +247,7 @@ class MascotGuideStarSpec extends Specification {
       val coordinates = Coordinates(RightAscension.fromAngle(Angle.fromHMS(3, 19, 48.2341).getOrElse(Angle.zero)), Declination.fromAngle(Angle.fromDMS(41, 30, 42.078).getOrElse(Angle.zero)).getOrElse(Declination.zero))
 
       val query = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromArcmin(MascotCat.defaultMinRadius), Angle.fromArcmin(MascotCat.defaultMaxRadius)), PPMXL)
-      val r = VoTableClient.catalog(query, TestVoTableBackend("/mascotquery.xml"))(implicitly).map { t =>
+      val r = VoTableClient.catalog(query, Some(TestVoTableBackend("/mascotquery.xml")))(implicitly).map { t =>
         val base = new SPTarget(coordinates.ra.toAngle.toDegrees, coordinates.dec.toDegrees)
         val env = TargetEnvironment.create(base)
         val inst = new Gsaoi()

--- a/bundle/edu.gemini.catalog/src/main/resources/votable-1.3.xsd
+++ b/bundle/edu.gemini.catalog/src/main/resources/votable-1.3.xsd
@@ -1,0 +1,572 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--W3C Schema for VOTable  = Virtual Observatory Tabular Format
+.Version 1.0 : 15-Apr-2002
+.Version 1.09: 23-Jan-2004 Version 1.09
+.Version 1.09: 30-Jan-2004 Version 1.091
+.Version 1.09: 22-Mar-2004 Version 1.092
+.Version 1.094: 02-Jun-2004 GROUP does not contain FIELD
+.Version 1.1 :  10-Jun-2004 remove the complexContent
+.Version 1.11: GL: 23-May-2006 remove most root elements, use name= type= iso ref= structure
+.Version 1.11: GL: 29-Aug-2006 review and added comments (prefixed by GL) 
+              before sending to Francois Ochsenbein
+.Version 1.12: FO: Preliminary Version 1.2
+.Version 1.18: FO: Tested (jax) version 1.2
+.Version 1.19: FO: Completed INFO attributes
+.Version 1.20: FO: Added xtype; content-role is less restrictive (May2009)
+.Version 1.20a: FO: PR-20090710 Cosmetics.
+.Version 1.20b: FO: INFO does not accept sub-elements (2009-09-29)
+.Version 1.20c: FO: elementFormDefault="qualified" to stay compatible with 1.1
+.Version 1.3: MT: Added BINARY2 element
+.Version 1.3: MT: Further relaxed LINK content-role type to token
+-->
+<xs:schema 
+   xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+   xmlns="http://www.ivoa.net/xml/VOTable/v1.3"
+   targetNamespace="http://www.ivoa.net/xml/VOTable/v1.3" 
+>
+<xs:annotation><xs:documentation>
+    VOTable is meant to serialize tabular documents in the
+    context of Virtual Observatory applications. This schema
+    corresponds to the VOTable document available from
+    http://www.ivoa.net/Documents/latest/VOT.html
+</xs:documentation></xs:annotation>
+
+<!-- Here we define some interesting new datatypes:
+     - anyTEXT   may have embedded XHTML (conforming HTML)
+     - astroYear is an epoch in Besselian or Julian year, e.g. J2000
+     - arrayDEF  specifies an array size e.g. 12x23x*
+     - dataType  defines the acceptable datatypes
+     - ucdType   defines the acceptable UCDs (UCD1+)
+     - precType  defines the acceptable precisions
+     - yesno     defines just the 2 alternatives
+-->
+
+<xs:complexType name="anyTEXT" mixed="true">
+  <xs:sequence>
+    <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:simpleType  name="astroYear">
+  <xs:restriction base="xs:token">
+    <xs:pattern  value="[JB]?[0-9]+([.][0-9]*)?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType  name="ucdType">
+  <xs:restriction base="xs:token">
+    <xs:annotation><xs:documentation>
+      Accept UCD1+
+      Accept also old UCD1 (but not / + %) including SIAP convention (with :)
+    </xs:documentation></xs:annotation>
+    <xs:pattern  value="[A-Za-z0-9_.:;\-]*"/><!-- UCD1 use also / + % -->
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType  name="arrayDEF">
+  <xs:restriction base="xs:token">
+    <xs:pattern  value="([0-9]+x)*[0-9]*[*]?(s\W)?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType  name="encodingType">
+  <xs:restriction base="xs:NMTOKEN">
+    <xs:enumeration value="gzip"/>
+    <xs:enumeration value="base64"/>
+    <xs:enumeration value="dynamic"/>
+    <xs:enumeration value="none"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="dataType">
+  <xs:restriction base="xs:NMTOKEN">
+    <xs:enumeration value="boolean"/>
+    <xs:enumeration value="bit"/>
+    <xs:enumeration value="unsignedByte"/>
+    <xs:enumeration value="short"/>
+    <xs:enumeration value="int"/>
+    <xs:enumeration value="long"/>
+    <xs:enumeration value="char"/>
+    <xs:enumeration value="unicodeChar"/>
+    <xs:enumeration value="float"/>
+    <xs:enumeration value="double"/>
+    <xs:enumeration value="floatComplex"/>
+    <xs:enumeration value="doubleComplex"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="precType">
+  <xs:restriction base="xs:token">
+    <xs:pattern value="[EF]?[1-9][0-9]*"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="yesno">
+  <xs:restriction base="xs:NMTOKEN">
+    <xs:enumeration value="yes"/>
+    <xs:enumeration value="no"/>
+  </xs:restriction>
+</xs:simpleType>
+
+  <xs:complexType name="Min">
+    <xs:attribute name="value" type="xs:string" use="required"/>
+    <xs:attribute name="inclusive" type="yesno" default="yes"/>
+  </xs:complexType>
+  <xs:complexType name="Max">
+    <xs:attribute name="value" type="xs:string" use="required"/>
+    <xs:attribute name="inclusive" type="yesno" default="yes"/>
+  </xs:complexType>
+  <xs:complexType name="Option">
+    <xs:sequence>
+      <xs:element name="OPTION" type="Option" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:token"/>
+    <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+  
+  <!-- VALUES expresses the values that can be taken by the data 
+    in a column or by a parameter
+  -->
+  <xs:complexType name="Values">
+    <xs:sequence>
+      <xs:element name="MIN" type="Min" minOccurs="0"/>
+      <xs:element name="MAX" type="Max" minOccurs="0"/>
+      <xs:element name="OPTION" type="Option" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="ID" type="xs:ID"/>
+    <xs:attribute name="type" default="legal">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="legal"/>
+          <xs:enumeration value="actual"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="null" type="xs:token"/>
+    <xs:attribute name="ref"  type="xs:IDREF"/>
+    <!-- xs:attribute name="invalid" type="yesno" default="no"/ -->
+  </xs:complexType>
+  
+  <!-- The LINK is a URL (href) or some other kind of reference (gref) -->
+  <xs:complexType name="Link">
+    <xs:annotation><xs:documentation> 
+    content-role was previsouly restricted as: <![CDATA[
+    <xs:attribute name="content-role">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="query"/>
+          <xs:enumeration value="hints"/>
+          <xs:enumeration value="doc"/>
+          <xs:enumeration value="location"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>]]>; is now a token.
+    </xs:documentation></xs:annotation>
+    <xs:attribute name="ID" type="xs:ID"/>
+    <xs:attribute name="content-role" type="xs:token"/>
+    <xs:attribute name="content-type" type="xs:token"/>
+    <xs:attribute name="title" type="xs:string"/>
+    <xs:attribute name="value" type="xs:string"/>
+    <xs:attribute name="href" type="xs:anyURI"/>
+    <xs:attribute name="gref" type="xs:token"/><!-- Deprecated in V1.1 -->
+    <xs:attribute name="action" type="xs:anyURI"/>
+  </xs:complexType>
+  
+<!-- INFO is defined in Version 1.2 as a PARAM of String type 
+<xs:complexType name="Info">
+  <xs:complexContent>
+    <xs:restriction base="Param">
+      <xs:attribute name="unit" fixed=""/>
+      <xs:attribute name="datatype" fixed="char"/>
+      <xs:attribute name="arraysize" fixed="*"/>
+    </xs:restriction>
+  </xs:complexContent>
+</xs:complexType>
+ -or- as a full definition:
+<xs:complexType name="Info">
+  <xs:sequence> 
+  <xs:element name="DESCRIPTION" type="anyTEXT" minOccurs="0"/>
+    <xs:element name="VALUES" type="Values" minOccurs="0"/>
+    <xs:element name="LINK" type="Link" minOccurs="0" maxOccurs="unbounded"/> 
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:token" use="required"/>
+  <xs:attribute name="value" type="xs:string" use="required"/>
+  <xs:attribute name="ID" type="xs:ID"/>
+  <xs:attribute name="unit" type="xs:token"/>
+  <xs:attribute name="xtype" type="xs:token"/>
+  <xs:attribute name="ref" type="xs:IDREF"/>
+  <xs:attribute name="ucd" type="ucdType"/>
+  <xs:attribute name="utype" type="xs:string"/>
+</xs:complexType>
+-->
+<!-- No sub-element is accepted in INFO for backward compatibility -->
+<xs:complexType name="Info">
+  <xs:simpleContent>
+    <xs:extension base="xs:string">
+      <xs:attribute name="ID" type="xs:ID"/>
+      <xs:attribute name="name"  type="xs:token" use="required"/>
+      <xs:attribute name="value" type="xs:string" use="required"/>
+      <xs:attribute name="unit"  type="xs:token"/>
+      <xs:attribute name="xtype" type="xs:token"/>
+      <xs:attribute name="ref"   type="xs:IDREF"/>
+      <xs:attribute name="ucd"   type="ucdType"/>
+      <xs:attribute name="utype" type="xs:string"/>
+    </xs:extension>
+  </xs:simpleContent>
+</xs:complexType>
+
+<!-- Expresses the coordinate system we are using --><!-- Deprecated V1.2 -->
+<xs:complexType name="CoordinateSystem">
+  <xs:annotation><xs:documentation>
+    Deprecated in Version 1.2
+  </xs:documentation></xs:annotation>
+  <xs:simpleContent>
+    <xs:extension base="xs:string">
+      <xs:attribute name="ID" type="xs:ID" use="required"/>
+      <xs:attribute name="equinox" type="astroYear"/>
+      <xs:attribute name="epoch" type="astroYear"/>
+      <xs:attribute name="system" default="eq_FK5">
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="eq_FK4"/>
+            <xs:enumeration value="eq_FK5"/>
+            <xs:enumeration value="ICRS"/>
+            <xs:enumeration value="ecl_FK4"/>
+            <xs:enumeration value="ecl_FK5"/>
+            <xs:enumeration value="galactic"/>
+            <xs:enumeration value="supergalactic"/>
+            <xs:enumeration value="xy"/>
+            <xs:enumeration value="barycentric"/>
+            <xs:enumeration value="geo_app"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:extension>
+  </xs:simpleContent>
+</xs:complexType>
+
+<xs:complexType name="Definitions">
+  <xs:annotation><xs:documentation>
+    Deprecated in Version 1.1
+  </xs:documentation></xs:annotation>
+  <xs:choice minOccurs="0" maxOccurs="unbounded">
+    <xs:element name="COOSYS" type="CoordinateSystem"/><!-- Deprecated in V1.2 -->
+    <xs:element name="PARAM" type="Param"/>
+  </xs:choice>
+</xs:complexType>
+
+<!-- FIELD is the definition of what is in a column of the table -->
+<xs:complexType name="Field">
+  <xs:sequence> <!-- minOccurs="0" maxOccurs="unbounded" -->
+    <xs:element name="DESCRIPTION" type="anyTEXT" minOccurs="0"/>
+    <xs:element name="VALUES" type="Values" minOccurs="0"/> <!-- maxOccurs="2" -->
+    <xs:element name="LINK" type="Link" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attribute name="ID" type="xs:ID"/>
+  <xs:attribute name="unit" type="xs:token"/>
+  <xs:attribute name="datatype" type="dataType" use="required"/>
+  <xs:attribute name="precision" type="precType"/>
+  <xs:attribute name="width" type="xs:positiveInteger"/>
+  <xs:attribute name="xtype" type="xs:token"/>
+  <xs:attribute name="ref" type="xs:IDREF"/>
+  <xs:attribute name="name" type="xs:token" use="required"/>
+  <xs:attribute name="ucd" type="ucdType"/>
+  <xs:attribute name="utype" type="xs:string"/>
+  <xs:attribute name="arraysize" type="xs:string"/>
+    <!-- GL: is the next deprecated element remaining 
+        (is not in PARAM, but will in new model be inherited) 
+    -->
+  <xs:attribute name="type">
+    <!-- type is not in the Version 1.1, but is kept for
+         backward compatibility purposes
+    -->
+    <xs:simpleType>
+      <xs:restriction base="xs:NMTOKEN">
+        <xs:enumeration value="hidden"/>
+        <xs:enumeration value="no_query"/>
+        <xs:enumeration value="trigger"/>
+        <xs:enumeration value="location"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+</xs:complexType>
+
+
+<!-- A PARAM is similar to a FIELD, but it also has a "value" attribute -->
+<!--  GL: implemented here as a subtype as suggested we do in Kyoto. -->
+<xs:complexType name="Param">
+  <xs:complexContent>
+    <xs:extension base="Field">
+      <xs:attribute name="value" type="xs:string" use="required"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+
+<!-- GROUP groups columns; may include descriptions, fields/params/groups -->
+<xs:complexType name="Group">
+  <xs:sequence>
+    <xs:element name="DESCRIPTION" type="anyTEXT" minOccurs="0"/>
+<!--  GL I guess I can understand the next choice element as one may (?) 
+      really want to group fields and params and groups in a particular order.
+-->    
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="FIELDref" type="FieldRef"/> 
+      <xs:element name="PARAMref" type="ParamRef"/> 
+      <xs:element name="PARAM" type="Param"/> 
+      <xs:element name="GROUP" type="Group"/> 
+      <!-- GL a GroupRef could remove recursion -->
+    </xs:choice>
+  </xs:sequence>
+  <xs:attribute name="ID"   type="xs:ID"/>
+  <xs:attribute name="name" type="xs:token"/>
+  <xs:attribute name="ref"  type="xs:IDREF"/>
+  <xs:attribute name="ucd"  type="ucdType"/>
+  <xs:attribute name="utype" type="xs:string"/>
+</xs:complexType>
+
+<!-- FIELDref and PARAMref are references to FIELD or PARAM defined
+     in the parent TABLE or RESOURCE -->
+<!-- GL This can not be enforced in XML Schema, so why not IDREF in <Group> ?
+     In particular if the UCD and utype attributes will NOT be added -->
+<xs:complexType name="FieldRef">
+  <xs:attribute name="ref" type="xs:IDREF" use="required"/>
+  <xs:attribute name="ucd"  type="ucdType"/>
+  <xs:attribute name="utype" type="xs:string"/>
+</xs:complexType>
+
+<xs:complexType name="ParamRef">
+  <xs:attribute name="ref" type="xs:IDREF" use="required"/>
+  <xs:attribute name="ucd"  type="ucdType"/>
+  <xs:attribute name="utype" type="xs:string"/>
+</xs:complexType>
+
+<!-- DATA is the actual table data, in one of three formats -->
+<!-- 
+  GL in Kyoto we discussed the option of having the specific Data items 
+  be subtypes of Data:
+-->
+<!-- 
+<xs:complexType name="Data" abstract="true"/>
+
+<xs:complexType name="TableData">
+  <xs:complexContent>
+    <xs:extension base="Data">
+     ... etc
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+ -->
+<xs:complexType name="Data">
+  <xs:annotation><xs:documentation>
+    Added in Version 1.2: INFO for diagnostics
+  </xs:documentation></xs:annotation>
+  <xs:sequence>
+    <xs:choice>
+      <xs:element name="TABLEDATA" type="TableData"/>
+      <xs:element name="BINARY" type="Binary"/>
+      <xs:element name="BINARY2" type="Binary2"/>
+      <xs:element name="FITS" type="FITS"/>
+    </xs:choice>
+    <xs:element name="INFO" type="Info" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<!-- Pure XML data -->
+<xs:complexType name="TableData">
+  <xs:sequence>
+    <xs:element name="TR" type="Tr" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="Td">
+  <xs:simpleContent>
+    <xs:extension base="xs:string">
+      <!-- xs:attribute name="ref" type="xs:IDREF"/ -->
+      <xs:annotation><xs:documentation>
+          The 'encoding' attribute is added here to avoid
+          problems of code generators which do not properly
+          interpret the TR/TD structures.
+          'encoding' was chosen because it appears in
+          appendix A.5
+      </xs:documentation></xs:annotation>
+      <xs:attribute name="encoding" type="encodingType"/>
+    </xs:extension>
+  </xs:simpleContent>
+</xs:complexType>
+
+<xs:complexType name="Tr">
+  <xs:annotation><xs:documentation>
+    The ID attribute is added here to the TR tag to avoid 
+    problems of code generators which do not properly 
+    interpret the TR/TD structures
+  </xs:documentation></xs:annotation>
+  <xs:sequence>
+    <xs:element name="TD" type="Td" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attribute name="ID" type="xs:ID"/>
+</xs:complexType>
+
+<!-- FITS file, perhaps with specification of which extension to seek to -->
+<xs:complexType name="FITS">
+  <xs:sequence>
+    <xs:element name="STREAM" type="Stream"/>
+  </xs:sequence>
+  <xs:attribute name="extnum" type="xs:positiveInteger"/>
+</xs:complexType>
+
+<!-- BINARY data format -->
+<xs:complexType name="Binary">
+  <xs:sequence>
+    <xs:element name="STREAM" type="Stream"/>
+  </xs:sequence>
+</xs:complexType>
+
+<!-- BINARY2 data format -->
+<xs:complexType name="Binary2">
+  <xs:sequence>
+    <xs:element name="STREAM" type="Stream"/>
+  </xs:sequence>
+</xs:complexType>
+
+<!-- STREAM can be local or remote, encoded or not -->
+<xs:complexType name="Stream">
+  <xs:simpleContent>
+    <xs:extension base="xs:string">
+      <xs:attribute name="type" default="locator">
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="locator"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="href" type="xs:anyURI"/>
+      <xs:attribute name="actuate" default="onRequest">
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="onLoad"/>
+            <xs:enumeration value="onRequest"/>
+            <xs:enumeration value="other"/>
+            <xs:enumeration value="none"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="encoding" type="encodingType" default="none"/>
+      <xs:attribute name="expires" type="xs:dateTime"/>
+      <xs:attribute name="rights" type="xs:token"/>
+    </xs:extension>
+  </xs:simpleContent>
+</xs:complexType>
+
+<!-- A TABLE is a sequence of FIELD/PARAMs and LINKS and DESCRIPTION, 
+     possibly followed by a DATA section 
+-->
+<xs:complexType name="Table">
+  <xs:annotation><xs:documentation>
+    Added in Version 1.2: INFO for diagnostics
+  </xs:documentation></xs:annotation>
+  <xs:sequence>
+    <xs:element name="DESCRIPTION" type="anyTEXT" minOccurs="0"/>
+<!-- GL: why a choice iso for example -->
+<!-- 
+      <xs:element name="PARAM" type="Param" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="FIELD" type="Field" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="GROUP" type="Group" minOccurs="0" maxOccurs="unbounded"/>
+-->
+<!-- 
+  This could also enforce groups to be defined after the fields and params 
+  to which they must have a reference, which is somewhat more logical
+-->
+    <!-- Added Version 1.2: -->
+    <xs:element name="INFO" type="Info" minOccurs="0" maxOccurs="unbounded"/> 
+    <!-- An empty table without any FIELD/PARAM should not be acceptable -->
+    <xs:choice minOccurs="1" maxOccurs="unbounded"> 
+      <xs:element name="FIELD" type="Field"/>
+      <xs:element name="PARAM" type="Param"/>
+      <xs:element name="GROUP" type="Group"/>
+    </xs:choice>
+    <xs:element name="LINK" type="Link" minOccurs="0" maxOccurs="unbounded"/>
+    <!-- This would allow several DATA parts in a table (future extension?)
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">  
+      <xs:element name="DATA" type="Data"/>
+      <xs:element name="INFO" type="Info" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    -->
+    <xs:element name="DATA" type="Data" minOccurs="0"/>
+    <xs:element name="INFO" type="Info" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attribute name="ID"   type="xs:ID"/>
+  <xs:attribute name="name" type="xs:token"/>
+  <xs:attribute name="ref"  type="xs:IDREF"/>
+  <xs:attribute name="ucd"  type="ucdType"/>
+  <xs:attribute name="utype" type="xs:string"/>
+  <xs:attribute name="nrows" type="xs:nonNegativeInteger"/>
+</xs:complexType>
+
+<!-- RESOURCES can contain DESCRIPTION, (INFO|PARAM|COSYS), LINK, TABLEs -->
+<xs:complexType name="Resource">
+  <xs:annotation><xs:documentation>
+     Added in Version 1.2: INFO for diagnostics in several places
+  </xs:documentation></xs:annotation>
+  <xs:sequence>
+    <xs:element name="DESCRIPTION" type="anyTEXT" minOccurs="0"/>
+    <xs:element name="INFO" type="Info" minOccurs="0" maxOccurs="unbounded"/>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="COOSYS" type="CoordinateSystem"/><!-- Deprecated in V1.2 -->
+      <xs:element name="GROUP" type="Group" />
+      <xs:element name="PARAM" type="Param" />
+    </xs:choice>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="LINK" type="Link" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:choice>
+        <xs:element name="TABLE" type="Table" />
+        <xs:element name="RESOURCE" type="Resource" />
+      </xs:choice>
+      <xs:element name="INFO" type="Info" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <!-- Suggested Doug Tody, to include new RESOURCE types -->
+    <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:token"/>
+  <xs:attribute name="ID"   type="xs:ID"/>
+  <xs:attribute name="utype" type="xs:string"/>
+  <xs:attribute name="type" default="results">
+    <xs:simpleType>
+      <xs:restriction base="xs:NMTOKEN">
+        <xs:enumeration value="results"/>
+        <xs:enumeration value="meta"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <!-- Suggested Doug Tody, to include new RESOURCE attributes -->
+  <xs:anyAttribute namespace="##other" processContents="lax"/>
+</xs:complexType>
+
+<!-- VOTable is the root element -->
+<xs:element name="VOTABLE">
+<xs:complexType>
+  <xs:sequence>
+    <xs:element name="DESCRIPTION" type="anyTEXT" minOccurs="0"/>
+    <xs:element name="DEFINITIONS" type="Definitions" minOccurs="0"/><!-- Deprecated -->
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="COOSYS" type="CoordinateSystem"/><!-- Deprecated in V1.2 -->
+      <xs:element name="GROUP" type="Group" />
+      <xs:element name="PARAM" type="Param" />
+      <xs:element name="INFO" type="Info" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:choice>
+    <xs:element name="RESOURCE" type="Resource" minOccurs="1" maxOccurs="unbounded"/>
+    <xs:element name="INFO" type="Info" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attribute name="ID" type="xs:ID"/>
+  <xs:attribute name="version">
+     <xs:simpleType>
+       <xs:restriction base="xs:NMTOKEN">
+         <xs:enumeration value="1.3"/>
+       </xs:restriction>
+     </xs:simpleType>
+   </xs:attribute>
+</xs:complexType>
+</xs:element>
+
+</xs:schema>

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -1,6 +1,6 @@
 package edu.gemini.catalog.api
 
-import edu.gemini.spModel.core.{MagnitudeBand, Coordinates, SiderealTarget}
+import edu.gemini.spModel.core.{MagnitudeBand, Coordinates, SiderealTarget, VersionToken}
 
 import scalaz._
 import Scalaz._
@@ -18,9 +18,17 @@ case class MagnitudeQueryFilter(mc: MagnitudeConstraints) extends QueryResultsFi
 }
 
 sealed abstract class CatalogName(val id: String, val displayName: String) extends Product with Serializable {
-  def supportedBands: List[MagnitudeBand] = Nil
+
+  def supportedBands: List[MagnitudeBand] =
+    Nil
+
   // Indicates what is the band used when a generic R band is required
-  def rBand: MagnitudeBand = MagnitudeBand.UC
+  def rBand: MagnitudeBand =
+    MagnitudeBand.UC
+
+  def voTableVersion: VersionToken =
+    VersionToken.unsafeFromIntegers(1, 2)
+
 }
 
 object CatalogName {
@@ -56,6 +64,9 @@ object CatalogName {
 
     override val rBand: MagnitudeBand =
       MagnitudeBand.R
+
+    override val voTableVersion: VersionToken =
+      VersionToken.unsafeFromIntegers(1, 3)
 
   }
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -4,7 +4,7 @@ import java.net.{URL, UnknownHostException}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.Logger
 
-import edu.gemini.catalog.api.{RadiusConstraint, NameCatalogQuery, ConeSearchCatalogQuery, CatalogQuery}
+import edu.gemini.catalog.api.{CatalogName, RadiusConstraint, NameCatalogQuery, ConeSearchCatalogQuery, CatalogQuery}
 import edu.gemini.spModel.core.Angle
 import edu.gemini.spModel.core.SiderealTarget
 import org.apache.commons.httpclient.{NameValuePair, HttpClient}
@@ -206,7 +206,7 @@ case object GaiaBackend extends CachedBackend with RemoteCallBackend {
 
     f"""|SELECT TOP $MaxResultCount $fields
         |      FROM gaiadr2.gaia_source
-        |     WHERE CONTAINS(POINT('ICRS',${Gaia.raField.id},${Gaia.decField.id}),CIRCLE('ICRS', ${cs.base.ra.toDegrees}%9.8f, ${cs.base.dec.toDegrees}%9.8f, ${cs.radiusConstraint.maxLimit.toDegrees}%9.8f))
+        |     WHERE CONTAINS(POINT('ICRS',${Gaia.raField.id},${Gaia.decField.id}),CIRCLE('ICRS', ${cs.base.ra.toDegrees}%9.8f, ${cs.base.dec.toDegrees}%9.8f, ${cs.radiusConstraint.maxLimit.toDegrees}%9.8f))=1
         |       AND (${Gaia.plxField.id} > 0)
         |       AND (${Gaia.gMagField.id} BETWEEN ${BrightLimit} AND ${FaintLimit})
         |       AND (${Gaia.bpRpField.id} IS NOT NULL)
@@ -280,10 +280,20 @@ trait VoTableClient {
 }
 
 object VoTableClient extends VoTableClient {
+
+  def defaultBackend(n: CatalogName): VoTableBackend =
+    n match {
+      case CatalogName.Gaia   => GaiaBackend
+      case CatalogName.SIMBAD => SimbadNameBackend
+      case _                  => ConeSearchBackend
+    }
+
   /**
    * Do a query for targets, it returns a list of targets and possible problems found
    */
-  def catalog(query: CatalogQuery, backend: VoTableBackend = ConeSearchBackend)(ec: ExecutionContext): Future[QueryResult] = {
+  def catalog(query: CatalogQuery, explicitBackend: Option[VoTableBackend])(ec: ExecutionContext): Future[QueryResult] = {
+    val backend = explicitBackend.getOrElse(defaultBackend(query.catalog))
+
     val f = for {
       url <- backend.catalogUrls
     } yield doQuery(query, url, backend)(ec)
@@ -296,8 +306,8 @@ object VoTableClient extends VoTableClient {
   /**
    * Do multiple parallel queries, it returns a consolidated list of targets and possible problems found
    */
-  def catalogs(queries: List[CatalogQuery], backend: VoTableBackend = ConeSearchBackend)(ec: ExecutionContext): Future[List[QueryResult]] = {
-    val r = queries.strengthR(backend).map { case (a, b) => catalog(a, b)(ec) }
+  def catalogs(queries: List[CatalogQuery], explicitBackend: Option[VoTableBackend])(ec: ExecutionContext): Future[List[QueryResult]] = {
+    val r = queries.strengthR(explicitBackend).map { case (a, b) => catalog(a, b)(ec) }
     Future.sequence(r)
   }
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -190,6 +190,54 @@ case object ConeSearchBackend extends CachedBackend with RemoteCallBackend {
   override def queryUrl(e: SearchKey): String = s"${e.url}/cgi-bin/conesearch.py"
 }
 
+case object GaiaBackend extends CachedBackend with RemoteCallBackend {
+  // For Java
+  val instance = this
+
+  val MaxResultCount: Int         = 1000
+  val BrightLimit: Int            =    6
+  val FaintLimit: Int             =   19
+  val ProperMotionLimitMasYr: Int =  100
+
+  def adql(cs: ConeSearchCatalogQuery): String = {
+    import CatalogAdapter.Gaia
+
+    val fields = Gaia.allFields.map(_.id).mkString(",")
+
+    f"""|SELECT TOP $MaxResultCount $fields
+        |      FROM gaiadr2.gaia_source
+        |     WHERE CONTAINS(POINT('ICRS',${Gaia.raField.id},${Gaia.decField.id}),CIRCLE('ICRS', ${cs.base.ra.toDegrees}%9.8f, ${cs.base.dec.toDegrees}%9.8f, ${cs.radiusConstraint.maxLimit.toDegrees}%9.8f))
+        |       AND (${Gaia.plxField.id} > 0)
+        |       AND (${Gaia.gMagField.id} BETWEEN ${BrightLimit} AND ${FaintLimit})
+        |       AND (${Gaia.bpRpField.id} IS NOT NULL)
+        |       AND (SQRT(POWER(${Gaia.pmRaField.id}, 2.0) + POWER(${Gaia.pmDecField.id}, 2.0)) < ${ProperMotionLimitMasYr})
+        |  ORDER BY ${Gaia.gMagField.id}
+      """.stripMargin
+  }
+
+  override protected [votable] def queryParams(q: CatalogQuery): Array[NameValuePair] =
+    q match {
+
+      case cs: ConeSearchCatalogQuery =>
+        Array(
+          new NameValuePair("REQUEST", "doQuery"      ),
+          new NameValuePair("LANG",    "ADQL"         ),
+          new NameValuePair("FORMAT",  "votable_plain"),
+          new NameValuePair("QUERY",   adql(cs)       )
+        )
+
+      case _                          =>
+        Array.empty
+    }
+
+
+  override val catalogUrls: NonEmptyList[URL] =
+    NonEmptyList(new URL("http://gea.esac.esa.int/tap-server/tap/sync"))
+
+  override def queryUrl(e: SearchKey): String =
+    e.url.toExternalForm
+}
+
 case object SimbadNameBackend extends CachedBackend with RemoteCallBackend {
   override val catalogUrls = NonEmptyList(new URL("http://simbad.cfa.harvard.edu/simbad"), new URL("http://simbad.u-strasbg.fr/simbad"))
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -305,6 +305,23 @@ object CatalogAdapter {
     val gMagField = FieldId("phot_g_mean_mag", Ucd("phot.mag;stat.mean;em.opt"))
     val bpRpField = FieldId("bp_rp",           Ucd("phot.color"               ))
 
+    /**
+     * List of all Gaia fields of interest.  These are used in forming the ADQL
+     * query that produces the VO Table.  See VoTableClient and the GaiaBackend.
+     */
+    val allFields: List[FieldId] =
+      List(
+        idField,
+        raField,
+        pmRaField,
+        decField,
+        pmDecField,
+        plxField,
+        rvField,
+        gMagField,
+        bpRpField
+      )
+
     final case class Conversion(
       b:   MagnitudeBand,
       g:   Double,

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -31,20 +31,19 @@ object VoTableParser extends VoTableParser {
   val UCD_MAG        = UcdWord("phot.mag")
   val STAT_ERR       = UcdWord("stat.error")
 
-  val xsd = "/votable-1.2.xsd"
+  private def validate(catalogName: CatalogName, xmlText: String): CatalogProblem \/ Unit =
+    \/.fromTryCatchNonFatal {
+      import javax.xml.transform.stream.StreamSource
+      import javax.xml.validation.SchemaFactory
 
-  private def validate(xmlText: String): Throwable \/ String = \/.fromTryCatchNonFatal {
-    import javax.xml.transform.stream.StreamSource
-    import javax.xml.validation.SchemaFactory
+      val xsd        = s"/votable-${catalogName.voTableVersion.format}.xsd"
+      val schemaLang = "http://www.w3.org/2001/XMLSchema"
+      val factory    = SchemaFactory.newInstance(schemaLang)
+      val schema     = factory.newSchema(new StreamSource(getClass.getResourceAsStream(xsd)))
+      val validator  = schema.newValidator()
 
-    val schemaLang = "http://www.w3.org/2001/XMLSchema"
-    val factory    = SchemaFactory.newInstance(schemaLang)
-    val schema     = factory.newSchema(new StreamSource(getClass.getResourceAsStream(xsd)))
-    val validator  = schema.newValidator()
-
-    validator.validate(new StreamSource(new ByteArrayInputStream(xmlText.getBytes(java.nio.charset.Charset.forName("UTF-8")))))
-    xmlText
-  }
+      validator.validate(new StreamSource(new ByteArrayInputStream(xmlText.getBytes(java.nio.charset.Charset.forName("UTF-8")))))
+    }.leftMap(_ => ValidationError(catalogName))
 
   /**
    * parse takes an input stream and attempts to read the xml content and convert it to a VoTable resource
@@ -65,8 +64,9 @@ object VoTableParser extends VoTableParser {
           } else {
             \/.right(parse(adapter, xml))
           }
-        case _ if validate(xmlText).isLeft => \/.left(ValidationError(catalog))
-        case _                             => \/.right(parse(adapter, XML.loadString(xmlText)))
+
+        case _                  =>
+          validate(catalog, xmlText).as(parse(adapter, XML.loadString(xmlText)))
       }
     }
 }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -48,15 +48,15 @@ class VoTableClientSpec extends Specification with VoTableClient {
     }
     "make a query" in {
       // This test loads a file. There is not much to test but it exercises the query backend chain
-      Await.result(VoTableClient.catalog(query, TestVoTableBackend("/votable-ucac4.xml"))(implicitly), 5.seconds).result.containsError should beFalse
+      Await.result(VoTableClient.catalog(query, Some(TestVoTableBackend("/votable-ucac4.xml")))(implicitly), 5.seconds).result.containsError should beFalse
     }
     "use the cache to skip queries" in {
       val counter = new AtomicInteger(0)
       val countingBackend = CountingCachedBackend(counter, "/votable-ucac4.xml")
       // Backend should be hit at most once per url
       val r = for {
-          f1 <- VoTableClient.catalog(query, countingBackend)(implicitly)
-          f2 <- VoTableClient.catalog(query, countingBackend)(implicitly)
+          f1 <- VoTableClient.catalog(query, Some(countingBackend))(implicitly)
+          f2 <- VoTableClient.catalog(query, Some(countingBackend))(implicitly)
         } yield (f1, f2)
       // Check both have the same results
       val result = Await.result(r, 10.seconds)
@@ -71,8 +71,8 @@ class VoTableClientSpec extends Specification with VoTableClient {
       val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), noMagnitudeConstraint, UCAC4)
       // Backend should be hit at most once per url
       val r = for {
-          f1 <- VoTableClient.catalog(query, countingBackend)(implicitly)
-          f2 <- VoTableClient.catalog(query2, countingBackend)(implicitly)
+          f1 <- VoTableClient.catalog(query, Some(countingBackend))(implicitly)
+          f2 <- VoTableClient.catalog(query2, Some(countingBackend))(implicitly)
         } yield (f1, f2)
       Await.result(r, 10.seconds)
       // Depending on timing it could hit all or less than all parallel urls
@@ -86,9 +86,9 @@ class VoTableClientSpec extends Specification with VoTableClient {
       val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromArcmin(12)), noMagnitudeConstraint, UCAC4)
       // Backend should be hit at most once per url
       val r = for {
-          f1 <- VoTableClient.catalog(query, countingBackend)(implicitly)
+          f1 <- VoTableClient.catalog(query, Some(countingBackend))(implicitly)
           _  <- Future.successful(TimeUnit.SECONDS.sleep(1)) // Give it time to hit the first query
-          f2 <- VoTableClient.catalog(query2, countingBackend)(implicitly)
+          f2 <- VoTableClient.catalog(query2, Some(countingBackend))(implicitly)
         } yield (f1, f2)
       // Depending on timing it could hit all or less than all parallel urls
       counter.get() should be_<=(countingBackend.catalogUrls.size)
@@ -102,10 +102,10 @@ class VoTableClientSpec extends Specification with VoTableClient {
       val query3 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.2)), noMagnitudeConstraint, UCAC4)
       // Backend should be hit at most once per url
       val r = for {
-          f1 <- VoTableClient.catalog(query, countingBackend)(implicitly)
+          f1 <- VoTableClient.catalog(query, Some(countingBackend))(implicitly)
           _  <- Future.successful(TimeUnit.SECONDS.sleep(1)) // Give it time to hit the first query
-          f2 <- VoTableClient.catalog(query2, countingBackend)(implicitly)
-          f3 <- VoTableClient.catalog(query3, countingBackend)(implicitly)
+          f2 <- VoTableClient.catalog(query2, Some(countingBackend))(implicitly)
+          f3 <- VoTableClient.catalog(query3, Some(countingBackend))(implicitly)
         } yield (f1, f2, f3)
       // Depending on timing it could hit all or less than all parallel urls
       counter.get() should be_<=(2 * countingBackend.catalogUrls.size)
@@ -117,8 +117,8 @@ class VoTableClientSpec extends Specification with VoTableClient {
       val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), noMagnitudeConstraint, UCAC4)
       // Backend should be hit at most once per url
       val r = for {
-          f1 <- VoTableClient.catalog(query, countingBackend)(implicitly)
-          f2 <- VoTableClient.catalog(query2, countingBackend)(implicitly)
+          f1 <- VoTableClient.catalog(query, Some(countingBackend))(implicitly)
+          f2 <- VoTableClient.catalog(query2, Some(countingBackend))(implicitly)
         } yield (f1, f2)
       val result = Await.result(r, 10.seconds)
       // Check that each query is matched
@@ -132,9 +132,9 @@ class VoTableClientSpec extends Specification with VoTableClient {
       val query2 = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.05)), noMagnitudeConstraint, UCAC4)
       //
       val r = for {
-          f1 <- VoTableClient.catalog(query, countingBackend)(implicitly)
+          f1 <- VoTableClient.catalog(query, Some(countingBackend))(implicitly)
           _  <- Future.successful(TimeUnit.SECONDS.sleep(1)) // Give it time to hit the first query
-          f2 <- VoTableClient.catalog(query2, countingBackend)(implicitly)
+          f2 <- VoTableClient.catalog(query2, Some(countingBackend))(implicitly)
         } yield (f1, f2)
       val result = Await.result(r, 10.seconds)
       // Check that the second query has less hits than the first given its smaller range
@@ -146,7 +146,7 @@ class VoTableClientSpec extends Specification with VoTableClient {
       val mc = MagnitudeConstraints(SingleBand(MagnitudeBand.J), FaintnessConstraint(15.0), None)
       val query = CatalogQuery(coordinates, RadiusConstraint.between(Angle.fromDegrees(0), Angle.fromDegrees(0.1)), mc, UCAC4)
 
-      val result = Await.result(VoTableClient.catalog(query, countingBackend)(implicitly), 10.seconds)
+      val result = Await.result(VoTableClient.catalog(query, Some(countingBackend))(implicitly), 10.seconds)
       // Extract the query params from the results
       result.query should beEqualTo(query)
     }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/VersionToken.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/VersionToken.scala
@@ -1,0 +1,73 @@
+package edu.gemini.spModel.core
+
+import scalaz._
+import Scalaz._
+
+/**
+ * Simple integer version token (e.g., 1.2.3) used to distinguish VO Table
+ * versions.
+ */
+sealed abstract case class VersionToken private (toNel: NonEmptyList[Int]) {
+
+  // Guaranteed by companion class, sanity checked here.
+  assert(toNel.list.all(_ >= 0))
+
+  /**
+   * Formats a version token into a series of non-zero integers separated by
+   * periods. For example "1.2.3".
+   */
+  def format: String =
+    toNel.list.toList.mkString(".")
+
+}
+
+object VersionToken {
+
+  /**
+   * Creates a `VersionToken` from a `NonEmptyList` of `Int` assuming the are
+   * all non-negative.
+   */
+  def fromNel(nel: NonEmptyList[Int]): Option[VersionToken] =
+    if (nel.list.all(_ >= 0)) Some(new VersionToken(nel) {}) else None
+
+  /**
+   * Creates a `VersionToken` from a series of `Int`, assuming they are all
+   * non-negative.
+   */
+  def fromIntegers(h: Int, t: Int*): Option[VersionToken] =
+    fromNel(NonEmptyList(h, t: _*))
+
+  /**
+   * Creates a `VersionToken` from a series of `Int`, throwing an exception if
+   * any are negative.
+   */
+  def unsafeFromIntegers(h: Int, t: Int*): VersionToken =
+    fromIntegers(h, t: _*)
+      .getOrElse(sys.error(s"negative version number(s): " + (h :: t.toList).mkString(", ")))
+
+  /**
+   * Parses a String version representation, assuming it is a series of
+   * non-negative integers separated by periods.
+   */
+  def parse(s: String): Option[VersionToken] =
+    \/.fromTryCatchNonFatal(s.split('.').map(_.toInt).toList)
+      .toOption
+      .flatMap {
+        case i :: is => fromNel(NonEmptyList(i, is: _*))
+        case _       => None
+      }
+
+  /**
+   * Parses a String version representation, throwing an exception if invalid.
+   */
+  def unsafeParse(s: String): VersionToken =
+    parse(s).getOrElse(sys.error(s"invalid version string '$s'"))
+
+
+  implicit def VersionTokenOrder: Order[VersionToken] =
+    new Order[VersionToken] {
+      def order(a: VersionToken, b: VersionToken): Ordering =
+        a.toNel.list.toList.zipAll(b.toNel.list.toList, 0, 0)
+         .foldMap { case (a0, b0) => Ordering.fromInt(a0 - b0) }
+    }
+}

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/Arbitraries.scala
@@ -186,4 +186,9 @@ trait Arbitraries {
   implicit def arbMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[K ==>> V] =
     Arbitrary(arbitrary[List[(K, V)]].map(==>>.fromList(_)))
 
+  implicit val arbVersionToken: Arbitrary[VersionToken] =
+    Arbitrary(nonEmptyListOf(posNum[Int]).map {
+      case i :: is => VersionToken.unsafeFromIntegers(i, is: _*)
+      case _       => sys.error("generated empty list!?")
+    })
 }

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/VersionTokenSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/VersionTokenSpec.scala
@@ -1,0 +1,48 @@
+package edu.gemini.spModel.core
+
+import org.scalacheck.Prop.forAll
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+object VersionTokenSpec extends Specification with Arbitraries with ScalaCheck {
+
+  "VersionToken" should {
+
+    "correspond to the format" in
+      forAll { (v: VersionToken) =>
+        v.format.split('.').toList.map(_.toInt) == v.toNel.list.toList
+      }
+
+    "roundtrip format => parse" in
+      forAll { (v: VersionToken) =>
+        VersionToken.parse(v.format) == Some(v)
+      }
+
+    "rountrip toNel => fromNel" in
+      forAll { (v: VersionToken) =>
+        VersionToken.fromNel(v.toNel) == Some(v)
+      }
+
+    "order properly" in
+      forAll { (v0: VersionToken, v1: VersionToken) =>
+
+        def zip(a: VersionToken, b: VersionToken): List[(Int, Int)] =
+          a.toNel.list.toList.zipAll(b.toNel.list.toList, 0, 0)
+
+        def isLt(a: VersionToken, b: VersionToken): Boolean =
+          zip(a, b).dropWhile {
+            case (n0, n1) => n0 == n1
+          }.headOption.exists {
+            case (n0, n1) => n0 < n1
+          }
+
+        (scalaz.Order[VersionToken]).apply(v0, v1) match {
+          case scalaz.Ordering.LT => isLt(v0, v1)
+          case scalaz.Ordering.GT => isLt(v1, v0)
+          case _                  => zip(v0, v1).forall { case (n0, n1) => n0 == n1 }
+        }
+      }
+
+  }
+
+}

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/SiderealNameEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/SiderealNameEditor.scala
@@ -24,7 +24,7 @@ final class SiderealNameEditor(mags: MagnitudeEditor2) extends TelescopePosEdito
   private def forkSearch(): Unit = {
     val searchItem = name.getValue
     val glass      = GlassLabel.show(name, "Searching ...") // We are on the EDT
-    VoTableClient.catalog(CatalogQuery(searchItem), SimbadNameBackend)(implicitly).onComplete { case tqr =>
+    VoTableClient.catalog(CatalogQuery(searchItem), None)(implicitly).onComplete { case tqr =>
       Swing.onEDT {
         glass.foreach(_.hide())
         tqr.map(r => (r.result.problems, r.result.targets.rows.headOption)) match {


### PR DESCRIPTION
The next REL-3676 installment adds Gaia to `VoTableClient` and updates the manual catalog UI to include Gaia in the list of options.

The bulk of this PR is the VO Table schema 1.3 version (which is needed for the Gaia results) but doesn't need to be reviewed.  It also adds a `VersionToken` class to work with the schema versions.