### PR TITLE
REL-3448: Fixed PARALLACTIC_OVERRIDE to not flip by 180.

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -167,9 +167,9 @@ final case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStr
         case vprobe: VProbe =>
           // Filter for brightness constraints and reachability.
           val results = ctx.getPosAngleConstraint match {
-            case FIXED                                                => filterBounded(List(ctx), mt, candidates)
-            case FIXED_180 | PARALLACTIC_ANGLE | PARALLACTIC_OVERRIDE => filterBounded(List(ctx, ctx180(ctx)), mt, candidates)
-            case UNBOUNDED                                            => filterUnbounded(ctx, mt, candidates)
+            case FIXED | PARALLACTIC_OVERRIDE  => filterBounded(List(ctx), mt, candidates)
+            case FIXED_180 | PARALLACTIC_ANGLE => filterBounded(List(ctx, ctx180(ctx)), mt, candidates)
+            case UNBOUNDED                     => filterUnbounded(ctx, mt, candidates)
           }
 
           // Select the highest quality target that vignettes the least.
@@ -178,9 +178,9 @@ final case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStr
         // Otherwise proceed as normal.
         case _ =>
           val results = ctx.getPosAngleConstraint match {
-            case FIXED                                                => selectBounded(List(ctx), mt, candidates)
-            case FIXED_180 | PARALLACTIC_ANGLE | PARALLACTIC_OVERRIDE => selectBounded(List(ctx, ctx180(ctx)), mt, candidates)
-            case UNBOUNDED                                            => selectUnbounded(ctx, mt, candidates)
+            case FIXED | PARALLACTIC_OVERRIDE  => selectBounded(List(ctx), mt, candidates)
+            case FIXED_180 | PARALLACTIC_ANGLE => selectBounded(List(ctx, ctx180(ctx)), mt, candidates)
+            case UNBOUNDED                     => selectUnbounded(ctx, mt, candidates)
           }
           params.brightest(results)(_._2).map {
             case (angle, st) => AgsStrategy.Selection(angle, List(AgsStrategy.Assignment(params.guideProbe, st)))


### PR DESCRIPTION
When using the `PARALLACTIC_OVERRIDE` mode, it was possible for the parallactic angle to be flipped by 180 degrees, which is not the desired behaviour as the PI knows what angle is desired. Thus, the `PARALLACTIC_OVERRIDE` option should behave like the `FIXED` option instead of the `FIXED_180` option.

This fixes that so that the angle does not end up flipped.