### PR TITLE
GHOSTSW-21: Added guiding apply keywords to SRIFU1, SRIFU2, and HRIFU1 when applicable

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -334,18 +334,21 @@ object Ghost {
   val SRIFU1DecDeg: String   = "srifu1CoordsDecDeg"
   val SRIFU1RAHMS: String    = "srifu1CoordsRAHMS"
   val SRIFU1DecDMS: String   = "srifu1CoordsDecDMS"
+  val SRIFU1Guiding: String  = "srifu1Guiding"
 
   val SRIFU2Name: String     = "srifu2Name"
   val SRIFU2RADeg: String    = "srifu2CoordsRADeg"
   val SRIFU2DecDeg: String   = "srifu2CoordsDecDeg"
   val SRIFU2RAHMS: String    = "srifu2CoordsRAHMS"
   val SRIFU2DecDMS: String   = "srifu2CoordsDecDMS"
+  val SRIFU2Guiding: String  = "srifu2Guiding"
 
   val HRIFU1Name: String     = "hrifu1Name"
   val HRIFU1RADeg: String    = "hrifu1CoordsRADeg"
   val HRIFU1DecDeg: String   = "hrifu1CoordsDecDeg"
   val HRIFU1RAHMS: String    = "hrifu1CoordsRAHMS"
   val HRIFU1DecDMS: String   = "hrifu1CoordsDecDMS"
+  val HRIFU1Guiding: String  = "hrifu1Guiding"
 
   val HRIFU2Name: String     = "hrifu2Name"
   val HRIFU2RADeg: String    = "hrifu2CoordsRADeg"

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -724,7 +724,7 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
         targetPane.ifu2Pane.visible = name2Opt.isDefined
 
         val (guideFibers1: Boolean, editableGuideFibers1: Boolean, guideFibers2: Boolean, editableGuideFibers2: Boolean) = asterism match {
-          case SingleTarget(gt, _)                   => (gt.guideFiberState === Enabled, true, false, false)
+          case SingleTarget(gt, _)                                 => (gt.guideFiberState === Enabled, true, false, false)
           case GhostAsterism.DualTarget(gt1, gt2, _)               => (gt1.guideFiberState == Enabled, true, gt2.guideFiberState == Enabled, true)
           case GhostAsterism.TargetPlusSky(gt, _, _)               => (gt.guideFiberState === Enabled, true, false, false)
           case GhostAsterism.SkyPlusTarget(_, gt2, _)              => (false, false, gt2.guideFiberState === Enabled, true)


### PR DESCRIPTION
I had forgotten to add guiding for SRIFU1, SRIFU2, and HRIFU1 targets to the configuration.
This rectifies that. You can see srifu1Guiding set to Disabled in the configuration in the screenshot.

![Screen Shot 2020-01-28 at 5 05 55 PM](https://user-images.githubusercontent.com/8795653/73301138-00871d00-41f1-11ea-9fed-d9cf710d66ed.png)
