### PR TITLE
REL-3791: allow PIs to adjust observation priority when on hold

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdObservation2.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/EdObservation2.java
@@ -863,9 +863,7 @@ public final class EdObservation2 extends OtItemEditor<ISPObservation, SPObserva
         } else {
             // must be a PI
 
-            // Don't allow changing priorities when status is not phase1 (not even when on-hold).
-            // This is to avoid getting to an un-editable state.
-            final boolean b = (current == ObsPhase2Status.PI_TO_COMPLETE);
+            final boolean b = (current == ObsPhase2Status.PI_TO_COMPLETE) || (current == ObsPhase2Status.ON_HOLD);
             _editorPanel.priorityHigh.setEnabled(b);
             _editorPanel.priorityMedium.setEnabled(b);
             _editorPanel.priorityLow.setEnabled(b);


### PR DESCRIPTION
This PR would permit PIs to edit observation priority (high/medium/low) for "on hold" observations.  There is a disconcerting warning against doing this very thing in the code that currently disables this feature:

> Don't allow changing priorities when status is not phase1 (not even when on-hold).		            
> This is to avoid getting to an un-editable state.

The warning has been there since the code was first ingested in GitHub 6 years ago. I can think of and find no reason why this should be the case and indeed testing doesn't reveal this problem. I hope it was a misunderstanding, but if anybody has more information please speak up!