### PR TITLE
REL-3743-B: fix test case which would have failed in the future

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/DefaultSchedulingBlock.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/DefaultSchedulingBlock.scala
@@ -46,12 +46,6 @@ object DefaultSchedulingBlock {
     center(new Semester(site, System.currentTimeMillis), site)
 
   private def center(sem: Semester, site: Site): Long =
-    center(sem.getStartDate(site), sem.getEndDate(site))
-
-  private def center(a: Date, b: Date): Long =
-    center(a.getTime, b.getTime)
-
-  private def center(a: Long, b: Long): Long =
-    a + (b - a) / 2
+    sem.getMidpointDate(site).getTime
 
 }

--- a/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2020A/SchedulingBlockTest.scala
+++ b/bundle/edu.gemini.spModel.io/src/test/scala/edu/gemini/spModel/io/impl/migration/to2020A/SchedulingBlockTest.scala
@@ -2,16 +2,28 @@ package edu.gemini.spModel.io.impl.migration.to2020A
 
 import edu.gemini.pot.sp.{ISPObservation, ISPProgram}
 import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.spModel.core.{Semester, Site}
 import edu.gemini.spModel.io.impl.migration.MigrationTest
 import edu.gemini.spModel.obs.{SchedulingBlock, SPObservation}
 import edu.gemini.spModel.rich.pot.sp._
 import org.specs2.mutable.Specification
+
+import scala.math.Ordering.Implicits._
 
 
 class SchedulingBlockTest extends Specification with MigrationTest {
 
   val ProgramName: String =
     "GS-2020A-Q-501.xml"
+
+  val sem2020A: Semester =
+    new Semester(2020, Semester.Half.A)
+
+  def currentSemester: Semester =
+    new Semester(Site.GS, System.currentTimeMillis)
+
+  def block(sem: Semester): SchedulingBlock =
+    SchedulingBlock(sem.getMidpointDate(Site.GS).getTime, SchedulingBlock.Duration.Unstated)
 
   val Mid2020A: SchedulingBlock =
     SchedulingBlock(1588354200000L, SchedulingBlock.Duration.Unstated)
@@ -29,8 +41,9 @@ class SchedulingBlockTest extends Specification with MigrationTest {
          .getOrElse(sys.error(s"Couldn't find observation $num"))
     }
 
-    "Add a scheduling block when not present" in withTestProgram2(ProgramName) {
-      _.findObsNumber(1).getSchedulingBlock.asScalaOpt must_== Some(Mid2020A)
+    "Add a scheduling block when not present" in withTestProgram2(ProgramName) { p =>
+      val expected = Some(block(List(currentSemester, sem2020A).max))
+      p.findObsNumber(1).getSchedulingBlock.asScalaOpt must_== expected
     }
 
     "Keep an existing scheduling block when present" in withTestProgram2(ProgramName) {


### PR DESCRIPTION
This PR updates #1716 to future-proof a test case.  The way that `DefaultSchedulingBlock` works is that it

1. Extracts the semester from a program id
2. Computes the midpoint of said semester
3. Compares it to the midpoint of the current semester
4. Chooses the bigger of the two for the scheduling block start

```scala
  def forPid(pid: SPProgramID): SchedulingBlock =
    SchedulingBlock(
      getPidSemesterCenter(pid).foldLeft(getCurrentSemesterCenter(Site.GS))(_ max _)
    )
```

The test case ignored that fact and would begin failing post-2020A without this update. 