### PR TITLE
Switch to https for GAIA

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -277,7 +277,7 @@ case object GaiaBackend extends CachedBackend with RemoteCallBackend {
 
 
   override val catalogUrls: NonEmptyList[URL] =
-    NonEmptyList(new URL("http://gea.esac.esa.int/tap-server/tap/sync"))
+    NonEmptyList(new URL("https://gea.esac.esa.int/tap-server/tap/sync"))
 
   override def queryUrl(e: SearchKey): String =
     e.url.toExternalForm


### PR DESCRIPTION
GAIA queries are failing in the production OT, which impacts (mostly) NGS2/GSAOI.  This is due to a server-side change to require https.  Log output from the current OT:

```
Feb 10, 2020 11:57:14 AM org.apache.commons.httpclient.HttpMethodBase processRedirectResponse
WARNING: Redirect from protocol http to https is not supported
```

Simply switching to https seems to fix the problem.