### PR TITLE
Make PIT use pitVersion in build.sbt to set version including test / production

### DIFF
--- a/app/pit/build.sbt
+++ b/app/pit/build.sbt
@@ -38,14 +38,6 @@ def common(pv: Version) = AppConfig(
     "org.osgi.framework.storage.clean"        -> "onFirstInit",
     "org.osgi.framework.startlevel.beginning" -> "100",
     "org.osgi.framework.bootdelegation"       -> "*",
-
-    // NOTE: changing this flag to false works in certain circumstances
-    // but is entirely unreliable. It is better to simply comment this
-    // line out for PIT production releases.
-    // (I think it seems to work if you quit sbt, change it, restart sbt,
-    // clean, compile, and then build the PIT.)
-    "edu.gemini.pit.test"                     -> "true",
-
     "edu.gemini.ags.host"                     -> "gnauxodb.gemini.edu",
     "edu.gemini.ags.port"                     -> "8443"
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ name := "ocs"
 
 organization in Global := "edu.gemini.ocs"
 
+// true indicates a test release, and false indicates a production release
 ocsVersion in ThisBuild := OcsVersion("2020A", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2020B", false, 2, 1, 0)

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization in Global := "edu.gemini.ocs"
 
 ocsVersion in ThisBuild := OcsVersion("2020A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2020B", true, 2, 1, 0)
+pitVersion in ThisBuild := OcsVersion("2020B", false, 2, 1, 0)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion

--- a/bundle/edu.gemini.pit.launcher/build.sbt
+++ b/bundle/edu.gemini.pit.launcher/build.sbt
@@ -18,26 +18,4 @@ OsgiKeys.dynamicImportPackage := Seq("")
 
 OsgiKeys.exportPackage := Seq()
 
-sourceGenerators in Compile += Def.task {
-  val pitVer = pitVersion.value
-  val outDir = (sourceManaged in Compile).value / "edu" / "gemini" / "pit" / "launcher"
-  val outFile = new File(outDir, pitVer.sourceFileName)
-  outDir.mkdirs
-  IO.write(outFile, pitVer.toClass("edu.gemini.pit.launcher")) // UTF-8 is default
-  Seq(outFile)
-}.taskValue
-
-initialCommands := "import edu.gemini.pit.launcher._, scalaz._, Scalaz._"
-
-scalacOptions in (Compile, doc) ++= Seq(
-  "-groups",
-  "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath,
-  "-doc-source-url", "https://github.com/gemini-hlws/ocs/master€{FILE_PATH}.scala"
-)
-
-publishArtifact in (ThisBuild, packageSrc) := true
-
-publishMavenStyle in ThisBuild := true
-
-
 fork in run := true

--- a/bundle/edu.gemini.pit.launcher/build.sbt
+++ b/bundle/edu.gemini.pit.launcher/build.sbt
@@ -18,4 +18,26 @@ OsgiKeys.dynamicImportPackage := Seq("")
 
 OsgiKeys.exportPackage := Seq()
 
+sourceGenerators in Compile += Def.task {
+  val pitVer = pitVersion.value
+  val outDir = (sourceManaged in Compile).value / "edu" / "gemini" / "pit" / "launcher"
+  val outFile = new File(outDir, pitVer.sourceFileName)
+  outDir.mkdirs
+  IO.write(outFile, pitVer.toClass("edu.gemini.pit.launcher")) // UTF-8 is default
+  Seq(outFile)
+}.taskValue
+
+initialCommands := "import edu.gemini.pit.launcher._, scalaz._, Scalaz._"
+
+scalacOptions in (Compile, doc) ++= Seq(
+  "-groups",
+  "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath,
+  "-doc-source-url", "https://github.com/gemini-hlws/ocs/master€{FILE_PATH}.scala"
+)
+
+publishArtifact in (ThisBuild, packageSrc) := true
+
+publishMavenStyle in ThisBuild := true
+
+
 fork in run := true

--- a/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
+++ b/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
@@ -18,18 +18,10 @@ object PITLauncher extends App {
   val locale = Locale.getDefault
   Locale.setDefault(Locale.ENGLISH)
 
-  // We normally want to be in test mode in development
-  //System.setProperty("edu.gemini.pit.test", "true")
   // Need to set this manually, as we are not inside OSGi
   val version = s"${Semester.current.year}.2.1"
   System.setProperty("edu.gemini.model.p1.schemaVersion", version)
   System.setProperty(classOf[Workspace].getName + ".fonts.shrunk", "true")
-
-  // Check version. This should be PIT version, and not OCS version.
-  //val version: Version = CurrentVersion.get()
-  System.out.println("***********************************")
-  System.out.println(s"******* VERSION: ${CurrentVersion.get()}")
-  System.out.println("***********************************")
 
   // Set manually AGS
   AgsRobot.ags = Some(AgsHttpClient("gsodb.gemini.edu", 8443))

--- a/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
+++ b/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
@@ -10,6 +10,7 @@ import edu.gemini.pit.ui.ShellAdvisor
 import edu.gemini.pit.ui.robot.AgsRobot
 import edu.gemini.ui.workspace.impl.Workspace
 
+
 /**
  * Launcher for the PIT in local mode, used for development
  */
@@ -18,11 +19,17 @@ object PITLauncher extends App {
   Locale.setDefault(Locale.ENGLISH)
 
   // We normally want to be in test mode in development
-  System.setProperty("edu.gemini.pit.test", "true")
+  //System.setProperty("edu.gemini.pit.test", "true")
   // Need to set this manually, as we are not inside OSGi
   val version = s"${Semester.current.year}.2.1"
   System.setProperty("edu.gemini.model.p1.schemaVersion", version)
   System.setProperty(classOf[Workspace].getName + ".fonts.shrunk", "true")
+
+  // Check version. This should be PIT version, and not OCS version.
+  //val version: Version = CurrentVersion.get()
+  System.out.println("***********************************")
+  System.out.println(s"******* VERSION: ${CurrentVersion.get()}")
+  System.out.println("***********************************")
 
   // Set manually AGS
   AgsRobot.ags = Some(AgsHttpClient("gsodb.gemini.edu", 8443))

--- a/bundle/edu.gemini.pit/build.sbt
+++ b/bundle/edu.gemini.pit/build.sbt
@@ -30,3 +30,24 @@ OsgiKeys.bundleSymbolicName := name.value
 OsgiKeys.dynamicImportPackage := Seq("")
 
 OsgiKeys.exportPackage := Seq()
+
+sourceGenerators in Compile += Def.task {
+  val pitVer = pitVersion.value
+  val outDir = (sourceManaged in Compile).value / "edu" / "gemini" / "pit" / "model"
+  val outFile = new File(outDir, pitVer.sourceFileName)
+  outDir.mkdirs
+  IO.write(outFile, pitVer.toClass("edu.gemini.pit.model")) // UTF-8 is default
+  Seq(outFile)
+}.taskValue
+
+initialCommands := "import edu.gemini.pit._, scalaz._, Scalaz._"
+
+scalacOptions in (Compile, doc) ++= Seq(
+  "-groups",
+  "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath,
+  "-doc-source-url", "https://github.com/gemini-hlws/ocs/master€{FILE_PATH}.scala"
+)
+
+publishArtifact in (ThisBuild, packageSrc) := true
+
+publishMavenStyle in ThisBuild := true

--- a/bundle/edu.gemini.pit/build.sbt
+++ b/bundle/edu.gemini.pit/build.sbt
@@ -40,14 +40,6 @@ sourceGenerators in Compile += Def.task {
   Seq(outFile)
 }.taskValue
 
-initialCommands := "import edu.gemini.pit._, scalaz._, Scalaz._"
-
-scalacOptions in (Compile, doc) ++= Seq(
-  "-groups",
-  "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath,
-  "-doc-source-url", "https://github.com/gemini-hlws/ocs/master€{FILE_PATH}.scala"
-)
-
 publishArtifact in (ThisBuild, packageSrc) := true
 
 publishMavenStyle in ThisBuild := true

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/model/AppMode.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/model/AppMode.scala
@@ -1,17 +1,5 @@
 package edu.gemini.pit.model
 
-import java.util.logging.Logger
-
-import scala.util.Try
-
 object AppMode {
-  private val Log = Logger.getLogger(AppMode.getClass.getName)
-
-  val TestProperty = "edu.gemini.pit.test"
-  lazy val isTest = Try {
-    System.getProperty(TestProperty).toBoolean
-  } getOrElse {
-    Log.warning(s"System property $TestProperty should be defined and have a boolean value. Using false as default.")
-    false
-  }
+  lazy val isTest = CurrentVersion.get().isTest
 }

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
@@ -2,7 +2,7 @@ package edu.gemini.pit.osgi
 
 import edu.gemini.ui.workspace.IShellAdvisor
 import edu.gemini.pit.ui.ShellAdvisor
-import edu.gemini.pit.model.{AppMode, Model}
+import edu.gemini.pit.model.Model
 import org.osgi.util.tracker.ServiceTracker
 import edu.gemini.ags.client.api.AgsClient
 import org.osgi.framework.{BundleActivator, BundleContext, ServiceReference}
@@ -10,8 +10,6 @@ import edu.gemini.pit.ui.robot.AgsRobot
 import java.io.File
 import java.util.Locale
 import java.util.logging.Logger
-
-import scalaz.\/
 
 class Activator extends BundleActivator {
   private val Log = Logger.getLogger(Activator.this.getClass.getName)
@@ -25,13 +23,6 @@ class Activator extends BundleActivator {
     // Since we haven't really handled i18n ...
     val locale = Locale.getDefault
     Locale.setDefault(Locale.ENGLISH)
-
-    // Turn this bundle property into the system property.
-    // TODO: Not sure if this is used anymore.
-//    \/.fromTryCatchNonFatal(context.getProperty(AppMode.TestProperty).toBoolean).fold(
-//      _ => Log.warning(s"Context property ${AppMode.TestProperty} should be defined and have a boolean value."),
-//      v => System.setProperty(AppMode.TestProperty, v.toString)
-//    )
 
     // The way Workspace works is that you create an IShellAdvisor and register it as a service. Workspace sees this and
     // pops up a corresponding top-level window (an IShell). Because our shell advisor needs the ability to open new

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/osgi/Activator.scala
@@ -28,10 +28,10 @@ class Activator extends BundleActivator {
 
     // Turn this bundle property into the system property.
     // TODO: Not sure if this is used anymore.
-    \/.fromTryCatchNonFatal(context.getProperty(AppMode.TestProperty).toBoolean).fold(
-      _ => Log.warning(s"Context property ${AppMode.TestProperty} should be defined and have a boolean value."),
-      v => System.setProperty(AppMode.TestProperty, v.toString)
-    )
+//    \/.fromTryCatchNonFatal(context.getProperty(AppMode.TestProperty).toBoolean).fold(
+//      _ => Log.warning(s"Context property ${AppMode.TestProperty} should be defined and have a boolean value."),
+//      v => System.setProperty(AppMode.TestProperty, v.toString)
+//    )
 
     // The way Workspace works is that you create an IShellAdvisor and register it as a service. Workspace sees this and
     // pops up a corresponding top-level window (an IShell). Because our shell advisor needs the ability to open new

--- a/bundle/edu.gemini.spModel.core/build.sbt
+++ b/bundle/edu.gemini.spModel.core/build.sbt
@@ -33,7 +33,7 @@ sourceGenerators in Compile += Def.task {
   val outDir = (sourceManaged in Compile).value / "edu" / "gemini" / "spModel" / "core"
   val outFile = new File(outDir, ocsVer.sourceFileName)
   outDir.mkdirs
-  IO.write(outFile, ocsVer.toClass) // UTF-8 is default
+  IO.write(outFile, ocsVer.toClass("edu.gemini.spModel.core")) // UTF-8 is default
   Seq(outFile)
 }.taskValue
 

--- a/project/OcsKey.scala
+++ b/project/OcsKey.scala
@@ -59,10 +59,12 @@ case class OcsVersion(semester: String, test: Boolean, xmlCompatibility: Int, se
 
   def sourceFileName = "CurrentVersion.java"
 
-  def toClass = s"""
-    |package edu.gemini.spModel.core;
+  def toClass(pkg: String): String = s"""
+    |package $pkg;
     |
     |import java.text.ParseException;
+    |import edu.gemini.spModel.core.Version;
+    |import edu.gemini.spModel.core.Semester;
     |
     |// AUTO-GENERATED; DO NOT MODIFY
     |
@@ -73,14 +75,14 @@ case class OcsVersion(semester: String, test: Boolean, xmlCompatibility: Int, se
     |    try {
     |      return new Version(Semester.parse("$semester"), $test, $xmlCompatibility, $serialCompatibility, $minor);
     |    } catch (ParseException pe) {
-    |      throw new Error("Bogus OCS Version; check the build.", pe);
+    |      throw new Error("Bogus Version; check the build.", pe);
     |    }
     |  }
     |
     |}
     """.trim.stripMargin
 
-  override def toString = {
+  override def toString: String = {
     val testString = if (test) "-test" else ""
     s"${semester}${testString}.$xmlCompatibility.$serialCompatibility.$minor"
   }


### PR DESCRIPTION
This eliminates the unpredictable `edu.gemini.pit.test` property to determine whether the PIT being built is a test release or a production release, and instead uses the `pitVersion` in the main `build.sbt` as is done with the OT.