### PR TITLE
REL-3829 - Remove AU partner from PIT, Prep for 21A

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization in Global := "edu.gemini.ocs"
 // true indicates a test release, and false indicates a production release
 ocsVersion in ThisBuild := OcsVersion("2020A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2020B", false, 2, 1, 2)
+pitVersion in ThisBuild := OcsVersion("2021A", true, 1, 1, 1)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableClientSpec.scala
@@ -36,7 +36,7 @@ class VoTableClientSpec extends Specification with VoTableClient {
       ConeSearchBackend.queryParams(query) should beEqualTo(Array(("CATALOG", "ucac4"), ("RA", "10.000"), ("DEC", "20.000"), ("SR", "0.100")))
     }
     "make a query to a bad site" in {
-      Await.result(doQuery(query, new URL("http://unknown.site.6BD3435D-F573-4760-8233-8ADF7D6137AA"), ConeSearchBackend)(implicitly), 30.seconds) should throwA[UnknownHostException]
+      Await.result(doQuery(query, new URL("http://unknown.site.7732BFA1-9937-4D1E-8969-B02782608DAD"), ConeSearchBackend)(implicitly), 30.seconds) should throwA[UnknownHostException]
     }
     "be able to select the first successful of several futures" in {
       def f1 = Future { Thread.sleep(1000); throw new RuntimeException("oops") }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Partners.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Partners.scala
@@ -8,7 +8,6 @@ object Partners {
 
   val name = Map[Any, String](
     NgoPartner.AR          -> "Argentina",
-    NgoPartner.AU          -> "Australia",
     NgoPartner.BR          -> "Brazil",
     NgoPartner.CA          -> "Canada",
     NgoPartner.CL          -> "Chile",
@@ -20,9 +19,6 @@ object Partners {
     ExchangePartner.SUBARU -> Site.Subaru.name,
     LargeProgramPartner    -> "Large Program"
   )
-
-  // REL-2248 Contains a list of partners that are not allowed on joint proposals
-  val jointProposalNotAllowed = List[NgoPartner](NgoPartner.AU)
 
   // REL-2670 A partner affiliation for an FT proposal can be either Ngo or Subaru
   type FtPartner = Option[NgoPartner \/ ExchangePartner.SUBARU.type]

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Semester.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Semester.scala
@@ -5,8 +5,8 @@ import java.util.{Calendar, TimeZone}
 
 object Semester {
 
-  lazy val year = 2020
-  lazy val semesterOption = SemesterOption.B
+  lazy val year = 2021
+  lazy val semesterOption = SemesterOption.A
 
   lazy val current = Semester(year, semesterOption)
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/package.scala
@@ -51,7 +51,6 @@ package object immutable {
   type NgoPartner = M.NgoPartner
   object NgoPartner extends EnumObject[M.NgoPartner] {
     val AR = M.NgoPartner.AR
-    val AU = M.NgoPartner.AU
     val BR = M.NgoPartner.BR
     val CA = M.NgoPartner.CA
     val CL = M.NgoPartner.CL

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -157,13 +157,15 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
   */
 case object SemesterConverter2020BTo2021A extends SemesterConverter {
 
-    val removeAustraliaSubmissions: TransformFunction = {
-      case n @ <ngo>{ns @ _*}</ngo> if (ns \\ "partner").exists(_.text == "au") =>
-        StepResult("Submission(s) to Australia have been removed.", Nil).successNel
-    }
+  val AuSubmissionMessage = "Submission(s) to Australia have been removed."
 
-    override val transformers: List[TransformFunction] =
-      List(removeAustraliaSubmissions)
+  val removeAustraliaSubmissions: TransformFunction = {
+    case n @ <ngo>{ns @ _*}</ngo> if (ns \\ "partner").exists(_.text == "au") =>
+      StepResult(AuSubmissionMessage, Nil).successNel
+  }
+
+  override val transformers: List[TransformFunction] =
+    List(removeAustraliaSubmissions)
 
 }
 

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -134,15 +134,7 @@ object SemesterConverter {
 
   // definition of a ZeroConverter
   private case object ZeroSemesterConverter extends SemesterConverter {
-
-    val removeAustraliaSubmissions: TransformFunction = {
-      case n @ <ngo>{ns @ _*}</ngo> if (ns \\ "partner").exists(_.text == "au") =>
-        StepResult("Submission(s) to Australia have been removed.", Nil).successNel
-    }
-
-    override val transformers: List[TransformFunction] =
-      List(removeAustraliaSubmissions)
-
+    override val transformers: List[TransformFunction] = Nil
   }
 
   // Monoid conversions
@@ -164,8 +156,15 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
   * This converter supports migrating to 2021A.
   */
 case object SemesterConverter2020BTo2021A extends SemesterConverter {
-  // TODO
-  override val transformers: List[TransformFunction] = Nil
+
+    val removeAustraliaSubmissions: TransformFunction = {
+      case n @ <ngo>{ns @ _*}</ngo> if (ns \\ "partner").exists(_.text == "au") =>
+        StepResult("Submission(s) to Australia have been removed.", Nil).successNel
+    }
+
+    override val transformers: List[TransformFunction] =
+      List(removeAustraliaSubmissions)
+
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/transform/UpConverter.scala
@@ -34,22 +34,23 @@ object UpConverter {
   }
 
   // Sequence of conversions for proposals from a given semester. Cleaned up for 2017A since older conversion multiples to increment version no longer necessary.
-  val from2020B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, LastStepConverter(Semester(2020, SemesterOption.A)))
-  val from2020A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, LastStepConverter(Semester(2019, SemesterOption.B)))
-  val from2019A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, LastStepConverter(Semester(2019, SemesterOption.A)))
-  val from2018B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, LastStepConverter(Semester(2018, SemesterOption.B)))
-  val from2018A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, LastStepConverter(Semester(2018, SemesterOption.A)))
-  val from2017B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, LastStepConverter(Semester(2017, SemesterOption.B)))
-  val from2017A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2017, SemesterOption.A)))
-  val from2016B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2016, SemesterOption.B)))
-  val from2016A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2016, SemesterOption.A)))
-  val from2015B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015BTo2016A, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2015, SemesterOption.B)))
-  val from2015A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2017ATo2017B,   LastStepConverter(Semester(2015, SemesterOption.A)))
-  val from2014B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2014, SemesterOption.B)))
-  val from2014A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2014, SemesterOption.A)))
-  val from2013B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2013, SemesterOption.B)))
-  val from2013A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2013, SemesterOption.A)))
-  val from2012B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2012BTo2013A, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2012, SemesterOption.B)))
+  val from2021A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, LastStepConverter(Semester(2020, SemesterOption.A)))
+  val from2020B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, LastStepConverter(Semester(2020, SemesterOption.A)))
+  val from2020A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, LastStepConverter(Semester(2019, SemesterOption.B)))
+  val from2019A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, LastStepConverter(Semester(2019, SemesterOption.A)))
+  val from2018B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, LastStepConverter(Semester(2018, SemesterOption.B)))
+  val from2018A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, LastStepConverter(Semester(2018, SemesterOption.A)))
+  val from2017B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, LastStepConverter(Semester(2017, SemesterOption.B)))
+  val from2017A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2017, SemesterOption.A)))
+  val from2016B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2016, SemesterOption.B)))
+  val from2016A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2016, SemesterOption.A)))
+  val from2015B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015BTo2016A, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2015, SemesterOption.B)))
+  val from2015A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015BTo2016A, SemesterConverter2015ATo2015B, SemesterConverter2017ATo2017B,   LastStepConverter(Semester(2015, SemesterOption.A)))
+  val from2014B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2014, SemesterOption.B)))
+  val from2014A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2014ATo2014B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2014, SemesterOption.A)))
+  val from2013B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2013, SemesterOption.B)))
+  val from2013A:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2013, SemesterOption.A)))
+  val from2012B:List[SemesterConverter] = List(SemesterConverterToCurrent, SemesterConverter2020BTo2021A, SemesterConverter2020ATo2020B, SemesterConverter2019BTo2020A, SemesterConverter2019ATo2019B, SemesterConverter2018BTo2019A, SemesterConverter2018ATo2018B, SemesterConverter2017BTo2018A, SemesterConverter2016BTo2017A, SemesterConverter2016ATo2016B, SemesterConverter2015ATo2015B, SemesterConverter2014BTo2015A, SemesterConverter2014BTo2014BSV, SemesterConverter2012BTo2013A, SemesterConverter2013ATo2013B, SemesterConverter2013BTo2014A, SemesterConverter2014ATo2014B, SemesterConverter2017ATo2017B, LastStepConverter(Semester(2012, SemesterOption.B)))
 
   /**
    * Converts one version of a proposal node to the next
@@ -60,6 +61,8 @@ object UpConverter {
   def convert(node: XMLNode):Result = node match {
     case p @ <proposal>{ns @ _*}</proposal> if (p \ "@schemaVersion").text == Proposal.currentSchemaVersion =>
       StepResult(Nil, node).successNel[String]
+    case p @ <proposal>{ns @ _*}</proposal> if (p \ "@schemaVersion").text.matches("2020.2.1")   =>
+      from2021A.concatenate.convert(node)
     case p @ <proposal>{ns @ _*}</proposal> if (p \ "@schemaVersion").text.matches("2020.1.1")   =>
       from2020B.concatenate.convert(node)
     case p @ <proposal>{ns @ _*}</proposal> if (p \ "@schemaVersion").text.matches("2019.2.[12]")   =>
@@ -131,7 +134,15 @@ object SemesterConverter {
 
   // definition of a ZeroConverter
   private case object ZeroSemesterConverter extends SemesterConverter {
-    override val transformers: List[TransformFunction] = Nil
+
+    val removeAustraliaSubmissions: TransformFunction = {
+      case n @ <ngo>{ns @ _*}</ngo> if (ns \\ "partner").exists(_.text == "au") =>
+        StepResult("Submission(s) to Australia have been removed.", Nil).successNel
+    }
+
+    override val transformers: List[TransformFunction] =
+      List(removeAustraliaSubmissions)
+
   }
 
   // Monoid conversions
@@ -147,6 +158,14 @@ case class LastStepConverter(semester: Semester) extends SemesterConverter {
       StepResult(s"Please use the PIT from semester ${semester.display} to view the unmodified proposal", n).successNel
   }
   override val transformers = List(notifyToUseOlderPIT)
+}
+
+/**
+  * This converter supports migrating to 2021A.
+  */
+case object SemesterConverter2020BTo2021A extends SemesterConverter {
+  // TODO
+  override val transformers: List[TransformFunction] = Nil
 }
 
 /**

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Submission.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Submission.xsd
@@ -192,7 +192,6 @@
     <xsd:simpleType name="NgoPartner">
         <xsd:restriction base="xsd:token">
             <xsd:enumeration value="ar"/>
-            <xsd:enumeration value="au"/>
             <xsd:enumeration value="br"/>
             <xsd:enumeration value="ca"/>
             <xsd:enumeration value="cl"/>

--- a/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_au_submission.xml
+++ b/bundle/edu.gemini.model.p1/src/test/resources/edu/gemini/model/p1/immutable/transform/proposal_au_submission.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<proposal schemaVersion="2020.1.1">
+    <meta band3optionChosen="false" overrideAffiliate="false"/>
+    <semester year="2020" half="B"/>
+    <title></title>
+    <abstract></abstract>
+    <scheduling></scheduling>
+    <keywords/>
+    <investigators>
+        <pi id="investigator-0">
+            <firstName>Principal</firstName>
+            <lastName>Investigator</lastName>
+            <status>PhD</status>
+            <gender>None selected</gender>
+            <email></email>
+            <address>
+                <institution></institution>
+                <address></address>
+                <country></country>
+            </address>
+        </pi>
+    </investigators>
+    <targets/>
+    <conditions/>
+    <blueprints/>
+    <observations/>
+    <proposalClass>
+        <queue tooOption="None">
+            <ngo partnerLead="investigator-0">
+                <request>
+                    <time units="hr">10.0</time>
+                    <minTime units="hr">5.0</minTime>
+                </request>
+                <partner>us</partner>
+            </ngo>
+            <ngo partnerLead="investigator-0">
+                <request>
+                    <time units="hr">1.0</time>
+                    <minTime units="hr">0.5</minTime>
+                </request>
+                <partner>au</partner>
+            </ngo>
+        </queue>
+    </proposalClass>
+</proposal>

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/PartnersSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/PartnersSpec.scala
@@ -6,11 +6,11 @@ class PartnersSpec extends Specification {
 
   "The Partners object" should {
     "not include the UK, REL-622" in {
-      NgoPartner.values must have size 8
+      NgoPartner.values must have size 7
       NgoPartner.forName("UK") must throwA[Exception]
     }
     "must include Korea, REL-2019" in {
-      NgoPartner.values must have size 8
+      NgoPartner.values must have size 7
       NgoPartner.forName("KR") must beEqualTo(NgoPartner.KR)
     }
   }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ProposalSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ProposalSpec.scala
@@ -14,7 +14,7 @@ class ProposalSpec extends Specification with SemesterProperties with XmlMatcher
     }
     "use a schema version read from System properties" in {
       val proposal = Proposal.empty
-      proposal.schemaVersion must beEqualTo("2020.2.1")
+      proposal.schemaVersion must beEqualTo("2021.1.1")
     }
     "set the band3optionChosen by default to false" in {
       val proposal = Proposal.empty
@@ -57,7 +57,7 @@ class ProposalSpec extends Specification with SemesterProperties with XmlMatcher
       val xml = XML.loadString(ProposalIo.writeToString(proposal))
 
       // verify the exported value is set to the current semester
-      xml must \\("proposal", "schemaVersion" -> "2020.2.1")
+      xml must \\("proposal", "schemaVersion" -> "2021.1.1")
     }
     "be able to open latin1 encoded files" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_latin1_encoding.xml")))

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ProposalSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/ProposalSpec.scala
@@ -49,7 +49,7 @@ class ProposalSpec extends Specification with SemesterProperties with XmlMatcher
       val xml = XML.loadString(ProposalIo.writeToString(proposal))
 
       // verify the exported value is set to the current semester
-      xml must \\("semester", "year" -> "2020", "half" -> "B")
+      xml must \\("semester", "year" -> "2021", "half" -> "A")
     }
     "set the schemaVersion to current upon saving a new proposal" in {
       val proposal = Proposal.empty

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/SemesterProperties.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/SemesterProperties.scala
@@ -1,5 +1,5 @@
 package edu.gemini.model.p1.immutable
 
 trait SemesterProperties {
-  System.setProperty("edu.gemini.model.p1.schemaVersion", "2020.2.1")
+  System.setProperty("edu.gemini.model.p1.schemaVersion", "2021.1.1")
 }

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/SemesterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/SemesterSpec.scala
@@ -6,7 +6,7 @@ import java.io.InputStreamReader
 class SemesterSpec extends Specification {
   "The Semester class" should {
     "have a default" in {
-      Semester.current must beEqualTo(Semester(2020, SemesterOption.B))
+      Semester.current must beEqualTo(Semester(2021, SemesterOption.A))
     }
     "deserialize any semester" in {
       val proposal = ProposalIo.read(new InputStreamReader(getClass.getResourceAsStream("proposal_with_old_semester.xml")))

--- a/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
+++ b/bundle/edu.gemini.model.p1/src/test/scala/edu/gemini/model/p1/immutable/transform/UpConverterSpec.scala
@@ -42,7 +42,7 @@ class UpConverterSpec extends Specification with SemesterProperties with XmlMatc
               i.visitor must beFalse
           }
 
-          proposal.semester must beEqualTo(Semester(2020, SemesterOption.B))
+          proposal.semester must beEqualTo(Semester(2021, SemesterOption.A))
       }
 
       UpConverter.upConvert(xml) must beSuccessful.like {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
@@ -31,7 +31,6 @@ object SpProgramFactory {
 
   private val NGO_TIME_ACCT = Map(
     AR -> TimeAcctCategory.AR,
-    AU -> TimeAcctCategory.AU,
     BR -> TimeAcctCategory.BR,
     CA -> TimeAcctCategory.CA,
     CL -> TimeAcctCategory.CL,

--- a/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
+++ b/bundle/edu.gemini.pit.launcher/src/main/scala/edu/gemini/pit/launcher/PITLauncher.scala
@@ -19,7 +19,7 @@ object PITLauncher extends App {
   Locale.setDefault(Locale.ENGLISH)
 
   // Need to set this manually, as we are not inside OSGi
-  val version = s"${Semester.current.year}.2.1"
+  val version = s"${Semester.current.year}.1.1"
   System.setProperty("edu.gemini.model.p1.schemaVersion", version)
   System.setProperty(classOf[Workspace].getName + ".fonts.shrunk", "true")
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/Institutions.scala
@@ -63,7 +63,6 @@ object Institutions {
 
   def country2Ngo(country: String): FtPartner = country match {
     case "Argentina"            => Some(-\/(NgoPartner.AR))
-    case "Australia"            => Some(-\/(NgoPartner.AU))
     case "Brazil"               => Some(-\/(NgoPartner.BR))
     case "Canada"               => Some(-\/(NgoPartner.CA))
     case "Chile"                => Some(-\/(NgoPartner.CL))

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -769,6 +769,28 @@ case class TimeProblems(p: Proposal, s: ShellAdvisor) {
   }
   lazy val b3ReqOrZero: TimeAmount = b3Req.map(_.time).getOrElse(TimeAmount.empty)
 
+  // REL-3829 - this is no longer needed but I have been advised that such things are often
+  //            resurrected so I'm leaving it here for now.
+  //
+  //  lazy val jointNotAllowed: List[Problem] = {
+  //    def checkForNotAllowedJointProposals(subs: Option[List[NgoSubmission]]):List[Problem] = {
+  //      val r = for {
+  //          subs <- subs
+  //          if subs.size > 1
+  //        } yield for {
+  //            p <- subs.filter(s => Partners.jointProposalNotAllowed.contains(s.partner))
+  //          } yield new Problem(Severity.Error, s"${~Partners.name.get(p.partner)} cannot be part of a joint proposal, please update the time request.", SCHEDULING_SECTION,
+  //              s.showPartnersView())
+  //      r.sequence.flatten
+  //    }
+  //
+  //    p.proposalClass match {
+  //      case p: GeminiNormalProposalClass => checkForNotAllowedJointProposals(p.subs.left.toOption)
+  //      case e: ExchangeProposalClass     => checkForNotAllowedJointProposals(e.subs.some)
+  //      case x                            => Nil
+  //    }
+  //  }
+
   private def when[A](b: Boolean)(a: => A) = b option a
 
   private def requestedTimeCheck(r: TimeAmount, o: TimeAmount, b: Band) =

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -768,24 +768,6 @@ case class TimeProblems(p: Proposal, s: ShellAdvisor) {
     case _ => None
   }
   lazy val b3ReqOrZero: TimeAmount = b3Req.map(_.time).getOrElse(TimeAmount.empty)
-  lazy val jointNotAllowed: List[Problem] = {
-    def checkForNotAllowedJointProposals(subs: Option[List[NgoSubmission]]):List[Problem] = {
-      val r = for {
-          subs <- subs
-          if subs.size > 1
-        } yield for {
-            p <- subs.filter(s => Partners.jointProposalNotAllowed.contains(s.partner))
-          } yield new Problem(Severity.Error, s"${~Partners.name.get(p.partner)} cannot be part of a joint proposal, please update the time request.", SCHEDULING_SECTION,
-              s.showPartnersView())
-      r.sequence.flatten
-    }
-
-    p.proposalClass match {
-      case p: GeminiNormalProposalClass => checkForNotAllowedJointProposals(p.subs.left.toOption)
-      case e: ExchangeProposalClass     => checkForNotAllowedJointProposals(e.subs.some)
-      case x                            => Nil
-    }
-  }
 
   private def when[A](b: Boolean)(a: => A) = b option a
 
@@ -816,7 +798,7 @@ case class TimeProblems(p: Proposal, s: ShellAdvisor) {
   def noMinBand3Time: Option[Problem] = b3Problem(r => r.time.hours > 0.0 && r.minTime.hours <= 0.0, Severity.Todo, "Please enter the minimum required time for a usable Band 3 allocation.")
   def band3MinTime: Option[Problem] = b3Problem(r => r.time.hours < r.minTime.hours, Severity.Error, "The minimum Band 3 required time must not be longer than the total Band 3 requested time.")
 
-  def all: List[Problem] = List(requestedTimeDiffers, requestedB3TimeDiffers, noTimeRequest, noBand3Time, noMinBand3Time, band3MinTime).flatten ++ jointNotAllowed
+  def all: List[Problem] = List(requestedTimeDiffers, requestedB3TimeDiffers, noTimeRequest, noBand3Time, noMinBand3Time, band3MinTime).flatten
 }
 
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/Partners.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/partner/Partners.scala
@@ -8,7 +8,6 @@ import javax.swing.Icon
 object PartnersFlags {
   val flag = Map[Any, Icon](
     NgoPartner.AR          -> SharedIcons.FLAG_AR,
-    NgoPartner.AU          -> SharedIcons.FLAG_AU,
     NgoPartner.BR          -> SharedIcons.FLAG_BR,
     NgoPartner.CA          -> SharedIcons.FLAG_CA,
     NgoPartner.CL          -> SharedIcons.FLAG_CL,


### PR DESCRIPTION
This removes AU from the Phase 1 model (it's still in the Phase 2 model because old programs yadda yadda).

This required an up-converter so I went ahead and did the rest of the 21A prep. 