### PR TITLE
REL-3747: visualization of PWFS1 options

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -151,7 +151,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
                 if (updated) {
                   val info = ObservationInfo(c, mt)
-                  val tm   = TargetsModel(info.some, q.base, q.radiusConstraint, m.targets)
+                  val tm   = TargetsModel(info.some, q.base, q.radiusConstraint, m.probeCandidates)
                   updateResultsModel(tm)
 
                   iw.repaint()
@@ -355,7 +355,11 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
       case q: ConeSearchCatalogQuery =>
         unplotCurrent()
 
-        val model = TargetsModel(info, q.base, q.radiusConstraint, queryResult.result.targets.rows)
+        val pc = info.flatMap(_.guideProbe).fold(List.empty[ProbeCandidates]) { gp =>
+          List(ProbeCandidates(gp, queryResult.result.targets.rows))
+        }
+
+        val model = TargetsModel(info, q.base, q.radiusConstraint, pc)
         updateResultsModel(model)
 
         // Update the count of rows

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TpePlotter.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/TpePlotter.scala
@@ -237,13 +237,14 @@ object adapters {
     // Table QueryResult methods
     override def getCatalog: Catalog = catalog
 
-    override def getDataVector: java.util.Vector[java.util.Vector[AnyRef]] = new java.util.Vector(model.targets.map { t =>
-      val mags = MagnitudeBand.all.map(t.magnitudeIn).collect {
-        case Some(v) => Double.box(v.value)
-        case None => null // This is required for the Java side of plotting
-      }
-      new java.util.Vector[AnyRef]((List(t.name, t.coordinates.ra.toAngle.formatHMS, t.coordinates.dec.formatDMS, GuidingQualityColumn.target2Analysis(model.info, t).map(_.quality), GuidingQualityColumn.target2FOV(model.info, t)) ::: mags).asJavaCollection)
-    }.asJavaCollection)
+    override def getDataVector: java.util.Vector[java.util.Vector[AnyRef]] =
+      new java.util.Vector(model.probeCandidates.flatMap(pc => pc.targets.strengthL(pc.guideProbe)).map { case (gp, t) =>
+        val mags = MagnitudeBand.all.map(t.magnitudeIn).collect {
+          case Some(v) => Double.box(v.value)
+          case None    => null // This is required for the Java side of plotting
+        }
+        new java.util.Vector[AnyRef]((List(t.name, t.coordinates.ra.toAngle.formatHMS, t.coordinates.dec.formatDMS, GuidingQualityColumn.target2Analysis(model.info, Some(gp), t).map(_.quality), GuidingQualityColumn.target2FOV(model.info, Some(gp), t)) ::: mags).asJavaCollection)
+      }.asJavaCollection)
 
     override def getColumnDesc(i: Int): FieldDesc = ???
 

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -29,7 +29,7 @@ import edu.gemini.spModel.gemini.phoenix.InstPhoenix
 import edu.gemini.spModel.gemini.texes.InstTexes
 import edu.gemini.spModel.gemini.trecs.InstTReCS
 import edu.gemini.spModel.gemini.visitor.VisitorInstrument
-import edu.gemini.spModel.guide.{GuideStarValidation, ValidatableGuideProbe}
+import edu.gemini.spModel.guide.{GuideProbe, GuideStarValidation, ValidatableGuideProbe}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env.TargetEnvironment
@@ -228,31 +228,38 @@ case class IdColumn(title: String) extends CatalogNavigatorColumn[String] {
 object GuidingQualityColumn {
   implicit val analysisOrder:Order[AgsAnalysis] = Order.orderBy(_.quality)
 
+  def validatableGuideProbe(gp: GuideProbe): Option[ValidatableGuideProbe] =
+    gp match {
+      case vgp: ValidatableGuideProbe => Some(vgp)
+      case _                          => None
+    }
+
   // Calculate the guiding quality of the target considering only its magnitude
   // while ignoring reachability.
-  def target2Analysis(info: Option[ObservationInfo], t: SiderealTarget): Option[AgsAnalysis] =
+  def target2Analysis(info: Option[ObservationInfo], gpo: Option[GuideProbe], t: SiderealTarget): Option[AgsAnalysis] =
     for {
       o   <- info
+      vgp <- gpo.flatMap(validatableGuideProbe) orElse o.guideProbe
       s   <- o.strategy
-      gp  <- o.guideProbe
       ctx <- o.toContext
-      a   <- s.strategy.analyzeMagnitude(ctx, o.mt, gp, t)
+      a   <- s.strategy.analyzeMagnitude(ctx, o.mt, vgp, t)
     } yield a
 
   // Calculate if the target is inside the probe FOV
-  def target2FOV(info: Option[ObservationInfo], t: Target): Option[GuideInFOV] = {
+  def target2FOV(info: Option[ObservationInfo], gpo: Option[GuideProbe], t: Target): Option[GuideInFOV] = {
     for {
       o   <- info
-      gp  <- o.guideProbe
+      vgp <- gpo.flatMap(validatableGuideProbe) orElse o.guideProbe
       ctx <- o.toContext
       c   <- t.coords(None)
       st = new SPTarget(SiderealTarget.empty.copy(coordinates = c))
-    } yield (gp.validate(st, ctx) === GuideStarValidation.VALID).fold(Inside, Outside)
+    } yield (vgp.validate(st, ctx) === GuideStarValidation.VALID).fold(Inside, Outside)
   }
 }
 
 case class GuidingQualityColumn(info: Option[ObservationInfo], title: String) extends CatalogNavigatorColumn[AgsGuideQuality] {
-  val gf: SiderealTarget @?> AgsGuideQuality = PLens{ t => GuidingQualityColumn.target2Analysis(info, t).map(p => Store(_ => sys.error("Not in use"), p.quality)) }
+  val gf: SiderealTarget @?> AgsGuideQuality =
+    PLens{ t => GuidingQualityColumn.target2Analysis(info, None, t).map(p => Store(_ => sys.error("Not in use"), p.quality)) }
 
   override val lens: Target @?> AgsGuideQuality = PLens(_.fold(
     PLens.nil.run,
@@ -264,7 +271,8 @@ case class GuidingQualityColumn(info: Option[ObservationInfo], title: String) ex
 }
 
 case class InFOVColumn(info: Option[ObservationInfo], title: String) extends CatalogNavigatorColumn[GuideInFOV] {
-  val gf: SiderealTarget @?> GuideInFOV = PLens{ t => GuidingQualityColumn.target2FOV(info, t).map(p => Store(_ => sys.error("Not in use"), p)) }
+  val gf: SiderealTarget @?> GuideInFOV =
+    PLens{ t => GuidingQualityColumn.target2FOV(info, None, t).map(p => Store(_ => sys.error("Not in use"), p)) }
 
   override val lens: Target @?> GuideInFOV = PLens(_.fold(
     PLens.nil.run,
@@ -342,7 +350,11 @@ case class MagnitudeColumn(band: MagnitudeBand) extends CatalogNavigatorColumn[M
 /**
  * Data model for the main table of the catalog navigator
  */
-case class TargetsModel(info: Option[ObservationInfo], base: Coordinates, radiusConstraint: RadiusConstraint, targets: List[SiderealTarget]) extends AbstractTableModel {
+case class TargetsModel(info: Option[ObservationInfo], base: Coordinates, radiusConstraint: RadiusConstraint, probeCandidates: List[ProbeCandidates]) extends AbstractTableModel {
+
+  val targets: List[SiderealTarget] =
+    probeCandidates.flatMap(_.targets)
+
   // Required to give limits to the existential type list
   type ColumnsList = List[CatalogNavigatorColumn[A] forSome { type A >: Null <: AnyRef}]
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeCatalogFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeCatalogFeature.scala
@@ -82,13 +82,13 @@ final class TpeCatalogFeature extends TpeImageFeature("Catalog", "Show or hide c
       s <- AgsRegistrar.currentStrategy(c)
       m  = ProbeLimitsTable.loadOrThrow()
       q <- s.catalogQueries(c, m).headOption.collect { case cs: ConeSearchCatalogQuery => cs }
-    } s.candidates(c, m)(global).map(_.flatMap(_.targets)).onSuccess { case ts =>
+    } s.candidates(c, m)(global).onSuccess { case pc =>
       Swing.onEDT {
         // assuming the state of the world is the same after the candidate
         // search, plot the candidates
         if (state == plotState(w)) {
           val in = ObservationInfo(c, m)
-          val tm = TargetsModel(Some(in), q.base, q.radiusConstraint, ts)
+          val tm = TargetsModel(Some(in), q.base, q.radiusConstraint, pc)
           p.plot(TableQueryResultAdapter(tm))
         }
       }


### PR DESCRIPTION
This PR adds visualization of PWFS1 options to the guide star candidate plot for GSOI/GeMS.  The challenging bit was a change to the plotter to accept an explicitly provided guide probe for the magnitude evaluation instead of always using the default guide probe for the strategy (CWFS1 in the case of the `Ngs2Strategy`).