### PR TITLE
REL-3764: Updating IP for gsodbtest / sbfodbdev-lv1.

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -549,7 +549,7 @@ def gsodbtest(version: Version) = AppConfig(
     "edu.gemini.dataman.gsa.summit.host" -> "cpofits-lv1.cl.gemini.edu",
     "edu.gemini.oodb.mail.smtpHost"      -> "smtp.cl.gemini.edu",
     "edu.gemini.util.trpc.name"          -> "Gemini South ODB (Test)",
-    "osgi.shell.telnet.ip"               -> "172.17.55.77"
+    "osgi.shell.telnet.ip"               -> "172.16.76.31"
   )
 ) extending List(odbtest(version), gsodbtest_credentials(version))
 


### PR DESCRIPTION
Due to the change from gsodbtest to sbfodbdev-lv1, the IP address of the VM has changed, which necessitates the change of the IP in the spdb build.sbt file in order to allow incoming telnet connections to the machine.

This updates the IP address.