### PR TITLE
Update AGS host

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization in Global := "edu.gemini.ocs"
 // true indicates a test release, and false indicates a production release
 ocsVersion in ThisBuild := OcsVersion("2020A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2020B", false, 2, 1, 0)
+pitVersion in ThisBuild := OcsVersion("2020B", true, 2, 1, 4)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion

--- a/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
+++ b/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
@@ -24,7 +24,7 @@ object PITLauncher extends App {
   System.setProperty(classOf[Workspace].getName + ".fonts.shrunk", "true")
 
   // Set manually AGS
-  AgsRobot.ags = Some(AgsHttpClient("gsodb.gemini.edu", 8443))
+  AgsRobot.ags = Some(AgsHttpClient("gnauxodb.gemini.edu", 8443))
 
   // Create workspace with a null bundle context, it internally checks if it is null
   val workspace = new Workspace(null)


### PR DESCRIPTION
Sets the AGS host correctly in the `PITLauncher` which is used now in the OSX version.