### PR TITLE
Switch actor to future in edu.gemini.pit.catalog

### DIFF
--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Catalog.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Catalog.scala
@@ -1,18 +1,21 @@
 package edu.gemini.pit.catalog
 
-import scala.actors.Actor._
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import scalaz._
+import Scalaz._
 
 object Catalog {
 
   // An empty catalog that always returns an error
   def empty(msg: String) = new Catalog {
-    def find(id: String)(callback: Callback) {
-      actor {
-        callback.safe(Error(new RuntimeException(msg)))
-      }
-    }
-    override def ||(outer: Catalog): Catalog = outer
-    override def &&(outer: Catalog): Catalog = outer
+
+    override def find(id: String)(implicit ex: ExecutionContext): Future[Result] =
+      Future.successful(Error(new RuntimeException(msg)))
+
+    override def ||(outer: Catalog): Catalog =
+      outer
+
   }
 
 }
@@ -20,61 +23,23 @@ object Catalog {
 trait Catalog { inner =>
 
   /** Given an id (a search string), do a lookup and invoke the callback at some later time. */
-  def find(id: String)(callback: Callback)
+  def find(id: String)(implicit ex: ExecutionContext): Future[Result]
 
   /** Return a new catalog that returns the first result from LHS *or* RHS. */
   def ||(outer: Catalog): Catalog = new Catalog {
 
-    def find(id: String)(callback: Callback) {
-      inner.find(id) { case m => accum ! m }
-      outer.find(id) { case m => accum ! m }
-      lazy val accum = actor {
-        react {
-          case s: Success => callback.safe(s)
-          case _ => react {
-            case r: Result => callback.safe(r)
-          }
-        }
+    def find(id: String)(implicit ex: ExecutionContext): Future[Result] = {
+      val fs = List(inner, outer).map(_.find(id))
+
+      Future.find(fs) {
+        case edu.gemini.pit.catalog.Success(_, _) => true
+        case _                                    => false
+      }.flatMap {
+        case Some(s) => Future.successful(s)
+        case _       => fs.head
       }
+
     }
-  }
-
-  /** Return a new catalog that returns the merged results from both LHS *and* RHS. */
-  def &&(outer: Catalog): Catalog = new Catalog {
-
-    def find(id: String)(callback: Callback) {
-      inner.find(id) { case (crA) => accum ! (('a, crA)) }
-      outer.find(id) { case (crB) => accum ! (('b, crB)) }
-      lazy val accum = actor {
-        await {
-          case ('a, a: Result) => await {
-            case ('b, b: Result) =>
-              callback.safe(merge(a, b))
-              exit()
-          }
-        }
-      }
-    }
-
-    def await(f: PartialFunction[Any, Unit]) {
-      loop {
-        react {
-          case m if f.isDefinedAt(m) => f(m)
-        }
-      }
-    }
-
-    /**
-     * Merge two results. If both sides succeed, add them together. Otherwise if the first one
-     * succeeds return it, otherwise return the other; we're assuming that any failure is as good
-     * as any other, so we just pick one.
-     */
-    def merge: ((Result, Result) => Result) = {
-      case (Success(a, ac), Success(b, bc)) => Success(a ++ b, ac ++ bc)
-      case (a @ Success(_, _), _)   => a
-      case (_, b)                   => b
-    }
-
   }
 
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Result.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Result.scala
@@ -2,6 +2,9 @@ package edu.gemini.pit.catalog
 
 import edu.gemini.model.p1.immutable.{NonSiderealTarget, SiderealTarget, Target}
 
+import scala.concurrent.ExecutionContext
+
+
 // Catalog lookup returns a result, which has four shapes
 sealed trait Result
 sealed trait Failure extends Result
@@ -19,11 +22,15 @@ case object Offline extends Failure
 // a choice, you apply it using the same callback that was used for the initial lookup.
 case class Choice(cat: Catalog, name: String, id: String) {
 
-  def apply(callback: Callback) {
+  def apply(callback: Callback)(implicit ex: ExecutionContext): Unit = {
     val f = callback.safe
-    cat.find(id) {
-      case Success(t :: Nil, Nil) => f(Success(List(withName(t, name)), Nil))
-      case r => f(r)
+    cat.find(id) onComplete {
+      case scala.util.Success(Success(t :: Nil, Nil)) =>
+        f(Success(List(withName(t, name)), Nil))
+      case scala.util.Success(r)                      =>
+        f(r)
+      case scala.util.Failure(t)                      =>
+        f(Error(t))
     }
   }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Simbad.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/Simbad.scala
@@ -9,21 +9,19 @@ import edu.gemini.spModel.core._
 import votable._
 import java.util.UUID
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+
+
 object Simbad extends Catalog with App {
 
   private lazy val hosts = Array("simbad.u-strasbg.fr", "simbad.cfa.harvard.edu")
   private lazy val simbad = hosts.map(apply).reduceLeft(_ || _)
 
-  def find(id:String)(callback:Result => Unit) {
-    simbad.find(id)(callback)
-  }
+  override def find(id:String)(implicit ex: ExecutionContext): Future[Result] =
+    simbad.find(id)(ex)
 
   def apply(host:String):Catalog = new Simbad(host)
-
-  find("sirius") {
-    case Success(t, cs) => println((t, cs))
-    case x              => println(x)
-  }
 
 }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/VOTableCatalog.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/VOTableCatalog.scala
@@ -5,7 +5,8 @@ import edu.gemini.model.p1.immutable.Target
 import java.io.IOException
 import java.net.URL
 import java.util.logging.Level
-import scala.actors.Actor._
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 import votable._
 
 // Type of catalogs that fetch a VOTable
@@ -15,28 +16,26 @@ trait VOTableCatalog extends Catalog {
   def host: String
   def decode(vot: VOTable): Seq[Target]
 
-  def find(id: String)(callback: Result => Unit) {
-    actor {
-      val f = callback.safe
-      try {
+  override def find(id: String)(implicit ex: ExecutionContext): Future[Result] =
+    Future {
+      val conn = url(id).openConnection
+      conn.setReadTimeout(1000 * 10) // 10 secs?
 
-        val conn = url(id).openConnection
-        conn.setReadTimeout(1000 * 10) // 10 secs?
+      // Parse the URL data into a VOTable
+      val vot = VOTable(conn.getInputStream)
+      decode(vot)
 
-        // Parse the URL data into a VOTable
-        val vot = VOTable(conn.getInputStream)
-        val ts = decode(vot)
-        if (ts.nonEmpty) f(Success(ts.toList, Nil)) else f(NotFound(id))
+    }.map {
+      case ts if ts.nonEmpty => Success(ts.toList, Nil)
+      case _                 => NotFound(id)
 
-      } catch {
-        case e:IOException =>
-          Log.warning("%s: %s(%s)".format(host, e.getClass.getSimpleName, e.getMessage))
-          f(Offline)
-        case t:Throwable =>
-          Log.log(Level.WARNING, "Unexpected trouble looking up %s on %s.".format(id, host), t)
-          f(Error(t))
-      }
+    }.recover {
+      case e: IOException =>
+        Log.warning("%s: %s(%s)".format(host, e.getClass.getSimpleName, e.getMessage))
+        Offline
+      case t              =>
+        Log.log(Level.WARNING, "Unexpected trouble looking up %s on %s.".format(id, host), t)
+        Error(t)
     }
-  }
 
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/VOTableCatalog.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/catalog/VOTableCatalog.scala
@@ -6,7 +6,7 @@ import java.io.IOException
 import java.net.URL
 import java.util.logging.Level
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{blocking, ExecutionContext}
 import votable._
 
 // Type of catalogs that fetch a VOTable
@@ -18,12 +18,14 @@ trait VOTableCatalog extends Catalog {
 
   override def find(id: String)(implicit ex: ExecutionContext): Future[Result] =
     Future {
-      val conn = url(id).openConnection
-      conn.setReadTimeout(1000 * 10) // 10 secs?
+      blocking {
+        val conn = url(id).openConnection
+        conn.setReadTimeout(1000 * 10) // 10 secs?
 
-      // Parse the URL data into a VOTable
-      val vot = VOTable(conn.getInputStream)
-      decode(vot)
+        // Parse the URL data into a VOTable
+        val vot = VOTable(conn.getInputStream)
+        decode(vot)
+      }
 
     }.map {
       case ts if ts.nonEmpty => Success(ts.toList, Nil)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SimbadLookup.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/SimbadLookup.scala
@@ -8,6 +8,7 @@ import java.awt.Component
 import java.util.logging.Logger
 import javax.swing.JOptionPane
 import jsky.util.gui.DialogUtil
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.swing.Swing
 import scalaz._, Scalaz._, scalaz.concurrent.Task
 
@@ -39,7 +40,10 @@ final class SimbadLookup(editor: TargetEditor) {
 
   private def search(query: String): Task[Unit] =
     show("Searching...") *> Task.async[SimbadResult] { k =>
-      Simbad.find(query)(r => k(r.right))
+      Simbad.find(query).onComplete {
+        case scala.util.Success(result) => k(result.right)
+        case scala.util.Failure(ex)     => k(ex.left)
+      }
     } >>= {
 
       // Failure cases


### PR DESCRIPTION
This PR replaces the use of `actor` with `Future` in `edu.gemini.pit.catalog`. This change is required to enable executing PIT on Java 13, which in turn is required for OS X notarization. I've done this in the most straightforward way that I could think of because the PIT catalog code has been superseded even in the `ocs` codebase, which itself is nearing its end of life.

I've also removed the `&&` combinator since it is unused.