### PR TITLE
Add hardened runtime option for codesigning

### DIFF
--- a/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
@@ -81,14 +81,14 @@ case class MacDistHandler(jre: Option[String], jreName: String) extends DistHand
       Files.walkFileTree(new File(appDir.getPath).toPath, new SimpleFileVisitor[Path]() {
         override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
           if (MacDistHandler.jarMatcher.matches(file) || MacDistHandler.dylibMatcher.matches(file)) {
-            Seq("codesign", "-f", "--options", "runtime", "-v", "-s", MacDistHandler.certificateHash, file.toFile.getAbsolutePath).!
+            Seq("codesign", "-f", "--options", "runtime", "--timestamp", "-v", "-s", MacDistHandler.certificateHash, file.toFile.getAbsolutePath).!
           }
           FileVisitResult.CONTINUE
         }
       })
 
       // Now sign the jre
-      if (Seq("codesign", "-f", "--options", "runtime", "-v", "-s", MacDistHandler.certificateHash, new File(jrePluginDir, jreName).getAbsolutePath).! != 0) {
+      if (Seq("codesign", "-f", "--options", "runtime", "--timestamp", "-v", "-s", MacDistHandler.certificateHash, new File(jrePluginDir, jreName).getAbsolutePath).! != 0) {
         log.error("*** Codesign error ")
       }
 
@@ -101,7 +101,7 @@ case class MacDistHandler(jre: Option[String], jreName: String) extends DistHand
       })
 
       // Finally sign the app
-      if (Seq("codesign", "-f", "--options", "runtime", "-v", "-s", MacDistHandler.certificateHash, appDir.getPath).! != 0) {
+      if (Seq("codesign", "-f", "--options", "runtime", "--timestamp", "-v", "-s", MacDistHandler.certificateHash, appDir.getPath).! != 0) {
         log.error("*** Codesign error")
       }
     }

--- a/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
+++ b/project/src/main/scala/edu/gemini/osgi/tools/app/MacDistHandler.scala
@@ -3,7 +3,7 @@ package edu.gemini.osgi.tools.app
 import java.io.{File, PrintWriter, IOException}
 import java.nio.file.{Files, SimpleFileVisitor, FileVisitResult, Path, FileSystems}
 import java.nio.file.attribute.BasicFileAttributes
-import edu.gemini.osgi.tools.app.{copy => recursivecopy} 
+import edu.gemini.osgi.tools.app.{copy => recursivecopy}
 
 import java.util.jar.Manifest
 
@@ -81,14 +81,14 @@ case class MacDistHandler(jre: Option[String], jreName: String) extends DistHand
       Files.walkFileTree(new File(appDir.getPath).toPath, new SimpleFileVisitor[Path]() {
         override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
           if (MacDistHandler.jarMatcher.matches(file) || MacDistHandler.dylibMatcher.matches(file)) {
-            Seq("codesign", "-f", "-v", "-s", MacDistHandler.certificateHash, file.toFile.getAbsolutePath).!
+            Seq("codesign", "-f", "--options", "runtime", "-v", "-s", MacDistHandler.certificateHash, file.toFile.getAbsolutePath).!
           }
           FileVisitResult.CONTINUE
         }
       })
 
       // Now sign the jre
-      if (Seq("codesign", "-f", "-v", "-s", MacDistHandler.certificateHash, new File(jrePluginDir, jreName).getAbsolutePath).! != 0) {
+      if (Seq("codesign", "-f", "--options", "runtime", "-v", "-s", MacDistHandler.certificateHash, new File(jrePluginDir, jreName).getAbsolutePath).! != 0) {
         log.error("*** Codesign error ")
       }
 
@@ -101,7 +101,7 @@ case class MacDistHandler(jre: Option[String], jreName: String) extends DistHand
       })
 
       // Finally sign the app
-      if (Seq("codesign", "-f", "-v", "-s", MacDistHandler.certificateHash, appDir.getPath).! != 0) {
+      if (Seq("codesign", "-f", "--options", "runtime", "-v", "-s", MacDistHandler.certificateHash, appDir.getPath).! != 0) {
         log.error("*** Codesign error")
       }
     }


### PR DESCRIPTION
This PR adds an option to the OSX signing stage to enable the "hardened runtime" option. It still needs testing