### PR TITLE
REL-3772: Remove investigator information from FT backend PDFS2, take 2.

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/scala/edu/gemini/model/p1/pdf/P1PDF.scala
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/scala/edu/gemini/model/p1/pdf/P1PDF.scala
@@ -121,16 +121,11 @@ object P1PDF {
    * This method also merges the attached pdf file to the end of the resulting pdf.
    */
   def createFromNode (xml: Node, template: Template, pdfFile: File, workingDir:Option[File] = None) {
-    // REL-3772: Do not display PI information for FT proposals.
-    val workingTemplate = {
-      val isFT: Boolean = (xml \ "proposalClass" \\ "fastTurnaround").theSeq.nonEmpty
-      if (isFT) template.copy(investigatorsList = InvestigatorsListOption.NoList) else template
-    }
     val attachment = {
       val f = new File((xml \ "meta" \ "attachment").text)
       if (f.isAbsolute) f else workingDir.map(new File(_, f.getPath)).getOrElse(f)
     }
-    createFromNode(xml, attachment, workingTemplate, pdfFile, workingDir)
+    createFromNode(xml, attachment, template, pdfFile, workingDir)
   }
 
 


### PR DESCRIPTION
The investigator information for FT should only be removed from the p1-monitor. This restores the default behaviour for the PIT and p1pdfmaker and removes it p1-monitor.