### PR TITLE
REL-3758: Removed GHOST from UIInfo.xml

### DIFF
--- a/bundle/jsky.app.ot/src/main/resources/resources/conf/UIInfo.xml
+++ b/bundle/jsky.app.ot/src/main/resources/resources/conf/UIInfo.xml
@@ -387,7 +387,7 @@
     <!--
       uiClassName="jsky.app.ot.gemini.flamingos2.EdCompInstFlamingos2"/>
     -->
-
+    <!--
     <UIInfo site="GS"
             dataObject="edu.gemini.spModel.gemini.ghost.Ghost"
             name="GHOST Instrument"
@@ -395,6 +395,7 @@
             imageKey="component.gif"
             shortDescription="The GHOST instrument is configured with this component."
             uiClassName="jsky.app.ot.gemini.ghost.GhostEditor"/>
+    -->
     <UIInfo
             site="GS"
             dataObject="edu.gemini.spModel.gemini.flamingos2.SeqConfigFlamingos2"


### PR DESCRIPTION
We don't want GHOST to appear amongst the list of instruments available for 2020A.
This removes it from the list.

![Screen Shot 2019-11-28 at 10 38 42 AM](https://user-images.githubusercontent.com/8795653/69810721-4ca2ea80-11cb-11ea-9165-106dd798ab0e.png)
