### PR TITLE
Minor GHOST fixes

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
@@ -105,16 +105,20 @@ public final class TargetSelection {
                     final GhostAsterism.SingleTarget gsa = (GhostAsterism.SingleTarget) a;
                     if (gsa.overriddenBase().isDefined())
                         res.add(new CoordinatesSelection(idx++, gsa.overriddenBase().get()));
-                    else
-                        res.add(new CoordinatesSelection(idx++, gsa.basePosition(ImOption.scalaNone()).get()));
+                    else {
+                        final scala.Option<Coordinates> c = gsa.basePosition(ImOption.scalaNone());
+                        res.add(new CoordinatesSelection(idx++, c.isDefined() ? c.get() : Coordinates.zero()));
+                    }
                     res.add(new NormalTargetSelection(idx++, gsa.target().spTarget()));
                     break;
                 case GhostDualTarget:
                     final GhostAsterism.DualTarget gda = (GhostAsterism.DualTarget) a;
                     if (gda.overriddenBase().isDefined())
                         res.add(new CoordinatesSelection(idx++, gda.overriddenBase().get()));
-                    else
-                        res.add(new CoordinatesSelection(idx++, gda.basePosition(ImOption.scalaNone()).get()));
+                    else {
+                        final scala.Option<Coordinates> c = gda.basePosition(ImOption.scalaNone());
+                        res.add(new CoordinatesSelection(idx++, c.isDefined() ? c.get() : Coordinates.zero()));
+                    }
                     res.add(new NormalTargetSelection(idx++, gda.target1().spTarget()));
                     res.add(new NormalTargetSelection(idx++, gda.target2().spTarget()));
                     break;
@@ -122,8 +126,10 @@ public final class TargetSelection {
                     final GhostAsterism.TargetPlusSky gtsa = (GhostAsterism.TargetPlusSky) a;
                     if (gtsa.overriddenBase().isDefined())
                         res.add(new CoordinatesSelection(idx++, gtsa.overriddenBase().get()));
-                    else
-                        res.add(new CoordinatesSelection(idx++, gtsa.basePosition(ImOption.scalaNone()).get()));
+                    else {
+                        final scala.Option<Coordinates> c = gtsa.basePosition(ImOption.scalaNone());
+                        res.add(new CoordinatesSelection(idx++, c.isDefined() ? c.get() : Coordinates.zero()));
+                    }
                     res.add(new NormalTargetSelection(idx++, gtsa.target().spTarget()));
                     res.add(new CoordinatesSelection(idx++, gtsa.sky()));
                     break;
@@ -131,8 +137,10 @@ public final class TargetSelection {
                     final GhostAsterism.SkyPlusTarget gsta = (GhostAsterism.SkyPlusTarget) a;
                     if (gsta.overriddenBase().isDefined())
                         res.add(new CoordinatesSelection(idx++, gsta.overriddenBase().get()));
-                    else
-                        res.add(new CoordinatesSelection(idx++, gsta.basePosition(ImOption.scalaNone()).get()));
+                    else {
+                        final scala.Option<Coordinates> c = gsta.basePosition(ImOption.scalaNone());
+                        res.add(new CoordinatesSelection(idx++, c.isDefined() ? c.get() : Coordinates.zero()));
+                    }
                     res.add(new CoordinatesSelection(idx++, gsta.sky()));
                     res.add(new NormalTargetSelection(idx++, gsta.target().spTarget()));
                     break;
@@ -140,16 +148,20 @@ public final class TargetSelection {
                     final GhostAsterism.HighResolutionTarget ghta = (GhostAsterism.HighResolutionTarget) a;
                     if (ghta.overriddenBase().isDefined())
                         res.add(new CoordinatesSelection(idx++, ghta.overriddenBase().get()));
-                    else
-                        res.add(new CoordinatesSelection(idx++, ghta.basePosition(ImOption.scalaNone()).get()));
+                    else {
+                        final scala.Option<Coordinates> c = ghta.basePosition(ImOption.scalaNone());
+                        res.add(new CoordinatesSelection(idx++, c.isDefined() ? c.get() : Coordinates.zero()));
+                    }
                     res.add(new NormalTargetSelection(idx++, ghta.target().spTarget()));
                     break;
                 case GhostHighResolutionTargetPlusSky:
                     final GhostAsterism.HighResolutionTargetPlusSky ghtsa = (GhostAsterism.HighResolutionTargetPlusSky) a;
                     if (ghtsa.overriddenBase().isDefined())
                         res.add(new CoordinatesSelection(idx++, ghtsa.overriddenBase().get()));
-                    else
-                        res.add(new CoordinatesSelection(idx++, ghtsa.basePosition(ImOption.scalaNone()).get()));
+                    else {
+                        final scala.Option<Coordinates> c = ghtsa.basePosition(ImOption.scalaNone());
+                        res.add(new CoordinatesSelection(idx++, c.isDefined() ? c.get() : Coordinates.zero()));
+                    }
                     res.add(new NormalTargetSelection(idx++, ghtsa.target().spTarget()));
                     res.add(new CoordinatesSelection(idx++, ghtsa.sky()));
                     break;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -176,7 +176,7 @@ class ItcImagingPanel(val owner: EdIteratorFolder) extends ItcPanel {
   def visibleFor(t: SPComponentType): Boolean = t match {
     case SPComponentType.INSTRUMENT_ACQCAM      => true
     case SPComponentType.INSTRUMENT_FLAMINGOS2  => true
-    case SPComponentType.INSTRUMENT_GHOST       => true
+    case SPComponentType.INSTRUMENT_GHOST       => false
     case SPComponentType.INSTRUMENT_GMOS        => true
     case SPComponentType.INSTRUMENT_GMOSSOUTH   => true
     case SPComponentType.INSTRUMENT_GSAOI       => true

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcUniqueConfig.scala
@@ -4,8 +4,9 @@ import edu.gemini.itc.shared.ConfigExtractor
 import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
 import edu.gemini.spModel.gemini.acqcam.InstAcqCam
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
-import edu.gemini.spModel.gemini.gmos.{FullExposureTime => GmosExposureTime, GmosNorthType, GmosSouthType, InstGmosNorth, InstGmosSouth}
-import edu.gemini.spModel.gemini.gnirs.{GNIRSParams, GNIRSConstants}
+import edu.gemini.spModel.gemini.ghost.Ghost
+import edu.gemini.spModel.gemini.gmos.{GmosNorthType, GmosSouthType, InstGmosNorth, InstGmosSouth, FullExposureTime => GmosExposureTime}
+import edu.gemini.spModel.gemini.gnirs.{GNIRSConstants, GNIRSParams}
 import edu.gemini.spModel.gemini.gsaoi.Gsaoi
 import edu.gemini.spModel.gemini.michelle.{InstMichelle, MichelleParams}
 import edu.gemini.spModel.gemini.nifs.InstNIFS
@@ -13,7 +14,6 @@ import edu.gemini.spModel.gemini.niri.{InstNIRI, Niri}
 import edu.gemini.spModel.gemini.trecs.{InstTReCS, TReCSParams}
 import edu.gemini.spModel.obscomp.InstConstants
 import jsky.app.ot.editor.seq.Keys._
-
 import scalaz._
 import Scalaz._
 
@@ -80,17 +80,20 @@ object ItcUniqueConfig {
   private def isSpectroscopy(c: Config): Boolean = !isImaging(c)
 
   // Decides if a configuration is for imaging or spectroscopy (in most cases based on the presence of a disperser element).
-  private def isImaging(c: Config): Boolean = c.getItemValue(INST_INSTRUMENT_KEY) match {
-    case InstAcqCam.INSTRUMENT_NAME_PROP    => true  // Acq cam is imaging only
-    case Flamingos2.INSTRUMENT_NAME_PROP    => c.getItemValue(INST_DISPERSER_KEY).equals(Flamingos2.Disperser.NONE)
-    case InstGmosNorth.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(GmosNorthType.DisperserNorth.MIRROR)
-    case InstGmosSouth.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(GmosSouthType.DisperserSouth.MIRROR)
-    case GNIRSConstants.INSTRUMENT_NAME_PROP=> c.getItemValue(INST_ACQ_MIRROR).equals(GNIRSParams.AcquisitionMirror.IN)
-    case Gsaoi.INSTRUMENT_NAME_PROP         => true  // Gsaoi is imaging only
-    case InstMichelle.INSTRUMENT_NAME_PROP  => c.getItemValue(INST_DISPERSER_KEY).equals(MichelleParams.Disperser.MIRROR)
-    case InstNIFS.INSTRUMENT_NAME_PROP      => false // NIFS is spectroscopy only
-    case InstNIRI.INSTRUMENT_NAME_PROP      => c.getItemValue(INST_DISPERSER_KEY).equals(Niri.Disperser.NONE)
-    case InstTReCS.INSTRUMENT_NAME_PROP     => c.getItemValue(INST_DISPERSER_KEY).equals(TReCSParams.Disperser.MIRROR)
+  private def isImaging(c: Config): Boolean = {
+    c.getItemValue(INST_INSTRUMENT_KEY) match {
+      case InstAcqCam.INSTRUMENT_NAME_PROP => true // Acq cam is imaging only
+      case Flamingos2.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(Flamingos2.Disperser.NONE)
+      case InstGmosNorth.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(GmosNorthType.DisperserNorth.MIRROR)
+      case InstGmosSouth.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(GmosSouthType.DisperserSouth.MIRROR)
+      case Ghost.INSTRUMENT_NAME_PROP => false // GHOST is spectroscopy only
+      case GNIRSConstants.INSTRUMENT_NAME_PROP => c.getItemValue(INST_ACQ_MIRROR).equals(GNIRSParams.AcquisitionMirror.IN)
+      case Gsaoi.INSTRUMENT_NAME_PROP => true // Gsaoi is imaging only
+      case InstMichelle.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(MichelleParams.Disperser.MIRROR)
+      case InstNIFS.INSTRUMENT_NAME_PROP => false // NIFS is spectroscopy only
+      case InstNIRI.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(Niri.Disperser.NONE)
+      case InstTReCS.INSTRUMENT_NAME_PROP => c.getItemValue(INST_DISPERSER_KEY).equals(TReCSParams.Disperser.MIRROR)
+    }
   }
 
   private def instrumentName(c: Config): Option[String] =


### PR DESCRIPTION
GHOST was resulting in a `None.get()` when switching from Sidereal to Nonsidereal target due to the fact that we explicitly list the base position as well as the IFU targets.

Additionally, GHOST does not support imaging, so this was changed.