### PR TITLE
GHOSTSW-9: Divide asterism types into resolution modes

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/ResolutionMode.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/ResolutionMode.java
@@ -3,6 +3,10 @@ package edu.gemini.spModel.target.env;
 import java.util.*;
 
 public enum ResolutionMode {
+    // This will be used by every instrument other than GHOST and thus can be considered disjoint;
+    // the overlapping name should not make a difference.
+    Standard("standard", "Standard Resolution", Collections.emptyList()),
+
     GhostStandard("ghostStandard", "Standard Resolution",
             Arrays.asList(
                     AsterismType.GhostSingleTarget,
@@ -28,5 +32,10 @@ public enum ResolutionMode {
         this.tag = tag;
         this.name = name;
         this.asterismTypes = asterismTypes;
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/ResolutionMode.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/ResolutionMode.java
@@ -1,0 +1,32 @@
+package edu.gemini.spModel.target.env;
+
+import java.util.*;
+
+public enum ResolutionMode {
+    GhostStandard("ghostStandard", "Standard Resolution",
+            Arrays.asList(
+                    AsterismType.GhostSingleTarget,
+                    AsterismType.GhostDualTarget,
+                    AsterismType.GhostTargetPlusSky,
+                    AsterismType.GhostSkyPlusTarget)
+    ),
+    GhostHigh("ghostHigh", "High Resolution",
+            Arrays.asList(
+                    AsterismType.GhostHighResolutionTarget,
+                    AsterismType.GhostHighResolutionTargetPlusSky
+            )),
+    GhostPRV("ghostPRV", "Precision Radial Velocity",
+            Collections.singletonList(AsterismType.GhostHighResolutionTarget));
+
+    public final String tag;
+    public final String name;
+    public final List<AsterismType> asterismTypes;
+
+    ResolutionMode(final String tag,
+                   final String name,
+                   final List<AsterismType> asterismTypes) {
+        this.tag = tag;
+        this.name = name;
+        this.asterismTypes = asterismTypes;
+    }
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
@@ -11,10 +11,9 @@ object AsterismTypeConverters {
    * 1. An initial ResolutionMode RM1 amd an AsterismType AT1
    * 2. A desired ResolutionMode RM2
    * Find the AsterismType that best matches.
-   * This is in place so that when the resolution mode is changed, the target data is maintained.
+   * This is in place so that when the resolution mode is changed, a cponversion can be performed so that the target
+   * data is maintained.
    */
-    // TODO-GHOST: Are the PRV conversions correct?
-    // TODO-GHOST: Do we need to introduce anything other asterism types for them?
   val asterismTypeConverters: Map[(ResolutionMode, AsterismType, ResolutionMode), AsterismType] = Map(
       (GhostStandard, GhostSingleTarget, GhostHigh)  -> GhostHighResolutionTarget,
       (GhostStandard, GhostSingleTarget, GhostPRV)   -> GhostHighResolutionTarget,

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
@@ -1,0 +1,14 @@
+package edu.gemini.spModel.gemini.ghost
+
+import edu.gemini.spModel.target.env.{AsterismType, ResolutionMode}
+
+object AsterismTypeConverters {
+  /**
+   * Given:
+   * 1. An initial ResolutionMode RM1 amd an AsterismType AT1
+   * 2. A desired ResolutionMode RM2
+   * Find the AsterismType that best matches.
+   * This is in place so that when the resolution mode is changed, the target data is maintained.
+   */
+  val asterismTypeConverters: Map[(ResolutionMode, AsterismType],
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
@@ -1,8 +1,11 @@
 package edu.gemini.spModel.gemini.ghost
 
 import edu.gemini.spModel.target.env.{AsterismType, ResolutionMode}
+import edu.gemini.spModel.target.env.AsterismType._
+import edu.gemini.spModel.target.env.ResolutionMode._
 
 object AsterismTypeConverters {
+
   /**
    * Given:
    * 1. An initial ResolutionMode RM1 amd an AsterismType AT1
@@ -10,5 +13,22 @@ object AsterismTypeConverters {
    * Find the AsterismType that best matches.
    * This is in place so that when the resolution mode is changed, the target data is maintained.
    */
-  val asterismTypeConverters: Map[(ResolutionMode, AsterismType],
+    // TODO-GHOST: Are the PRV conversions correct?
+    // TODO-GHOST: Do we need to introduce anything other asterism types for them?
+  val asterismTypeConverters: Map[(ResolutionMode, AsterismType, ResolutionMode), AsterismType] = Map(
+      (GhostStandard, GhostSingleTarget, GhostHigh)  -> GhostHighResolutionTarget,
+      (GhostStandard, GhostSingleTarget, GhostPRV)   -> GhostHighResolutionTarget,
+      (GhostStandard, GhostDualTarget, GhostHigh)    -> GhostHighResolutionTargetPlusSky,
+      (GhostStandard, GhostDualTarget, GhostPRV)     -> GhostHighResolutionTarget,
+      (GhostStandard, GhostTargetPlusSky, GhostHigh) -> GhostHighResolutionTargetPlusSky,
+      (GhostStandard, GhostTargetPlusSky, GhostPRV)  -> GhostHighResolutionTarget,
+      (GhostStandard, GhostSkyPlusTarget, GhostHigh) -> GhostHighResolutionTargetPlusSky,
+      (GhostStandard, GhostSkyPlusTarget, GhostPRV)  -> GhostHighResolutionTarget,
+
+      (GhostHigh, GhostHighResolutionTarget, GhostStandard) -> GhostSingleTarget,
+      (GhostHigh, GhostHighResolutionTarget, GhostPRV)      -> GhostSingleTarget,
+      (GhostHigh, GhostHighResolutionTargetPlusSky, GhostStandard) -> GhostTargetPlusSky,
+      (GhostHigh, GhostHighResolutionTargetPlusSky, GhostPRV) -> GhostHighResolutionTarget,
+
+      (GhostPRV, GhostHighResolutionTarget, GhostStandard) -> GhostSingleTarget)
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -3,7 +3,7 @@ package edu.gemini.spModel.gemini.ghost
 import edu.gemini.spModel.core._
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover
 import edu.gemini.spModel.target.{SPCoordinates, SPTarget}
-import edu.gemini.spModel.target.env.{Asterism, AsterismType}
+import edu.gemini.spModel.target.env.{Asterism, AsterismType, ResolutionMode}
 import java.time.Instant
 
 import scalaz._
@@ -173,6 +173,8 @@ object GhostAsterism {
       case SkyPlusTarget(_,t,_) => t.coordinates(when)
     }
 
+    override def resolutionMode: ResolutionMode = ResolutionMode.GhostStandard
+
     override def asterismType: AsterismType = this match {
       case SingleTarget(_,_)    => AsterismType.GhostSingleTarget
       case DualTarget(_,_,_)    => AsterismType.GhostDualTarget
@@ -264,6 +266,8 @@ object GhostAsterism {
       case HighResolutionTarget(t,b) => HighResolutionTarget(t.copyWithClonedTarget, b.map(_.clone))
       case HighResolutionTargetPlusSky(t,s,b) => HighResolutionTargetPlusSky(t.copyWithClonedTarget, s.clone, b.map(_.clone))
     }
+
+    override def resolutionMode: ResolutionMode = ResolutionMode.GhostHigh
 
     override def asterismType: AsterismType = this match {
       case HighResolutionTarget(_,_)          => AsterismType.GhostHighResolutionTarget

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -92,6 +92,9 @@ trait Asterism {
   /** Construct a copy of this Asterism with cloned SPTargets (necessary because they are mutable). */
   def copyWithClonedTargets: Asterism
 
+  // The mode of the resolultion: should be standard for everything but GHOST.
+  def resolutionMode: ResolutionMode
+
   // Get the type of this asterism as an AsterismType.
   def asterismType: AsterismType
 }
@@ -110,6 +113,7 @@ object Asterism {
     override def basePosition(time: Option[Instant]) = t.getCoordinates(time.map(_.toEpochMilli))
     override def copyWithClonedTargets() = Single(t.clone)
     override def basePositionProperMotion = Target.pm.get(t.getTarget)
+    override def resolutionMode: ResolutionMode = ResolutionMode.Standard
     override def asterismType: AsterismType = AsterismType.Single
   }
 

--- a/bundle/jsky.app.ot/src/main/resources/resources/conf/UIInfo.xml
+++ b/bundle/jsky.app.ot/src/main/resources/resources/conf/UIInfo.xml
@@ -390,7 +390,7 @@
 
     <UIInfo site="GS"
             dataObject="edu.gemini.spModel.gemini.ghost.Ghost"
-            name="GHOST instrument"
+            name="GHOST Instrument"
             type="instrument"
             imageKey="component.gif"
             shortDescription="The GHOST instrument is configured with this component."

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -24,6 +24,7 @@ import scala.swing.event.SelectionChanged
 final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
 
   private object ui extends GridBagPanel {
+    private var row = 0
     border = ComponentEditor.PANEL_BORDER
 
     /** Position angle components. */
@@ -39,31 +40,39 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
     val tfComp: Component = Component.wrap(posAngleCtrl.getTextField)
     layout(posAngleLabel) = new Constraints() {
       anchor = Anchor.NorthEast
+      gridx = 0
+      gridy = row
       insets = new Insets(3, 10, 0, 20)
     }
     layout(tfComp) = new Constraints() {
       anchor = Anchor.NorthWest
       gridx = 1
+      gridy = row
       insets = new Insets(0, 0, 0, 20)
     }
     layout(posAngleUnits) = new Constraints() {
       anchor = Anchor.NorthWest
       gridx = 2
+      gridy = row
       insets = new Insets(3, 0, 0, 20)
     }
     layout(new Label) = new Constraints() {
       anchor = Anchor.West
       gridx = 3
+      gridy = row
       weightx = 1.0
     }
+    row += 1
 
     layout(new Separator()) = new Constraints() {
       anchor = Anchor.West
       fill = Fill.Horizontal
-      gridy = 1
+      gridx = 0
+      gridy = row
       gridwidth = 3
       insets = new Insets(10, 0, 0, 0)
     }
+    row += 1
 
     /**
      * RESOLUTION MODE
@@ -72,7 +81,8 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
     resolutionModeLabel.horizontalAlignment = Alignment.Right
     layout(resolutionModeLabel) = new Constraints() {
       anchor = Anchor.East
-      gridy = 2
+      gridx = 0
+      gridy = row
       insets = new Insets(12, 10, 0, 20)
     }
 
@@ -87,11 +97,12 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
     layout(resolutionModeComboBox) = new Constraints() {
       anchor = Anchor.NorthWest
       gridx = 1
+      gridy = row
       gridwidth = 2
-      gridy = 2
       fill = Fill.Horizontal
       insets = new Insets(10, 0, 0, 20)
     }
+    row += 1
 
     /**
      * TARGET MODE
@@ -100,11 +111,11 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
     targetModeLabel.horizontalAlignment = Alignment.Right
     layout(targetModeLabel) = new Constraints() {
       anchor = Anchor.East
-      gridy = 3
+      gridx = 0
+      gridy = row
       insets = new Insets(12, 10, 0, 20)
     }
 
-    // TODO: We don't need this anymore.
     /** A list of available asterism types. */
     val asterismList: List[AsterismType] = List(
       GhostSingleTarget,
@@ -120,14 +131,16 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       anchor = Anchor.NorthWest
       gridx = 1
       gridwidth = 2
-      gridy = 3
+      gridy = row
       fill = Fill.Horizontal
       insets = new Insets(10, 0, 0, 20)
     }
+    row += 1
 
     layout(new Label) = new Constraints() {
       anchor = Anchor.North
-      gridy = 4
+      gridx = 0
+      gridy = row
       weighty = 1.0
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -113,7 +113,7 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       GhostHighResolutionTargetPlusSky
     )
 
-    val asterismComboBox: ComboBox[AsterismType] = new ComboBox[AsterismType](asterismList)
+    val asterismComboBox: ComboBox[AsterismType] = new ComboBox[AsterismType](resolutionModeComboBox.selection.item.asterismTypes)
     layout(asterismComboBox) = new Constraints() {
       anchor = Anchor.NorthWest
       gridx = 1
@@ -135,6 +135,13 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
     listenTo(resolutionModeComboBox.selection)
     reactions += {
       case SelectionChanged(`resolutionModeComboBox`) =>
+        // The old resolution mode.
+
+
+        // The new resolution mode.
+        val newResolutionMode = resolutionModeComboBox.selection.item
+
+        // The asterism type.
          val asterismType = asterismComboBox.selection.item
 )
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -89,6 +89,7 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       gridx = 1
       gridwidth = 2
       gridy = 2
+      fill = Fill.Horizontal
       insets = new Insets(10, 0, 0, 20)
     }
 
@@ -120,6 +121,7 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       gridx = 1
       gridwidth = 2
       gridy = 3
+      fill = Fill.Horizontal
       insets = new Insets(10, 0, 0, 20)
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -1,16 +1,17 @@
 package jsky.app.ot.gemini.ghost
 
 import java.beans.PropertyDescriptor
-import javax.swing.JPanel
 
+import javax.swing.JPanel
 import edu.gemini.pot.sp.ISPObsComponent
 import edu.gemini.shared.gui.bean.TextFieldPropertyCtrl
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.gemini.ghost.Ghost
 import edu.gemini.spModel.gemini.ghost.AsterismConverters._
 import edu.gemini.spModel.rich.pot.sp._
-import edu.gemini.spModel.target.env.AsterismType
+import edu.gemini.spModel.target.env.{AsterismType, ResolutionMode}
 import edu.gemini.spModel.target.env.AsterismType._
+import edu.gemini.spModel.target.env.ResolutionMode._
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 import jsky.app.ot.gemini.editor.ComponentEditor
 
@@ -63,13 +64,44 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       insets = new Insets(10, 0, 0, 0)
     }
 
-    val asterismLabel: Label = new Label("Select configuration:")
-    asterismLabel.horizontalAlignment = Alignment.Right
-    layout(asterismLabel) = new Constraints() {
+    /**
+     * RESOLUTION MODE
+     */
+    val resolutionModeLabel: Label = new Label("Resolution Mode:")
+    resolutionModeLabel.horizontalAlignment = Alignment.Right
+    layout(resolutionModeLabel) = new Constraints() {
       anchor = Anchor.East
       gridy = 2
       insets = new Insets(12, 10, 0, 20)
     }
+
+    /** A list of available resolution modes. */
+    val resolutionModes: List[ResolutionMode] = List(
+      GhostStandard,
+      GhostHigh,
+      GhostPRV
+    )
+
+    val resolutionModeComboBox: ComboBox[ResolutionMode] = new ComboBox[ResolutionMode](resolutionModes)
+    layout(resolutionModeComboBox) = new Constraints() {
+      anchor = Anchor.NorthWest
+      gridx = 1
+      gridwidth = 2
+      gridy = 2
+      insets = new Insets(10, 0, 0, 20)
+    }
+
+    /**
+     * TARGET MODE
+     */
+    val targetModeLabel: Label = new Label("Target Mode:")
+    targetModeLabel.horizontalAlignment = Alignment.Right
+    layout(targetModeLabel) = new Constraints() {
+      anchor = Anchor.East
+      gridy = 4
+      insets = new Insets(12, 10, 0, 20)
+    }
+
 
     /** A list of available asterism types. */
     val asterismList: List[AsterismType] = List(
@@ -96,6 +128,17 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       weighty = 1.0
     }
 
+    /**
+     * When the resolution mode changes, change the target modes.
+     * We try to change the target mode to the closest mode in the newly selected resolution.
+     */
+    listenTo(resolutionModeComboBox.selection)
+    reactions += {
+      case SelectionChanged(`resolutionModeComboBox`) =>
+         val asterismType = asterismComboBox.selection.item
+)
+
+    }
     listenTo(asterismComboBox.selection)
     reactions += {
       case SelectionChanged(`asterismComboBox`) =>

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -103,6 +103,9 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
         converter.foreach(convertAsterism)
     }
 
+    val tabPane: TabbedPane = new TabbedPane();
+
+
     /** Convert the asterism to the new type, and set the new target environment. */
     def convertAsterism(converter: AsterismConverter): Unit = Swing.onEDT {
       // Disable the combo box, and enable it only if conversion succeeds.

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -15,6 +15,8 @@ import edu.gemini.spModel.target.env.ResolutionMode._
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 import jsky.app.ot.gemini.editor.ComponentEditor
 
+import scala.collection.JavaConverters._
+
 import scala.swing._
 import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing.event.SelectionChanged
@@ -102,7 +104,7 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       insets = new Insets(12, 10, 0, 20)
     }
 
-
+    // TODO: We don't need this anymore.
     /** A list of available asterism types. */
     val asterismList: List[AsterismType] = List(
       GhostSingleTarget,
@@ -113,12 +115,12 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       GhostHighResolutionTargetPlusSky
     )
 
-    val asterismComboBox: ComboBox[AsterismType] = new ComboBox[AsterismType](resolutionModeComboBox.selection.item.asterismTypes)
+    val asterismComboBox: ComboBox[AsterismType] = new ComboBox[AsterismType](resolutionModeComboBox.selection.item.asterismTypes.asScala)
     layout(asterismComboBox) = new Constraints() {
       anchor = Anchor.NorthWest
       gridx = 1
       gridwidth = 2
-      gridy = 2
+      gridy = 4
       insets = new Insets(10, 0, 0, 20)
     }
 
@@ -130,22 +132,27 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
 
     /**
      * When the resolution mode changes, change the target modes.
-     * We try to change the target mode to the closest mode in the newly selected resolution.
+     * We try to change the target mode to the closest mode in the newly selected resolution to maintain
+     * as much of the target version as possible.
      */
     listenTo(resolutionModeComboBox.selection)
     reactions += {
       case SelectionChanged(`resolutionModeComboBox`) =>
         // The old resolution mode.
+        // How do we get this?
 
 
         // The new resolution mode.
         val newResolutionMode = resolutionModeComboBox.selection.item
 
         // The asterism type.
-         val asterismType = asterismComboBox.selection.item
-)
-
+        val asterismType = asterismComboBox.selection.item
     }
+
+    /**
+     * Now when the asterism type changes, change the target environment, trying to maintain as
+     * much of the original target environment as we can.
+     */
     listenTo(asterismComboBox.selection)
     reactions += {
       case SelectionChanged(`asterismComboBox`) =>

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -179,8 +179,6 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
         converter.foreach(convertAsterism)
     }
 
-    val tabPane: TabbedPane = new TabbedPane();
-
     def resolutionMode: ResolutionMode =
       getContextObservation.findTargetObsComp.map(_.getAsterism.resolutionMode).getOrElse(ResolutionMode.GhostStandard)
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -2,7 +2,7 @@ package jsky.app.ot.gemini.ghost
 
 import java.beans.PropertyDescriptor
 
-import javax.swing.JPanel
+import javax.swing.{DefaultComboBoxModel, JPanel}
 import edu.gemini.pot.sp.ISPObsComponent
 import edu.gemini.shared.gui.bean.TextFieldPropertyCtrl
 import edu.gemini.shared.util.immutable.ScalaConverters._
@@ -158,8 +158,9 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
 
           // Update the contents of the asterism combo box to only allow asterisms of this resolution mode
           // and make sure we are at the selected mode.
-          asterismComboBox.peer.removeAllItems()
-          resolutionMode.asterismTypes.asScala.foreach(asterismComboBox.peer.addItem)
+          // We need to set a new model: we cannot modify the model directly as per Scala Swing.
+          asterismComboBox.peer.setModel(new DefaultComboBoxModel[AsterismType]())
+          newResolutionMode.asterismTypes.asScala.foreach(asterismComboBox.peer.addItem)
           asterismComboBox.selection.item = newAsterismType
         }
 
@@ -217,14 +218,11 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
         .filter(asterismList.contains)
 
       // Set the asterism types to match those available to the resolution mode.
-      asterismComboBox.peer.removeAllItems()
+      // We need to set a new model: we cannot modify the model directly as per Scala Swing.
+      asterismComboBox.peer.setModel(new DefaultComboBoxModel[AsterismType]())
       resolutionMode.asterismTypes.asScala.foreach(asterismComboBox.peer.addItem)
       ui.asterismComboBox.selection.item = selection.getOrElse(resolutionMode.asterismTypes.asScala.head)
 
-//        selection.foreach { at =>
-//        ui.asterismComboBox.selection.item = at
-//        ui.asterismComboBox.enabled = true
-//      }
       ui.resolutionModeComboBox.enabled = true
       ui.asterismComboBox.enabled = true
       listenTo(asterismComboBox.selection)


### PR DESCRIPTION
In the GHOST instrument configuration node, the user chooses the asterism type to be observed: this determines the behaviour of the target node component in terms of what is allowed and what is expected.

Originally, we had a single drop-down list of all the available asterism modes. It was decided that this should be refined into three resolution modes - standard resolution, high resolution, and precision radial velocity - and then have sub-modes that determine the asterism type.

In addition, when the user changes resolution modes, we attempt to pick the asterism type closest in the new resolution mode to the old resolution mode and perform a conversion on the target environment so that no information is lost.

Here is what the original looked like:

![Screen Shot 2019-11-22 at 9 52 36 AM](https://user-images.githubusercontent.com/8795653/69427219-deaf7c80-0d0d-11ea-9c11-29152d3d0c14.png)

Here are some screen shots of the new layout:

![Screen Shot 2019-11-22 at 9 46 37 AM](https://user-images.githubusercontent.com/8795653/69427262-f4bd3d00-0d0d-11ea-993a-7505e3963b80.png)
![Screen Shot 2019-11-22 at 9 46 27 AM](https://user-images.githubusercontent.com/8795653/69427263-f555d380-0d0d-11ea-8379-46ec44ecdd37.png)
![Screen Shot 2019-11-22 at 9 46 10 AM](https://user-images.githubusercontent.com/8795653/69427264-f555d380-0d0d-11ea-80fb-98994352564d.png)

