### PR TITLE
REL-3813: Version change to get PIT to work.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization in Global := "edu.gemini.ocs"
 // true indicates a test release, and false indicates a production release
 ocsVersion in ThisBuild := OcsVersion("2020A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2020B", true, 2, 1, 4)
+pitVersion in ThisBuild := OcsVersion("2020B", false, 2, 1, 2)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion


### PR DESCRIPTION
When we updated the certificates, I re-versioned the PIT as 2020B.2.2.1, which broke the PIT. It should have been re-versioned as 2020B.2.1.2, which results in a match with the current version. (Note that re-versioning as 2020B.2.2.2 would have broken things as well since the previous version was broken.)

I spoke with Bryan and this is not a problem since 2020B.2.2.1 was never released, so the versioning remains consistent.