### PR TITLE
REL-3808: Avoid [45,150] for GNIRS average parallactic angle.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -1149,23 +1149,11 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         return false;
     }
 
-    // REL-3808: Prefer parallactic angles that avoid [45,150].
-    // All methods to set pos angle in SPInstObsComp delegate to setPosAngleDegrees, so we only need change this method.
+    // REL-3808: We want to avoid CRPAs (Cass Rotator Parallactic Anglees) in [45,150].
+    // Note this is not the same as the parallactic angle, which can still be in [45, 150].
+    // Always flipping the default parallactic angle accomplishes this.
     @Override
-    public void setPosAngleDegrees(double newValue) {
-        final double oldValue = getPosAngleDegrees();
-        final double normalizedValue = edu.gemini.spModel.util.Angle.normalizeDegrees(newValue);
-        final double preferredValue;
-
-        // 150 + 180 = 330 < 360 so we don't have to normalize anything here.
-        if (getPosAngleConstraint() == PosAngleConstraint.PARALLACTIC_ANGLE
-                && normalizedValue >= 45 && normalizedValue <= 150)
-            preferredValue = newValue + 180;
-        else
-            preferredValue = normalizedValue;
-        if (oldValue != preferredValue) {
-            _positionAngle = preferredValue;
-            firePropertyChange(InstConstants.POS_ANGLE_PROP, oldValue, preferredValue);
-        }
+    public Option<edu.gemini.spModel.core.Angle> calculateParallacticAngle(final ISPObservation obs) {
+        return super.calculateParallacticAngle(obs).map(edu.gemini.spModel.core.Angle::flip);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -183,10 +183,10 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         _nf.setMaximumFractionDigits(3);
     }
 
-    private static final Duration SETUP_TIME_LGS     = Duration.ofMinutes(25);
-    private static final Duration SETUP_TIME_IFU     = Duration.ofMinutes(20);
-    private static final Duration SETUP_TIME         = Duration.ofMinutes(15);
-    private static final Duration REACQUISITION_TIME = Duration.ofMinutes( 6); // 6 minutes as defined in REL-1346
+    private static final Duration SETUP_TIME_LGS = Duration.ofMinutes(25);
+    private static final Duration SETUP_TIME_IFU = Duration.ofMinutes(20);
+    private static final Duration SETUP_TIME = Duration.ofMinutes(15);
+    private static final Duration REACQUISITION_TIME = Duration.ofMinutes(6); // 6 minutes as defined in REL-1346
 
     /**
      * Constructor
@@ -227,15 +227,15 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     }
 
 
-    public static Duration getSetupTimeLgs () {
+    public static Duration getSetupTimeLgs() {
         return SETUP_TIME_LGS;
     }
 
-    public static Duration getSetupTimeIfu () {
+    public static Duration getSetupTimeIfu() {
         return SETUP_TIME_IFU;
     }
 
-    public static Duration getSetupTime () {
+    public static Duration getSetupTime() {
         return SETUP_TIME;
     }
 
@@ -260,9 +260,11 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
 
     /**
      * For ITC.
+     *
      * @deprecated config is a key-object collection and is thus not type-safe. It is meant for ITC only.
      */
-    @Deprecated @Override
+    @Deprecated
+    @Override
     public Duration getSetupTime(Config conf) {
         if (conf.containsItem(AOConstants.AO_SYSTEM_KEY)) {
             final GuideStarType guideStarType = (GuideStarType) conf.getItemValue(AOConstants.AO_GUIDE_STAR_TYPE_KEY);
@@ -275,7 +277,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
 
         if (slitWidth.equals(GNIRSParams.SlitWidth.IFU)) {
             return getSetupTimeIfu();
-        } else  {
+        } else {
             return getSetupTime();
         }
     }
@@ -292,7 +294,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     }
 
     @Override
-    public Duration getReacquisitionTime (Config config) {
+    public Duration getReacquisitionTime(Config config) {
         return REACQUISITION_TIME;
     }
 
@@ -888,7 +890,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         }
         v = ImOption.apply(Pio.getValue(paramSet, FOCUS_PROP.getName()))
                 .getOrElse(FocusSuggestion.DEFAULT.displayValue());
-            setFocus(new Focus(v));
+        setFocus(new Focus(v));
 
         // REL-2090: Special workaround for elimination of former PositionAngleMode, since functionality has been
         // merged with PosAngleConstraint but we still need legacy code.
@@ -900,7 +902,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
             _setPosAngleConstraint(v);
 
         setOverrideAcqObsWavelength(
-            Pio.getBooleanValue(paramSet, OVERRIDE_ACQ_OBS_WAVELENGTH_PROP.getName(), true)
+                Pio.getBooleanValue(paramSet, OVERRIDE_ACQ_OBS_WAVELENGTH_PROP.getName(), true)
         );
 
         v = Pio.getValue(paramSet, PORT_PROP);
@@ -927,7 +929,7 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         sc.putParameter(DefaultParameter.getInstance(GNIRSConstants.CROSS_DISPERSED_PROP, getCrossDispersed()));
         sc.putParameter(DefaultParameter.getInstance(GNIRSConstants.WOLLASTON_PRISM_PROP, getWollastonPrism()));
         sc.putParameter(DefaultParameter.getInstance(GNIRSConstants.READ_MODE_PROP, getReadMode()));
-    //    sc.putParameter(DefaultParameter.getInstance(GNIRSConstants.FILTER_PROP, getFilter()));
+        //    sc.putParameter(DefaultParameter.getInstance(GNIRSConstants.FILTER_PROP, getFilter()));
         sc.putParameter(DefaultParameter.getInstance(WELL_DEPTH_PROP, getWellDepth()));
         sc.putParameter(DefaultParameter.getInstance(GNIRSConstants.ACQUISITION_MIRROR_PROP, getAcquisitionMirror()));
         sc.putParameter(DefaultParameter.getInstance(GNIRSConstants.CENTRAL_WAVELENGTH_PROP, getCentralWavelength()));
@@ -1023,7 +1025,8 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
         return null;
     }
 
