### PR TITLE
GHOSTSW-27: Set PWFS2 inner radius for GHOST.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -314,6 +314,8 @@ final class Ghost extends SPInstObsComp(GhostMixin.SP_TYPE) with PropertyProvide
   }
 
   override def getVignettableScienceArea: ScienceAreaGeometry = GhostScienceAreaGeometry
+
+  override def pwfs2VignettingClearance: Angle = Angle.arcsecs(5.5)
 }
 
 object Ghost {


### PR DESCRIPTION
As per Steve's specification, as a temporary measure, we will use an inner radius of 5.5 arcsecs.