### PR TITLE
Add isCustom method to GMOS FPU enums

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosCommonType.java
@@ -85,6 +85,7 @@ public class GmosCommonType {
         boolean isIFU();
         boolean isNS();
         boolean isNSslit();
+        boolean isCustom();
 
         /**
          * True if the slit is wider than it is tall.  See REL-661 comment on

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
@@ -302,7 +302,9 @@ public class GmosNorthType {
         NS_3("N and S 1.00 arcsec", 1.00, "NS1.0arcsec",       Ictd.track("NS1.0arcsec")),
         NS_4("N and S 1.50 arcsec", 1.50, "NS1.5arcsec",       Ictd.track("NS1.5arcsec")),
         NS_5("N and S 2.00 arcsec", 2.00, "NS2.0arcsec",       Ictd.track("NS2.0arcsec")),
-        CUSTOM_MASK("Custom Mask", "custom",                   Ictd.installed()),
+        CUSTOM_MASK("Custom Mask", "custom",                   Ictd.installed()) {
+            @Override public boolean isCustom() { return true; }
+        },
         ;
 
         /** The default FPUnit value **/
@@ -317,7 +319,6 @@ public class GmosNorthType {
         private double _width;
 
         private final IctdTracking _ictd;
-
 
         // initialize with the name and slit width in arcsec
         FPUnitNorth(String displayValue, String logValue, IctdTracking ictd) {
@@ -376,6 +377,8 @@ public class GmosNorthType {
         public boolean isImaging() {
             return this == FPU_NONE;
         }
+
+        @Override public boolean isCustom() { return false; }
 
         /**
          * Test to see if FPU is in spectroscopic mode.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
@@ -301,7 +301,9 @@ public class GmosSouthType {
         NS_3("N and S 1.00 arcsec", 1.00, "NS1.0arcsec",       Ictd.track("NS1.0arcsec")),
         NS_4("N and S 1.50 arcsec", 1.50, "NS1.5arcsec",       Ictd.track("NS1.5arcsec")),
         NS_5("N and S 2.00 arcsec", 2.00, "NS2.0arcsec",       Ictd.track("NS2.0arcsec")),
-        CUSTOM_MASK("Custom Mask", "custom",                   Ictd.installed()),
+        CUSTOM_MASK("Custom Mask", "custom",                   Ictd.installed()){
+            @Override public boolean isCustom() { return true; }
+        },
         ;
 
         /** The default FPUnit value **/
@@ -367,6 +369,8 @@ public class GmosSouthType {
         public static FPUnitSouth getFPUnit(String name, FPUnitSouth nvalue) {
             return SpTypeUtil.oldValueOf(FPUnitSouth.class, name, nvalue);
         }
+
+        @Override public boolean isCustom() { return false; }
 
         /**
          * Test to see if GMOS is imaging.  This checks for the


### PR DESCRIPTION
Added a method to tell if an FPU is custom. It would make it easy to handle custom masks in the seqexec