### PR TITLE
Fix pit launcher hardcoded test property

### DIFF
--- a/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
+++ b/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
@@ -17,10 +17,10 @@ object PITLauncher extends App {
   val locale = Locale.getDefault
   Locale.setDefault(Locale.ENGLISH)
 
-  // Check first on the env or else default to true
+  // Check first on the env or else default to false
   Option(System.getProperty("edu.gemini.pit.test")) match {
-    case None => System.setProperty("edu.gemini.pit.test", "true")
-    case _ => ()
+    case None => System.setProperty("edu.gemini.pit.test", "false")
+    case _    => ()
   }
   // Need to set this manually, as we are not inside OSGi
   val version = s"${Semester.current.year}.2.1"

--- a/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
+++ b/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
@@ -17,8 +17,11 @@ object PITLauncher extends App {
   val locale = Locale.getDefault
   Locale.setDefault(Locale.ENGLISH)
 
-  // We normally want to be in test mode in development
-  System.setProperty("edu.gemini.pit.test", "true")
+  // Check first on the env or else default to true
+  Option(System.getProperty("edu.gemini.pit.test")) match {
+    case None => System.setProperty("edu.gemini.pit.test", "true")
+    case _ => ()
+  }
   // Need to set this manually, as we are not inside OSGi
   val version = s"${Semester.current.year}.2.1"
   System.setProperty("edu.gemini.model.p1.schemaVersion", version)


### PR DESCRIPTION
The PIT Launcher hardcodes the test property which makes sense for development but it is bad when using it for distribution using ocs-osx