### PR TITLE
REL-3789: add noteTitle parameter to ToO trigger

### DIFF
--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/TooUpdate.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/TooUpdate.java
@@ -42,12 +42,15 @@ public interface TooUpdate extends Serializable {
     Option<Duration> getExposureTime();
 
     /**
-     * Gets the text of the note that will be added to the observation.  For
-     * example, it could contain a link to the finding chart to use.
-     *
-     * @return note text, or <code>null</code> if not specified
+     * Gets the text of the note that will be added to the observation, if any.
+     * For example, it could contain a link to the finding chart to use.
      */
-    String getNote();
+    Option<String> getNote();
+
+    /**
+     * Gets the title of the note that will be added to the observation, if any.
+     */
+    Option<String> getNoteTitle();
 
     /**
      * Gets the elevation constraints that should apply to this TOO trigger,

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/impl/TooUpdateServiceImpl.java
@@ -4,6 +4,7 @@ import edu.gemini.pot.sp.*;
 import static edu.gemini.pot.sp.SPComponentBroadType.INSTRUMENT;
 import edu.gemini.pot.spdb.IDBDatabaseService;
 import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SPBadIDException;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.spModel.gemini.altair.AltairAowfsGuider;
@@ -157,18 +158,19 @@ final class TooUpdateServiceImpl implements TooUpdateService {
     private void _addNote(final ISPObservation obs, final ISPFactory factory, final TooUpdate update)
             throws SPException {
 
-        final String noteText = update.getNote();
-        if (noteText == null) return;
+        final Option<String> noteText  = update.getNote();
+        final Option<String> noteTitle = update.getNoteTitle();
+        if (noteText.isDefined() || noteTitle.isDefined()) {
+            final ISPObsComponent obsComp;
+            obsComp = factory.createObsComponent(obs.getProgram(), SPNote.SP_TYPE, null);
 
-        final ISPObsComponent obsComp;
-        obsComp = factory.createObsComponent(obs.getProgram(), SPNote.SP_TYPE, null);
+            final SPNote note = (SPNote) obsComp.getDataObject();
+            note.setTitle(noteTitle.getOrElse("Finding Chart"));
+            note.setNote(noteText.getOrElse(""));
 
-        final SPNote note = (SPNote) obsComp.getDataObject();
-        note.setTitle("Finding Chart");
-        note.setNote(noteText);
-
-        obsComp.setDataObject(note);
-        obs.addObsComponent(0, obsComp);
+            obsComp.setDataObject(note);
+            obs.addObsComponent(0, obsComp);
+        }
     }
 
     private void _addTimingWindow(final ISPObservation obs, final ISPFactory factory, final TooUpdate update)

--- a/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/www/HttpTooUpdate.java
+++ b/bundle/edu.gemini.oodb.too.url/src/main/java/edu/gemini/spdb/rapidtoo/www/HttpTooUpdate.java
@@ -27,6 +27,7 @@ public final class HttpTooUpdate implements TooUpdate {
     public static final String EXPOSURE_TIME_PARAM  = "exptime";
     public static final String POSITION_ANGLE_PARAM = "posangle";
     public static final String NOTE_PARAM           = "note";
+    public static final String NOTE_TITLE_PARAM     = "noteTitle";
     public static final String GROUP_PARAM          = "group";
     public static final String READY_PARAM          = "ready";
 
@@ -38,7 +39,8 @@ public final class HttpTooUpdate implements TooUpdate {
     private final Option<TooGuideTarget> _guide;
     private final Double _posAngle;
     private final Option<Duration> _exposureTime;
-    private final String _note;
+    private final Option<String> _note;
+    private final Option<String> _noteTitle;
     private final TooElevationConstraint _elevation;
     private final TooTimingWindow _timingWindow;
     private final String _group;
@@ -89,7 +91,8 @@ public final class HttpTooUpdate implements TooUpdate {
         }
         _exposureTime = ImOption.apply(expTime);
 
-        _note  = req.getParameter(NOTE_PARAM);
+        _note         = ImOption.apply(req.getParameter(NOTE_PARAM));
+        _noteTitle    = ImOption.apply(req.getParameter(NOTE_TITLE_PARAM));
         _elevation    = HttpTooElevationConstraint.parse(req);
         _timingWindow = HttpTooTimingWindow.parse(req);
 
@@ -128,8 +131,14 @@ public final class HttpTooUpdate implements TooUpdate {
         return _exposureTime;
     }
 
-    public String getNote() {
+    @Override
+    public Option<String> getNote() {
         return _note;
+    }
+
+    @Override
+    public Option<String> getNoteTitle() {
+        return _noteTitle;
     }
 
     public TooElevationConstraint getElevationConstraint() {

--- a/bundle/edu.gemini.oodb.too.url/src/test/scala/edu/gemini/spdb/rapidtoo/www/HttpUpdateSpec.scala
+++ b/bundle/edu.gemini.oodb.too.url/src/test/scala/edu/gemini/spdb/rapidtoo/www/HttpUpdateSpec.scala
@@ -52,5 +52,21 @@ object HttpUpdateSpec extends Specification with ScalaCheck with Arbitraries wit
     "exptime: succeed if not specified" in {
       (new HttpTooUpdate(req.without("exptime"))).getExposureTime() must_== ImOption.empty()
     }
+
+    "missing note is ok" in {
+      (new HttpTooUpdate(req.without("note"))).getNote() must_== ImOption.empty()
+    }
+
+    "specified note is ok" in {
+      (new HttpTooUpdate(req)).getNote() must_== ImOption.apply("hello")
+    }
+
+    "missing noteTitle is ok" in {
+      (new HttpTooUpdate(req)).getNoteTitle() must_== ImOption.empty()
+    }
+
+    "specified noteTitle is ok" in {
+      (new HttpTooUpdate(req.modifiedWith("noteTitle" -> "title"))).getNoteTitle() must_== ImOption.apply("title")
+    }
   }
 }


### PR DESCRIPTION
A small update to ToO triggering to allow the note title to be set in the request instead of being fixed to "Finding Chart".  The requirement is that either note text or note title result in a note being added and that given note text without a title, it should default to "Finding Chart".