### PR TITLE
Include user targets in the sequence config

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -29,15 +29,15 @@ object HS2Spec extends Specification with ScalaCheck {
       runSearch(Search.Comet("kjhdwekuq")) must_== \/-(Nil)
     }
 
-    // "handle multiple results" in {
-    //   runSearch(Search.Comet("hu")).map(_.take(5)) must_== \/-(List(
-    //     Row(HD.Comet("7P"), "Churyumov-Gerasimenko"),
-    //     Row(HD.Comet("06P"), "Schuster"),
-    //     Row(HD.Comet("30P"), "McNaught-Hughes"),
-    //     Row(HD.Comet("78P"), "Hug-Bell"),
-    //     Row(HD.Comet("/1880 Y1"), "Pechule")
-    //   ))
-    // }
+     "handle multiple results" in {
+       runSearch(Search.Comet("hu")).map(_.take(5)) must_== \/-(List(
+         Row(HD.Comet("67P"), "Churyumov-Gerasimenko"),
+         Row(HD.Comet("106P"), "Schuster"),
+         Row(HD.Comet("130P"), "McNaught-Hughes"),
+         Row(HD.Comet("178P"), "Hug-Bell"),
+         Row(HD.Comet("C/1880 Y1"), "Pechule")
+       ))
+     }
 
     "handle single result (Format 1) Hubble (C/1937 P1)" in {
       runSearch(Search.Comet("hubble")) must_== \/-(List(
@@ -61,11 +61,11 @@ object HS2Spec extends Specification with ScalaCheck {
 
     "handle multiple results" in {
       runSearch(Search.Asteroid("her")).map(_.take(5)) must_== \/-(List(
-        Row(HD.AsteroidOldStyle(103), "Hera"),
-        Row(HD.AsteroidOldStyle(121), "Hermione"),
-        Row(HD.AsteroidOldStyle(135), "Hertha"),
-        Row(HD.AsteroidOldStyle(206), "Hersilia"),
-        Row(HD.AsteroidOldStyle(214), "Aschera")
+        Row(HD.AsteroidNewStyle("A868 RA"), "Hera"),
+        Row(HD.AsteroidNewStyle("A872 JA"), "Hermione"),
+        Row(HD.AsteroidNewStyle("A874 DA"), "Hertha"),
+        Row(HD.AsteroidNewStyle("A879 TC"), "Hersilia"),
+        Row(HD.AsteroidNewStyle("A880 DB"), "Aschera")
       ))
     }
 
@@ -77,7 +77,7 @@ object HS2Spec extends Specification with ScalaCheck {
 
     "handle single result (Format 2) 29 Amphitrite" in {
       runSearch(Search.Asteroid("amphitrite")) must_== \/-(List(
-        Row(HD.AsteroidOldStyle(29), "Amphitrite")
+        Row(HD.AsteroidNewStyle("A854 EB"), "Amphitrite")
       ))
     }
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -415,6 +415,10 @@ object Ghost {
   val HRIFU2_RA_HMS: String    = "hrifu2CoordsRAHMS"
   val HRIFU2_DEC_DMS: String   = "hrifu2CoordsDecDMS"
 
+  // Property names for user targets
+  def userTargetParams(index: Int): (String, String, String, String, String) =
+    (s"userTarget${index}Name", s"userTarget${index}CoordsRADeg", s"userTarget${index}CoordsDecDeg", s"userTarget${index}CoordsRAHMS", s"userTarget${index}CoordsDecDMS")
+
   /** The properties supported by this class. */
   private def initProp(propName: String, query: Boolean, iter: Boolean): PropertyDescriptor = {
     PropertySupport.init(propName, classOf[Ghost], query, iter)


### PR DESCRIPTION
We need to pass GHOST user targets to the seqexec and while a previous PR was included letting the seqexec query them but it maybe better to include them in the sequence:
Note, the targets are corrected by proper motion like for the science targets
![image (5)](https://user-images.githubusercontent.com/3615303/82265259-91b30880-9934-11ea-8793-5970ba99c8a8.png)

