### PR TITLE
GHOSTSW-18: Proper motion coordinates now sent in sequence for targets.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
@@ -1,19 +1,22 @@
 package edu.gemini.spModel.gemini.ghost
 
+import java.time.Instant
 import java.util.{Map => JMap}
 
 import edu.gemini.pot.sp.ISPObsComponent
 import edu.gemini.spModel.config.AbstractObsComponentCB
 import edu.gemini.spModel.data.config._
 import edu.gemini.spModel.obscomp.InstConstants
-import edu.gemini.spModel.target.SPSkyObject
+import edu.gemini.spModel.target.{SPCoordinates, SPSkyObject, SPTarget}
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 
 import scala.collection.JavaConverters._
+
 import scalaz._
 import Scalaz._
 
-/** Configuration builder for GHOST.
+/**
+  * Configuration builder for GHOST.
   */
 final class GhostCB(obsComp: ISPObsComponent) extends AbstractObsComponentCB(obsComp) {
   @transient private var sysConfig: Option[ISysConfig] = None
@@ -49,12 +52,18 @@ final class GhostCB(obsComp: ISPObsComponent) extends AbstractObsComponentCB(obs
       // must operate on an SPSkyObject.
       def coordParam(so: SPSkyObject, name: Option[String],
                      raDeg: String, decDeg: String,
-                     raHMS: String, decDMS: String) : Unit = so.getCoordinates(None).foreach { c =>
-        name.foreach(n => config.putParameter(systemName, StringParameter.getInstance(n, so.getName)))
-        config.putParameter(systemName, StringParameter.getInstance(raDeg,  c.ra.formatDegrees))
-        config.putParameter(systemName, StringParameter.getInstance(decDeg, c.dec.formatDegrees))
-        config.putParameter(systemName, StringParameter.getInstance(raHMS,  c.ra.formatHMS))
-        config.putParameter(systemName, StringParameter.getInstance(decDMS, c.dec.formatDMS))
+                     raHMS: String, decDMS: String) : Unit = {
+        val coords = so match {
+          case c: SPCoordinates => c.getCoordinates.some
+          case t: SPTarget => t.getProperMotion.map(_.calculateAt(t.getTarget, Instant.now())).orElse(t.getCoordinates(None))
+        }
+        coords.foreach { c =>
+          name.foreach(n => config.putParameter(systemName, StringParameter.getInstance(n, so.getName)))
+          config.putParameter(systemName, StringParameter.getInstance(raDeg, c.ra.formatDegrees))
+          config.putParameter(systemName, StringParameter.getInstance(decDeg, c.dec.formatDegrees))
+          config.putParameter(systemName, StringParameter.getInstance(raHMS, c.ra.formatHMS))
+          config.putParameter(systemName, StringParameter.getInstance(decDMS, c.dec.formatDMS))
+        }
       }
 
       /** Add the target information for the observation for GHOST to the

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
@@ -11,9 +11,9 @@ import edu.gemini.spModel.target.{SPCoordinates, SPSkyObject, SPTarget}
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 
 import scala.collection.JavaConverters._
-
 import scalaz._
 import Scalaz._
+import edu.gemini.spModel.core.Angle
 
 /**
   * Configuration builder for GHOST.
@@ -59,10 +59,10 @@ final class GhostCB(obsComp: ISPObsComponent) extends AbstractObsComponentCB(obs
         }
         coords.foreach { c =>
           name.foreach(n => config.putParameter(systemName, StringParameter.getInstance(n, so.getName)))
-          config.putParameter(systemName, StringParameter.getInstance(raDeg, c.ra.formatDegrees))
-          config.putParameter(systemName, StringParameter.getInstance(decDeg, c.dec.formatDegrees))
-          config.putParameter(systemName, StringParameter.getInstance(raHMS, c.ra.formatHMS))
-          config.putParameter(systemName, StringParameter.getInstance(decDMS, c.dec.formatDMS))
+          config.putParameter(systemName, DefaultParameter.getInstance(raDeg, c.ra.toDegrees))
+          config.putParameter(systemName, DefaultParameter.getInstance(decDeg, c.dec.toDegrees))
+          config.putParameter(systemName, DefaultParameter.getInstance(raHMS, c.ra.formatHMS))
+          config.putParameter(systemName, DefaultParameter.getInstance(decDMS, c.dec.formatDMS))
         }
       }
 


### PR DESCRIPTION
GHOST requires target coordinates sent with proper motion taken into effect.
Previously, we sent regular coordinates. Now we use the proper motion calculator that was implemented from OCS3 to send the proper motion coordinates for targets.

Here, in the target editor, you can see the coordinates from the catalog for M32 along with the proper motion information.

![Screen Shot 2020-01-20 at 4 13 54 PM](https://user-images.githubusercontent.com/8795653/72752196-5a0f9c00-3ba0-11ea-912b-1fdad7697766.png)

Here, in the static configuration, you can see the proper-motion adjusted coordinates for M32 being sent:

![Screen Shot 2020-01-20 at 4 14 19 PM](https://user-images.githubusercontent.com/8795653/72752264-7f040f00-3ba0-11ea-95ee-d7253f000326.png)
