### PR TITLE
add montage image servers

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalogClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/image/ImageCatalogClient.scala
@@ -179,6 +179,7 @@ object ImageCatalogClient {
     def openConnection: Task[ConnectionDescriptor] = Task.delay {
       Log.info(s"Downloading image at $url")
       val connection = url.openConnection()
+      connection.setReadTimeout(90 * 1000) // Montage can take a while
       ConnectionDescriptor(Option(connection.getContentType), Option(connection.getContentEncoding), connection.getInputStream)
     }
 


### PR DESCRIPTION
This adds the Montage version of the 2MASS image server, which create custom tiled images that fill the TPE field better than the existing servers. Here is an example looking at M3. It's a little movie actually, if you click on it.

![2019-10-23 13 19 26](https://user-images.githubusercontent.com/1200131/67422676-8fecb680-f598-11e9-9671-190e53eea712.gif)

Note that the image in the example has been cached locally. The first time it was accessed it took about 30 seconds, because the mosaic process has to do a lot of work aligning/scaling/rotating and matching contrast levels. The server caches tiles (so nearby positions will resolve more quickly) as well as the final mosaic image (so other people looking at the observation should receive the image quickly).

This is work-in-progress (need to move the montage server over to Gemini, it's running on my private Heroku account right now).