### PR TITLE
REL-3744: adjust GSAOI hotspot

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArray.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/GsaoiDetectorArray.java
@@ -40,8 +40,8 @@ public enum GsaoiDetectorArray {
     public static final double DETECTOR_GAP_ARCSEC  = DETECTOR_GAP_MM * SCALE;
 
     // Account for ODGW hotspot offset (in arcsec)
-    public static final double ODGW_HOTSPOT_OFFSET_P = -5.0;
-    public static final double ODGW_HOTSPOT_OFFSET_Q =  8.0;
+    public static final double ODGW_HOTSPOT_OFFSET_P = -5.0 - DETECTOR_GAP_ARCSEC / 2.0;
+    public static final double ODGW_HOTSPOT_OFFSET_Q =  8.0 + DETECTOR_GAP_ARCSEC / 2.0;
 
     private static final Rectangle2D TOP_LEFT_SHAPE;
     static {


### PR DESCRIPTION
Update the GSAOI hotspot as requested, such that the (-5, 8) offset is relative to the lower left corner of detector array 3 instead of the base position.  In the image below the view is centered at (0,0) so an offset of (5, -8) should fall in the corner of array 3.

![GSAOI Hotspot](https://user-images.githubusercontent.com/4906023/69752837-e1a4d580-1130-11ea-96e0-db78c957ae62.png)
