### PR TITLE
Ghost Exposure Time / Count Sequence Update

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/SeqConfigGhost.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/SeqConfigGhost.java
@@ -15,15 +15,19 @@ import java.util.Collections;
 import java.util.Map;
 
 final public class SeqConfigGhost extends SeqConfigObsBase implements PropertyProvider {
-    public static final SPComponentType SP_TYPE = SPComponentType.ITERATOR_GHOST;
+
+    public static final SPComponentType SP_TYPE =
+        SPComponentType.ITERATOR_GHOST;
+
     public static final ISPNodeInitializer<ISPSeqComponent, SeqConfigGhost> NI =
-            new ComponentNodeInitializer<>(SP_TYPE, SeqConfigGhost::new, SeqConfigGhostCB::new);
+        new ComponentNodeInitializer<>(SP_TYPE, SeqConfigGhost::new, SeqConfigGhostCB::new);
+
     public static final String SYSTEM_NAME = SeqConfigNames.INSTRUMENT_CONFIG_NAME;
 
     public static final Map<String, PropertyDescriptor> PROPERTY_MAP =
-            Collections.unmodifiableMap(
-                    PropertySupport.filter(PropertyFilter.ITERABLE_FILTER, Ghost$.MODULE$.PropertyMap())
-            );
+        Collections.unmodifiableMap(
+            PropertySupport.filter(PropertyFilter.ITERABLE_FILTER, Ghost$.MODULE$.PropertyMap())
+        );
 
     public SeqConfigGhost() {
         super(SP_TYPE, SYSTEM_NAME);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/SeqConfigGhostCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/SeqConfigGhostCB.java
@@ -28,7 +28,7 @@ final public class SeqConfigGhostCB extends HelperSeqCompCB {
 
         config.putParameter(SeqConfigNames.INSTRUMENT_CONFIG_NAME,
                 StringParameter.getInstance(InstConstants.INSTRUMENT_NAME_PROP,
-                        InstGmosSouth.INSTRUMENT_NAME_PROP));
+                        Ghost$.MODULE$.INSTRUMENT_NAME_PROP()));
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/SeqConfigGhostCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/SeqConfigGhostCB.java
@@ -2,16 +2,30 @@ package edu.gemini.spModel.gemini.ghost;
 
 import edu.gemini.pot.sp.ISPSeqComponent;
 import edu.gemini.spModel.config.HelperSeqCompCB;
+import edu.gemini.spModel.data.config.DefaultParameter;
 import edu.gemini.spModel.data.config.IConfig;
 import edu.gemini.spModel.data.config.StringParameter;
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
 import edu.gemini.spModel.obscomp.InstConstants;
 import edu.gemini.spModel.seqcomp.SeqConfigNames;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 final public class SeqConfigGhostCB extends HelperSeqCompCB {
     private static final long serialVersionUID = 1L;
+
+    private static final List<String> EXP_PROPS =
+      Collections.unmodifiableList(
+        Arrays.asList(
+            Ghost$.MODULE$.BLUE_EXPOSURE_COUNT_PROP().getName(),
+            Ghost$.MODULE$.BLUE_EXPOSURE_TIME_PROP().getName(),
+            Ghost$.MODULE$.RED_EXPOSURE_COUNT_PROP().getName(),
+            Ghost$.MODULE$.RED_EXPOSURE_TIME_PROP().getName()
+        )
+      );
 
     public SeqConfigGhostCB(final ISPSeqComponent seqComp) {
         super(seqComp);
@@ -29,6 +43,22 @@ final public class SeqConfigGhostCB extends HelperSeqCompCB {
         config.putParameter(SeqConfigNames.INSTRUMENT_CONFIG_NAME,
                 StringParameter.getInstance(InstConstants.INSTRUMENT_NAME_PROP,
                         Ghost$.MODULE$.INSTRUMENT_NAME_PROP()));
+
+        // A small hack to swap these to the "observe" system to be consistent
+        // everywhere.
+        for (String propName : EXP_PROPS) {
+            final Object o = config.getParameterValue(
+                    SeqConfigNames.INSTRUMENT_CONFIG_NAME,
+                    propName
+            );
+            config.removeParameter(SeqConfigNames.INSTRUMENT_CONFIG_NAME, propName);
+            if (o != null) {
+                config.putParameter(
+                    SeqConfigNames.OBSERVE_CONFIG_NAME,
+                    DefaultParameter.getInstance(propName, o)
+                );
+            }
+        }
     }
 
     @Override

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/seqcomp/GhostSeqRepeatExp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/seqcomp/GhostSeqRepeatExp.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
  * The difference here is that GHOST does not have a single exposure time, but due to having two detectors - a red
  * and a blue - exposure times and exposure counts for each. Additionally, GHOST does not have coadds.
  */
-public class GhostSeqRepeatExp extends SeqRepeat implements Serializable {
+public abstract class GhostSeqRepeatExp extends SeqRepeat implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private double redExposureTime = InstConstants.DEF_EXPOSURE_TIME;

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -97,18 +97,20 @@ final class Ghost extends SPInstObsComp(GhostMixin.SP_TYPE) with PropertyProvide
   }
 
   override def getSysConfig: ISysConfig = {
+    // Red/Blue exposure time parameters are added in the "observe" system.
+    //    sc.putParameter(DefaultParameter.getInstance(Ghost.RED_EXPOSURE_TIME_PROP.getName, getRedExposureTime))
+    //    sc.putParameter(DefaultParameter.getInstance(Ghost.RED_EXPOSURE_COUNT_PROP.getName, getRedExposureCount))
+    //    sc.putParameter(DefaultParameter.getInstance(Ghost.BLUE_EXPOSURE_TIME_PROP.getName, getBlueExposureTime))
+    //    sc.putParameter(DefaultParameter.getInstance(Ghost.BLUE_EXPOSURE_COUNT_PROP.getName, getBlueExposureCount))
+
     val sc = new DefaultSysConfig(SeqConfigNames.INSTRUMENT_CONFIG_NAME)
     sc.putParameter(StringParameter.getInstance(ISPDataObject.VERSION_PROP, getVersion))
     sc.putParameter(DefaultParameter.getInstance(Ghost.POS_ANGLE_PROP, getPosAngle))
     sc.putParameter(DefaultParameter.getInstance(Ghost.PORT_PROP, getIssPort))
     sc.putParameter(DefaultParameter.getInstance(Ghost.ENABLE_FIBER_AGITATOR_1_PROP.getName, isEnableFiberAgitator1))
     sc.putParameter(DefaultParameter.getInstance(Ghost.ENABLE_FIBER_AGITATOR_2_PROP.getName, isEnableFiberAgitator2))
-    sc.putParameter(DefaultParameter.getInstance(Ghost.RED_EXPOSURE_TIME_PROP.getName, getRedExposureTime))
-    sc.putParameter(DefaultParameter.getInstance(Ghost.RED_EXPOSURE_COUNT_PROP.getName, getRedExposureCount))
     sc.putParameter(DefaultParameter.getInstance(Ghost.RED_BINNING_PROP.getName, getRedBinning))
     sc.putParameter(DefaultParameter.getInstance(Ghost.RED_READ_NOISE_GAIN_PROP, getRedReadNoiseGain))
-    sc.putParameter(DefaultParameter.getInstance(Ghost.BLUE_EXPOSURE_TIME_PROP.getName, getBlueExposureTime))
-    sc.putParameter(DefaultParameter.getInstance(Ghost.BLUE_EXPOSURE_COUNT_PROP.getName, getBlueExposureCount))
     sc.putParameter(DefaultParameter.getInstance(Ghost.BLUE_BINNING_PROP.getName, getBlueBinning))
     sc.putParameter(DefaultParameter.getInstance(Ghost.BLUE_READ_NOISE_GAIN_PROP, getBlueReadNoiseGain))
     sc


### PR DESCRIPTION
Ghost exposure time properties were being placed in the "observe" system config in some places and the "instrument" system config in others.  The OCS in general has special handling of exposure time that is hard to replicate for Ghost. This PR makes the special Ghost-specific exposure time parameters always appear in the "observe" system config.