### PR TITLE
re-use JAXB context

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ProposalIo.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/ProposalIo.scala
@@ -19,7 +19,7 @@ case class ProposalConversion(transformed: Boolean, from: Semester, changes: Seq
 object ProposalIo {
   private val LOG = Logger.getLogger(getClass.getName)
 
-  private def context: JAXBContext = {
+  private val context: JAXBContext = {
     val factory        = new M.ObjectFactory
     val contextPackage = factory.getClass.getName.reverse.dropWhile(_ != '.').drop(1).reverse
     JAXBContext.newInstance(contextPackage, ProposalIo.getClass.getClassLoader)


### PR DESCRIPTION
re-using the JAXB context for subsequent P1 Proposal deserialization speeds things up significantly. Loading up the 19B proposals went from 30s to < 2s.