### PR TITLE
REL-3458: allow anybody to edit the PI email

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdProgram.java
@@ -313,7 +313,16 @@ public final class EdProgram extends OtItemEditor<ISPProgram, SPProgram> impleme
         _w.firstNameBox.setEnabled(enabled);
         _w.lastNameBox.setEnabled(enabled);
 
-        _w.emailBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));
+        // REL-3458
+        //
+        // Previously this widget was protected so that only staff can edit it.
+        // The following now allows the PI email to be edited by anybody who
+        // otherwise has permission to edit the program in the current situation.
+        // The downside is that "user" keys are tied to the email address and
+        // will stop working if the address is edited. OTOH, nobody has a user
+        // key.
+        _w.emailBox.setEnabled(enabled);
+
         _w.phoneBox.setEnabled(enabled);
         _w.affiliationBox.setEnabled(enabled);
         _w.additionalSupportBox.setEnabled(OTOptions.isStaff(getProgram().getProgramID()));


### PR DESCRIPTION
This PR would make it possible for anybody who otherwise has access to a program to change the PI email field *in the OT editor* at least.  The reason it wasn't this way before is that "user" keys are tied to this email address.  If your access to the program is via a user key then you end up not being able to sync the program and losing even the ability to edit it unless you can switch to some other key that does work.  So that seems poor.  I expect support ticket requests.

I have a question in the JIRA task but thought I'd get this PR out for discussion in the meantime.