### PR TITLE
REL-3769: Resource changes for PIT 2020B.

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -8,7 +8,8 @@ class Root(sem:Semester) extends SingleSelectNode[Semester, Instrument, Any](sem
   var title = "Select Instrument"
   var description = s"The following instruments are available for semester ${sem.year}${sem.half}. See the Gemini website for information on instrument capabilities and configuration options."
 
-  def choices: List[Instrument] = List(Alopeke, Flamingos2, GmosNorth, GmosSouth, Gnirs, Gpi, Graces, Gsaoi, Igrins, Nifs, Niri, Visitor, Zorro)
+  // REL-3769: GPI not available in 2020B.
+  def choices: List[Instrument] = List(Alopeke, Flamingos2, GmosNorth, GmosSouth, Gnirs, Graces, Gsaoi, Igrins, Nifs, Niri, Visitor, Zorro)
 
   def apply(i:Instrument) = i match {
     case Alopeke    => Left(inst.Alopeke())

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/exchange/Subaru.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/exchange/Subaru.scala
@@ -10,7 +10,9 @@ object Subaru {
   class InstrumentNode extends SingleSelectNode[Unit, SubaruInstrument, SubaruBlueprint](()) {
     val title       = "Subaru Instrument"
     val description = "Select the Subaru instrument."
-    def choices     = SubaruInstrument.values.toList.filterNot(_ == M.SubaruInstrument.SUPRIME_CAM)
+    // REL-3769 2020B: Subaru COMICS and FMOS not offered.
+    def choices: List[SubaruInstrument] = SubaruInstrument.values.toList
+      .filter(i => i != SubaruInstrument.FMOS && i != SubaruInstrument.SUPRIME_CAM && i != SubaruInstrument.COMICS)
 
     def apply(i: SubaruInstrument) = i match {
       case ins if ins == SubaruInstrument.forName("VISITOR") => Left(CustomNameNode(SubaruBlueprint(ins, None)))

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -489,6 +489,7 @@ package object immutable {
 
   type SubaruInstrument = M.SubaruInstrument
   object SubaruInstrument extends EnumObject[M.SubaruInstrument] {
+    val SUPRIME_CAM = M.SubaruInstrument.SUPRIME_CAM
     val COMICS = M.SubaruInstrument.COMICS
     val FMOS   = M.SubaruInstrument.FMOS
     val IRCS   = M.SubaruInstrument.IRCS

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -154,14 +154,30 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
   */
 case object SemesterConverter2020ATo2020B extends SemesterConverter {
   // REL-3769 will be here when the requirements are finalized.
-  override val transformers: List[TransformFunction] = Nil
+  val gpiRemover: TransformFunction = removeBlueprint("gpi", "GPI")._1
+
+  lazy val subaruComicsMessage: String = "Subaru proposal with COMICS has been removed."
+  val subaruComicsTransform: TransformFunction = {
+  case p @ <blueprints>{ns @ _*}</blueprints> if (p \\ "instrument").exists(_.text == "COMICS") =>
+    val filtered = ns.filter{n => !(n \\ "subaru" \\ "instrument").exists(_.text == "COMICS")}
+    StepResult(subaruComicsMessage, <blueprints>{filtered}</blueprints>).successNel
+  }
+
+  lazy val subaruFmosMessage: String = "Subaru proposal with FMOS has been removed."
+  val subaruFmosTransform: TransformFunction = {
+    case p @ <blueprints>{ns @ _*}</blueprints> if (p \\ "instrument").exists(_.text == "FMOS") =>
+      val filtered = ns.filter{n => !(n \\ "subaru" \\ "instrument").exists(_.text == "FMOS")}
+      StepResult(subaruFmosMessage, <blueprints>{filtered}</blueprints>).successNel
+  }
+
+  override val transformers: List[TransformFunction] = List(gpiRemover, subaruComicsTransform, subaruFmosTransform)
 }
 
 /**
   *  This Converter will support migrating to 2020A
   */
 case object SemesterConverter2019BTo2020A extends SemesterConverter {
-  lazy val subaruSuprimeMessage: String = "Subaru proposal with Suprime Cam has been migrated to Hyper Suprime Cam"
+  val subaruSuprimeMessage: String = "Subaru proposal with Suprime Cam has been migrated to Hyper Suprime Cam."
   val subaruSuprimeTransform: TransformFunction = {
     case p @ <subaru>{ns @ _*}</subaru> if (p \\ "instrument").exists(_.text == "Suprime Cam") =>
       object SuprimeTransform extends BasicTransformer {

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -156,14 +156,14 @@ case object SemesterConverter2020ATo2020B extends SemesterConverter {
   // REL-3769 will be here when the requirements are finalized.
   val gpiRemover: TransformFunction = removeBlueprint("gpi", "GPI")._1
 
-  lazy val subaruComicsMessage: String = "Subaru proposal with COMICS has been removed."
+  val subaruComicsMessage: String = "Subaru proposal with COMICS has been removed."
   val subaruComicsTransform: TransformFunction = {
   case p @ <blueprints>{ns @ _*}</blueprints> if (p \\ "instrument").exists(_.text == "COMICS") =>
     val filtered = ns.filter{n => !(n \\ "subaru" \\ "instrument").exists(_.text == "COMICS")}
     StepResult(subaruComicsMessage, <blueprints>{filtered}</blueprints>).successNel
   }
 
-  lazy val subaruFmosMessage: String = "Subaru proposal with FMOS has been removed."
+  val subaruFmosMessage: String = "Subaru proposal with FMOS has been removed."
   val subaruFmosTransform: TransformFunction = {
     case p @ <blueprints>{ns @ _*}</blueprints> if (p \\ "instrument").exists(_.text == "FMOS") =>
       val filtered = ns.filter{n => !(n \\ "subaru" \\ "instrument").exists(_.text == "FMOS")}

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/subaru_multiple.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/subaru_multiple.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2019.1.2">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2019" half="A"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets>
+        <sidereal epoch="J2000" id="target-0">
+            <name>M  32</name>
+            <degDeg>
+                <ra>10.6742709999999760839273221790790557861328125</ra>
+                <dec>40.86516899999998031489667482674121856689453125</dec>
+            </degDeg>
+            <properMotion deltaRA="-17.0" deltaDec="-5.0"/>
+            <magnitudes>
+                <magnitude band="U" system="Vega">9.510000228881836</magnitude>
+                <magnitude band="B" system="Vega">9.029999732971191</magnitude>
+                <magnitude band="V" system="Vega">8.079999923706055</magnitude>
+                <magnitude band="J" system="Vega">6.2769999504089355</magnitude>
+                <magnitude band="H" system="Vega">5.366000175476074</magnitude>
+                <magnitude band="K" system="Vega">5.09499979019165</magnitude>
+            </magnitudes>
+        </sidereal>
+        <sidereal epoch="J2000" id="target-1">
+            <name>M  64</name>
+            <degDeg>
+                <ra>194.182066999999960899003781378269195556640625</ra>
+                <dec>21.68265800000000353975337930023670196533203125</dec>
+            </degDeg>
+            <magnitudes>
+                <magnitude band="B" system="Vega">9.359999656677246</magnitude>
+                <magnitude band="V" system="Vega">8.520000457763672</magnitude>
+                <magnitude band="J" system="Vega">6.267000198364258</magnitude>
+                <magnitude band="H" system="Vega">5.581999778747559</magnitude>
+                <magnitude band="K" system="Vega">5.329999923706055</magnitude>
+            </magnitudes>
+        </sidereal>
+        <sidereal epoch="J2000" id="target-2">
+            <name>M  64</name>
+            <degDeg>
+                <ra>194.182066999999960899003781378269195556640625</ra>
+                <dec>21.68265800000000353975337930023670196533203125</dec>
+            </degDeg>
+            <magnitudes>
+                <magnitude band="B" system="Vega">9.359999656677246</magnitude>
+                <magnitude band="V" system="Vega">8.520000457763672</magnitude>
+                <magnitude band="J" system="Vega">6.267000198364258</magnitude>
+                <magnitude band="H" system="Vega">5.581999778747559</magnitude>
+                <magnitude band="K" system="Vega">5.329999923706055</magnitude>
+            </magnitudes>
+        </sidereal>
+        <sidereal epoch="J2000" id="target-3">
+            <name>M  32</name>
+            <degDeg>
+                <ra>10.6742709999999760839273221790790557861328125</ra>
+                <dec>40.86516899999998031489667482674121856689453125</dec>
+            </degDeg>
+            <properMotion deltaRA="-17.0" deltaDec="-5.0"/>
+            <magnitudes>
+                <magnitude band="U" system="Vega">9.510000228881836</magnitude>
+                <magnitude band="B" system="Vega">9.029999732971191</magnitude>
+                <magnitude band="V" system="Vega">8.079999923706055</magnitude>
+                <magnitude band="J" system="Vega">6.2769999504089355</magnitude>
+                <magnitude band="H" system="Vega">5.366000175476074</magnitude>
+                <magnitude band="K" system="Vega">5.09499979019165</magnitude>
+            </magnitudes>
+        </sidereal>
+        <sidereal epoch="J2000" id="target-4">
+            <name>M  32</name>
+            <degDeg>
+                <ra>10.6742709999999760839273221790790557861328125</ra>
+                <dec>40.86516899999998031489667482674121856689453125</dec>
+            </degDeg>
+            <properMotion deltaRA="-17.0" deltaDec="-5.0"/>
+            <magnitudes>
+                <magnitude band="U" system="Vega">9.510000228881836</magnitude>
+                <magnitude band="B" system="Vega">9.029999732971191</magnitude>
+                <magnitude band="V" system="Vega">8.079999923706055</magnitude>
+                <magnitude band="J" system="Vega">6.2769999504089355</magnitude>
+                <magnitude band="H" system="Vega">5.366000175476074</magnitude>
+                <magnitude band="K" system="Vega">5.09499979019165</magnitude>
+            </magnitudes>
+        </sidereal>
+    </targets>
+    <conditions>
+        <condition id="condition-0">
+            <name>CC 50%/Clear, IQ 20%/Best, SB 20%/Darkest, WV Any</name>
+            <cc>50%/Clear</cc>
+            <iq>20%/Best</iq>
+            <sb>20%/Darkest</sb>
+            <wv>Any</wv>
+        </condition>
+    </conditions>
+    <blueprints>
+        <subaru id="blueprint-0">
+            <name>Subaru (Suprime Cam)</name>
+            <visitor>false</visitor>
+            <instrument>Suprime Cam</instrument>
+        </subaru>
+        <subaru id="blueprint-1">
+            <name>Subaru (FOCAS)</name>
+            <visitor>false</visitor>
+            <instrument>FOCAS</instrument>
+        </subaru>
+        <subaru id="blueprint-2">
+            <name>Subaru (MOIRCS)</name>
+            <visitor>false</visitor>
+            <instrument>MOIRCS</instrument>
+        </subaru>
+        <subaru id="blueprint-3">
+            <name>Subaru (COMICS)</name>
+            <visitor>false</visitor>
+            <instrument>COMICS</instrument>
+        </subaru>
+        <subaru id="blueprint-4">
+            <name>Subaru (FMOS)</name>
+            <visitor>false</visitor>
+            <instrument>FMOS</instrument>
+        </subaru>
+    </blueprints>
+    <observations>
+        <observation band="Band 1/2" enabled="true" target="target-0" condition="condition-0" blueprint="blueprint-0">
+            <progTime units="hr">5.0</progTime>
+            <partTime units="hr">0.0</partTime>
+            <time units="hr">5.0</time>
+            <meta ck="">
+                <visibility>Limited</visibility>
+            </meta>
+        </observation>
+        <observation band="Band 1/2" enabled="true" target="target-2" condition="condition-0" blueprint="blueprint-1">
+            <progTime units="hr">3.0</progTime>
+            <partTime units="hr">0.0</partTime>
+            <time units="hr">3.0</time>
+            <meta ck="">
+                <visibility>Good</visibility>
+            </meta>
+        </observation>
+        <observation band="Band 1/2" enabled="true" target="target-1" condition="condition-0" blueprint="blueprint-2">
+            <progTime units="hr">4.0</progTime>
+            <partTime units="hr">0.0</partTime>
+            <time units="hr">4.0</time>
+            <meta ck="">
+                <visibility>Good</visibility>
+            </meta>
+        </observation>
+        <observation band="Band 1/2" enabled="true" target="target-4" condition="condition-0" blueprint="blueprint-3">
+            <progTime units="hr">1.0</progTime>
+            <partTime units="hr">0.0</partTime>
+            <time units="hr">1.0</time>
+            <meta ck="">
+                <visibility>Limited</visibility>
+            </meta>
+        </observation>
+        <observation band="Band 1/2" enabled="true" target="target-3" condition="condition-0" blueprint="blueprint-4">
+            <progTime units="hr">2.0</progTime>
+            <partTime units="hr">0.0</partTime>
+            <time units="hr">2.0</time>
+            <meta ck="">
+                <visibility>Limited</visibility>
+            </meta>
+        </observation>
+    </observations>
+    <proposalClass>
+        <sip tooOption="None">
+            <submission>
+                <request>
+                    <time units="hr">0.0</time>
+                    <minTime units="hr">0.0</minTime>
+                </request>
+            </submission>
+        </sip>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/dtree/RootSpec.scala
@@ -23,9 +23,9 @@ class RootSpec extends Specification {
       val root = new Root(Semester(2016, B))
       root.choices must contain(Instrument.Visitor)
     }
-    "include Gpi" in {
-      val root = new Root(Semester(2016, A))
-      root.choices must contain(Instrument.Gpi)
+    "GPI is not available in 2020B" in {
+      val root = new Root(Semester(2016, B))
+      root.choices must not contain Instrument.Gpi
     }
     "include Graces" in {
       val root = new Root(Semester(2016, A))

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -393,6 +393,16 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
 
       proposal must beSuccessful
     }
+    "proposal with Subaru COMICS and FMOS must remove them, REL-3769" in {
+      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("subaru_multiple.xml")))
+
+      val converted = UpConverter.convert(xml)
+      converted must beSuccessful.like {
+        case StepResult(changes, _) =>
+          changes must contain(SemesterConverter2020ATo2020B.subaruComicsMessage)
+          changes must contain(SemesterConverter2020ATo2020B.subaruFmosMessage)
+      }
+    }
     "proposal with trecs blueprints must remove them, REL-1112" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_trecs.xml")))
 

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -710,14 +710,17 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
       }
     }
     "proposal with GPI and HStar and HLiwa modes should become H direct, REL-2671" in {
-      val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gpi_hstar.xml")))
+      skipped {
+        // GPI is not offered in 2020B.
+        val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("proposal_with_gpi_hstar.xml")))
 
-      val converted = UpConverter.convert(xml)
-      converted must beSuccessful.like {
-        case StepResult(changes, result) =>
-          changes must have length 6
-          result \\ "gpi" must \\("observingMode") \>~ "H.direct"
-          result \\ "gpi" must \\("name") \> "GPI H direct Prism"
+        val converted = UpConverter.convert(xml)
+        converted must beSuccessful.like {
+          case StepResult(changes, result) =>
+            changes must have length 6
+            result \\ "gpi" must \\("observingMode") \>~ "H.direct"
+            result \\ "gpi" must \\("name") \> "GPI H direct Prism"
+        }
       }
     }
     "proposal with observation time attribute should be transformed to progTime attribute, REL-2985" in {
@@ -754,14 +757,14 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
           result \\ "flamingos2" must not(\\("name") \>~ ".*J-lo (1.122 um).*")
       }
     }
-    "Subaru prposal with Surprime Cam, REL-3638" in {
+    "Subaru proposal with Surprime Cam, REL-3638" in {
       val xml = XML.load(new InputStreamReader(getClass.getResourceAsStream("subaru_suprime.xml")))
 
       val converted = UpConverter.convert(xml)
       converted must beSuccessful.like {
         case StepResult(changes, result) =>
           changes must have length 5
-          changes must contain("Subaru proposal with Suprime Cam has been migrated to Hyper Suprime Cam")
+          changes must contain(SemesterConverter2019BTo2020A.subaruSuprimeMessage)
           result \\ "subaru" must \\("name") \> "Subaru (Hyper Suprime Cam)"
           result \\ "subaru" must \\("instrument") \> "Hyper Suprime Cam"
       }


### PR DESCRIPTION
As per REL-3769, the following are not available in 2020B:

1. GPI
2. Subaru COMICS
3. Subaru FMOS

Here are some screenshots showing their removal upon opening a program with Subaru COMICS, Subaru FMOS, and Subaru Prime (which should change, from last semester, to Subaru Hyper Prime):

![Screen Shot 2020-01-22 at 2 41 49 PM](https://user-images.githubusercontent.com/8795653/72919397-29596f00-3d26-11ea-9ce0-7566611584ce.png)

![Screen Shot 2020-01-22 at 2 43 16 PM](https://user-images.githubusercontent.com/8795653/72919422-324a4080-3d26-11ea-9b40-ccb85b9f9311.png)

![Screen Shot 2020-01-22 at 2 44 28 PM](https://user-images.githubusercontent.com/8795653/72919432-3aa27b80-3d26-11ea-8a26-e935bf7831dd.png)
