### PR TITLE
REL-3771: NGS2 updates after commissioning

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsMagnitudeTable.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsMagnitudeTable.scala
@@ -27,22 +27,22 @@ object GemsMagnitudeTable extends MagnitudeTable {
   import SkyBackground.{ PERCENT_20 => SB20, PERCENT_50 => SB50, PERCENT_80 => SB80, ANY => SBAny }
 
   private val cc50 = Map(
-    ((IQ20,  SB20 ), (18.0, 10.5)),
-    ((IQ20,  SB50 ), (17.9, 10.5)),
-    ((IQ20,  SB80 ), (17.8, 10.2)),
-    ((IQ20,  SBAny), (17.7, 10.0)),
-    ((IQ70,  SB20 ), (17.6, 10.0)),
-    ((IQ70,  SB50 ), (17.5, 10.0)),
-    ((IQ70,  SB80 ), (17.4,  9.7)),
-    ((IQ70,  SBAny), (17.3,  9.5)),
-    ((IQ85,  SB20 ), (17.2,  9.5)),
-    ((IQ85,  SB50 ), (17.1,  9.5)),
-    ((IQ85,  SB80 ), (17.0,  9.2)),
-    ((IQ85,  SBAny), (16.9,  9.0)),
-    ((IQAny, SB20 ), (16.2,  9.0)),
-    ((IQAny, SB50 ), (16.1,  9.0)),
-    ((IQAny, SB80 ), (16.0,  9.0)),
-    ((IQAny, SBAny), (15.9,  8.7))
+    ((IQ20,  SB20 ), (18.5, 10.5)),
+    ((IQ20,  SB50 ), (18.5, 10.5)),
+    ((IQ20,  SB80 ), (18.4, 10.2)),
+    ((IQ20,  SBAny), (18.3, 10.0)),
+    ((IQ70,  SB20 ), (18.2, 10.0)),
+    ((IQ70,  SB50 ), (18.2, 10.0)),
+    ((IQ70,  SB80 ), (18.1,  9.7)),
+    ((IQ70,  SBAny), (18.0,  9.5)),
+    ((IQ85,  SB20 ), (17.9,  9.5)),
+    ((IQ85,  SB50 ), (17.9,  9.5)),
+    ((IQ85,  SB80 ), (17.8,  9.2)),
+    ((IQ85,  SBAny), (17.7,  9.0)),
+    ((IQAny, SB20 ), (17.6,  9.0)),
+    ((IQAny, SB50 ), (17.3,  9.0)),
+    ((IQAny, SB80 ), (17.0,  9.0)),
+    ((IQAny, SBAny), (16.7,  8.7))
   )
 
   def cwfsConstraintsForCc50(iq: ImageQuality, sb: SkyBackground): MagnitudeConstraints = {

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -330,57 +330,34 @@ object CatalogAdapter {
       g:   Double,
       p1:  Double,
       p2:  Double,
-      p3:  Double,
-      min: Double,
-      max: Double
+      p3:  Double
     ) {
 
       /**
        * Convert the catalog g-mag value to a magnitude in another band.
        */
-      def convert(gMag: Double, bpRp: Double): Option[Magnitude] =
-        ((min < bpRp) && (bpRp < max)) option
-          Magnitude(
-            gMag + g + p1*bpRp + p2*Math.pow(bpRp, 2) + p3*Math.pow(bpRp, 3),
-            b,
-            None,
-            MagnitudeSystem.Vega  // Note that Gaia magnitudes are in the Vega system.
-          )
+      def convert(gMag: Double, bpRp: Double): Magnitude =
+        Magnitude(
+          gMag + g + p1*bpRp + p2*Math.pow(bpRp, 2) + p3*Math.pow(bpRp, 3),
+          b,
+          None,
+          MagnitudeSystem.Vega  // Note that Gaia magnitudes are in the Vega system.
+        )
 
     }
 
     val conversions: List[Conversion] =
       List(
-        Conversion(MagnitudeBand.V,   0.017600,  0.00686, 0.173200,  0.000000, -0.50, 2.75),
-        Conversion(MagnitudeBand.R,   0.003226, -0.38330, 0.134500,  0.000000, -0.50, 2.75),
-        Conversion(MagnitudeBand.I,  -0.020850, -0.74190, 0.096310,  0.000000, -0.50, 2.75),
-        Conversion(MagnitudeBand._r,  0.128790, -0.24662, 0.027464,  0.049465,  0.20, 2.00),
-        Conversion(MagnitudeBand._i,  0.296760, -0.64728, 0.101410,  0.000000,  0.00, 4.50),
-        Conversion(MagnitudeBand._g, -0.135180,  0.46245, 0.251710, -0.021349, -0.50, 2.00),
-        Conversion(MagnitudeBand.K,   0.188500, -2.09200, 0.134500,  0.000000,  0.25, 5.50),
-        Conversion(MagnitudeBand.H,   0.162100, -1.96800, 0.132800,  0.000000,  0.25, 5.00),
-        Conversion(MagnitudeBand.J,   0.018830, -1.39400, 0.078930,  0.000000, -0.50, 5.50)
+        Conversion(MagnitudeBand.V,   0.017600,  0.00686, 0.173200,  0.000000),
+        Conversion(MagnitudeBand.R,   0.003226, -0.38330, 0.134500,  0.000000),
+        Conversion(MagnitudeBand.I,  -0.020850, -0.74190, 0.096310,  0.000000),
+        Conversion(MagnitudeBand._r,  0.128790, -0.24662, 0.027464,  0.049465),
+        Conversion(MagnitudeBand._i,  0.296760, -0.64728, 0.101410,  0.000000),
+        Conversion(MagnitudeBand._g, -0.135180,  0.46245, 0.251710, -0.021349),
+        Conversion(MagnitudeBand.K,   0.188500, -2.09200, 0.134500,  0.000000),
+        Conversion(MagnitudeBand.H,   0.162100, -1.96800, 0.132800,  0.000000),
+        Conversion(MagnitudeBand.J,   0.018830, -1.39400, 0.078930,  0.000000)
       )
-
-    private def unconvert(mag: Magnitude, f: Conversion=>Double): Option[Double] =
-      conversions.find(_.b === mag.band).map { c =>
-        val bpRp = f(c)
-        mag.value - (c.g + bpRp*(c.p1 + bpRp*(c.p2 + bpRp*c.p3)))
-      }
-
-    /**
-     * Convert from a particular band back to the catalog gmag value using the
-     * minimum supported bp-rp value.
-     */
-    def unconvertMin(mag: Magnitude): Option[Double] =
-      unconvert(mag, _.min)
-
-    /**
-     * Convert from a particular band back to the catalog gmag value using the
-     * maximum supported bp-rp value.
-     */
-    def unconvertMax(mag: Magnitude): Option[Double] =
-      unconvert(mag, _.max)
 
     override def isMagnitudeField(v: (FieldId, String)): Boolean =
       sys.error("unused")
@@ -423,7 +400,7 @@ object CatalogAdapter {
       (for {
         gMag <- doubleValue(gMagField)
         bpRp <- doubleValue(bpRpField)
-      } yield conversions.flatMap(_.convert(gMag, bpRp).toList)).getOrElse(Nil)
+      } yield conversions.map(_.convert(gMag, bpRp))).getOrElse(Nil)
 
     }
   }

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -395,7 +395,7 @@ class VoTableParserSpec extends Specification with VoTableParser {
               <TD>0.031294621220519486</TD>
               <TD>2015.5</TD>
               <TD>13.91764</TD>
-              <TD>2.68324375</TD> <!-- Out of range for r and g conversion -->
+              <TD>2.68324375</TD>
               <TD></TD>
             </TR>
             <TR>
@@ -693,9 +693,8 @@ class VoTableParserSpec extends Specification with VoTableParser {
       a.magnitudes shouldEqual Nil
       b.magnitudes shouldEqual Nil
 
-      // Third target has bp-rp out of range for r and g bands.
       import MagnitudeBand._
-      c.magnitudes.map(_.band).toSet shouldEqual Set(V, R, I, _i, K, H, J)
+      c.magnitudes.map(_.band).toSet shouldEqual Set(_g, _r, V, R, I, _i, K, H, J)
 
       // Final target has everything.
       d.magnitudes.map(_.band).toSet shouldEqual CatalogName.Gaia.supportedBands.toSet


### PR DESCRIPTION
This PR addresses parts 1 and 3 of REL-3771.  Namely:

1. New CWFS NGS2 limiting magnitudes
3. Remove the Color restrictions in the transformation equations 

Part of 3 was to use fixed g GAIA magnitude limits in the search, which simplifies the code a bit.