### PR TITLE
GHOSTSW-27: Adjusted inner PWFS2 radius.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -315,7 +315,7 @@ final class Ghost extends SPInstObsComp(GhostMixin.SP_TYPE) with PropertyProvide
 
   override def getVignettableScienceArea: ScienceAreaGeometry = GhostScienceAreaGeometry
 
-  override def pwfs2VignettingClearance: Angle = Angle.arcsecs(5.5)
+  override def pwfs2VignettingClearance: Angle = Angle.arcmins(5.5)
 }
 
 object Ghost {


### PR DESCRIPTION
The inner radius for PWFS2 for GHOST was set for 5.5 arcsec, which needed to be adjusted.