-    @Override public ConfigSequence postProcessSequence(ConfigSequence in) {
+    @Override
+    public ConfigSequence postProcessSequence(ConfigSequence in) {
         final Config[] configs = in.getAllSteps();
 
         for (Config c : configs) {
@@ -1039,8 +1042,8 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
             final Object explicitCamera = c.getItemValue(GNIRSConstants.CAMERA_KEY);
             if (explicitCamera == null) {
                 final Wavelength cwl = (Wavelength) c.getItemValue(GNIRSConstants.CENTRAL_WAVELENGTH_KEY);
-                final PixelScale  ps = (PixelScale) c.getItemValue(GNIRSConstants.PIXEL_SCALE_KEY);
-                final Camera  camera = (cwl == null) || (ps == null) ? Camera.DEFAULT : Camera.getDefault(cwl.doubleValue(), ps);
+                final PixelScale ps = (PixelScale) c.getItemValue(GNIRSConstants.PIXEL_SCALE_KEY);
+                final Camera camera = (cwl == null) || (ps == null) ? Camera.DEFAULT : Camera.getDefault(cwl.doubleValue(), ps);
                 c.putItem(GNIRSConstants.CAMERA_KEY, camera);
             }
         }
@@ -1092,8 +1095,15 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     private static final Angle PWFS1_VIG = Angle.arcmins(5.0);
     private static final Angle PWFS2_VIG = Angle.arcmins(4.8);
 
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override
+    public Angle pwfs1VignettingClearance() {
+        return PWFS1_VIG;
+    }
+
+    @Override
+    public Angle pwfs2VignettingClearance() {
+        return PWFS2_VIG;
+    }
 
 
     /**
@@ -1129,13 +1139,33 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     @Override
     public ImList<PosAngleConstraint> getSupportedPosAngleConstraints() {
         return DefaultImList.create(PosAngleConstraint.FIXED,
-                                    PosAngleConstraint.PARALLACTIC_ANGLE,
-                                    PosAngleConstraint.PARALLACTIC_OVERRIDE);
+                PosAngleConstraint.PARALLACTIC_ANGLE,
+                PosAngleConstraint.PARALLACTIC_OVERRIDE);
     }
 
     @Override
     public boolean allowUnboundedPositionAngle() {
         // Unsupported for GNIRS.
         return false;
+    }
+
+    // REL-3808: Prefer parallactic angles that avoid [45,150].
+    // All methods to set pos angle in SPInstObsComp delegate to setPosAngleDegrees, so we only need change this method.
+    @Override
+    public void setPosAngleDegrees(double newValue) {
+        final double oldValue = getPosAngleDegrees();
+        final double normalizedValue = edu.gemini.spModel.util.Angle.normalizeDegrees(newValue);
+        final double preferredValue;
+
+        // 150 + 180 = 330 < 360 so we don't have to normalize anything here.
+        if (getPosAngleConstraint() == PosAngleConstraint.PARALLACTIC_ANGLE
+                && normalizedValue >= 45 && normalizedValue <= 150)
+            preferredValue = newValue + 180;
+        else
+            preferredValue = normalizedValue;
+        if (oldValue != preferredValue) {
+            _positionAngle = preferredValue;
+            firePropertyChange(InstConstants.POS_ANGLE_PROP, oldValue, preferredValue);
+        }
     }
 }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/ParallacticAngleControls.scala
@@ -9,7 +9,6 @@ import java.time.format.DateTimeFormatter
 
 import javax.swing.{BorderFactory, Icon}
 import javax.swing.border.EtchedBorder
-import edu.gemini.pot.sp.ISPNode
 import edu.gemini.spModel.core.Angle
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.inst.ParallacticAngleSupport
@@ -17,24 +16,18 @@ import edu.gemini.spModel.obs.{ObsTargetCalculatorService, SPObservation, Schedu
 import edu.gemini.spModel.obs.SchedulingBlock.Duration
 import edu.gemini.spModel.obs.SchedulingBlock.Duration._
 import edu.gemini.spModel.rich.shared.immutable._
-import edu.gemini.shared.util.immutable.{ImOption, Option => JOption}
+import edu.gemini.shared.util.immutable.{Option => JOption}
 import edu.gemini.spModel.obscomp.SPInstObsComp
-import edu.gemini.spModel.syntax.sp.node._
 import jsky.app.ot.editor.OtItemEditor
-import jsky.app.ot.gemini.editor.EphemerisUpdater
 import jsky.app.ot.gemini.schedulingBlock.{SchedulingBlockDialog, SchedulingBlockUpdate}
 import jsky.app.ot.util.TimeZonePreference
 import jsky.util.Resources
-import jsky.util.gui.DialogUtil
 
 import scala.swing.GridBagPanel.{Anchor, Fill}
 import scala.swing._
 import scala.swing.event.{ButtonClicked, Event}
 import scalaz._
 import Scalaz._
-import scalaz.effect.IO
-
-import scala.util.Try
 
 /**
   * This class encompasses all of the logic required to manage the average parallactic angle information associated
@@ -45,8 +38,8 @@ import scala.util.Try
 class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publisher {
   import ParallacticAngleControls._
 
-  val Nop = new Runnable {
-    override def run() = ()
+  val Nop: Runnable = new Runnable {
+    override def run(): Unit = ()
   }
 
   private var editor:    Option[OtItemEditor[_, _]] = None
@@ -285,7 +278,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
         site,
         mode)
 
-      sb.foreach(updateSchedulingBlock(_))
+      sb.foreach(updateSchedulingBlock)
     }
   }
 
@@ -365,7 +358,7 @@ class ParallacticAngleControls(isPaUi: Boolean) extends GridBagPanel with Publis
 }
 
 object ParallacticAngleControls {
-  val Log = Logger.getLogger(getClass.getName)
+  val Log: Logger = Logger.getLogger(getClass.getName)
   case object ParallacticAngleChangedEvent extends Event
 
   // Precision limit for which two parallactic angles are considered equivalent.


### PR DESCRIPTION
The GNIRS acquisition mirror slips at some instrument angles, and the most slippage is seen at Cassegrain Rotator angles of 45 - 150 degrees. When the OT selects the PA for average parallactic angle observations it has two choices separated by 180 degrees. We would like the default to be the one that avoids 45 < CRPA < 150.

Because of this, we want to avoid the average parallactic angle in [45, 150] and take the 180 degree flip instead. We do this by overriding `InstGNIRS`'`setPosAngleDegrees` method inherited from `SPInstObsComp`, to which all methods that set the pos angle are delegated.