### PR TITLE
REL-3854: Update to run standalone AGS service app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ app/**/idea
 *.iml
 *.ipr
 *.iws
+.idea
 
 # Eclipse specific
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ app/**/idea
 .classpath
 
 # Credentials
+app/ags/conf/gemKeystore
 app/spdb/conf/gemKeystore
 bundle/edu.gemini.services.server/src/main/resources/edu/gemini/services/server/util/24408334e14c4c6ca38b20b445384c25e9c4a8a9-privatekey.p12
 bundle/edu.gemini.services.server/src/main/scala/edu/gemini/services/server/util/24408334e14c4c6ca38b20b445384c25e9c4a8a9-privatekey.p12

--- a/app/ags/build.sbt
+++ b/app/ags/build.sbt
@@ -3,12 +3,16 @@ import OcsKeys._
 import edu.gemini.osgi.tools.Version
 import edu.gemini.osgi.tools.app.{ Configuration => AppConfig, _ }
 import edu.gemini.osgi.tools.app.Configuration.Distribution.{ Test => TestDistro, _ }
-import OcsCredentials.Spdb._
+import OcsCredentials.Ags._
 
 ocsAppSettings
 
 // Application for AGS servlets
 ocsAppManifest := {
+  // check for link to keystore
+  val f = baseDirectory.value / "conf" / "gemKeystore"
+  if (!f.isFile)
+    println(s"[${scala.Console.RED}error${scala.Console.RESET}] Keystore file ${f} was not found ... please link it!")
   val v = ocsVersion.value.toBundleVersion
   Application(
     id = "ags",
@@ -36,7 +40,7 @@ def common(version: Version) = AppConfig(
     "-Dnetworkaddress.cache.ttl=60",
     "-Duser.language=en",
     "-Duser.country=US",
-    "-Xmx2048M",
+    "-Xmx3072M",
     "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006",
     "-d64"
   ),
@@ -46,8 +50,10 @@ def common(version: Version) = AppConfig(
     "org.osgi.framework.bootdelegation"                -> "*",
     "org.osgi.framework.startlevel.beginning"          -> "99",
     "org.osgi.framework.storage.clean"                 -> "onFirstInit",
-    "org.osgi.service.http.port"                       -> "9123",
-    "org.osgi.service.http.secure.enabled"             -> "false"
+    "org.osgi.service.http.port"                       -> "8442",
+    "org.osgi.service.http.port.secure"                -> "8443",
+    "org.osgi.service.http.secure.enabled"             -> "true",
+    "org.ops4j.pax.web.ssl.keystore"                   -> "conf/gemKeystore"
   ),
   log = Some("log/ags.%u.%g.log"),
   bundles = List(
@@ -61,7 +67,11 @@ def common(version: Version) = AppConfig(
     BundleSpec("org.apache.commons.logging",             Version(1, 1, 0)),
     BundleSpec("org.apache.felix.http.jetty",            Version(2, 2, 0)),
     BundleSpec("io.argonaut",                            Version(6, 2, 0)),
-    BundleSpec("edu.gemini.pot",                         version)
+    BundleSpec("edu.gemini.pot",                         version),
+    BundleSpec("org.ops4j.pax.web.pax-web-extender-war", Version(1, 1, 13)),
+    BundleSpec("org.ops4j.pax.web.pax-web-jetty-bundle", Version(1, 1, 13)),
+    BundleSpec("org.ops4j.pax.web.pax-web-jsp",          Version(1, 1, 13)),
+    BundleSpec("org.ops4j.pax.web.pax-web-spi",          Version(1, 1, 13))
   )
 ) extending List(common_credentials(version), with_gogo_credentials(version))
 

--- a/app/ags/conf/logging.properties
+++ b/app/ags/conf/logging.properties
@@ -1,0 +1,14 @@
+handlers = java.util.logging.FileHandler java.util.logging.ConsoleHandler
+
+.level = INFO
+
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.ConsoleHandler.level = WARNING
+
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.FileHandler.limit = 10000000
+java.util.logging.FileHandler.count = 100
+
+#edu.gemini.dataman.level = FINE
+h2database.level = WARNING
+

--- a/project/OcsCredentials.scala.template
+++ b/project/OcsCredentials.scala.template
@@ -43,6 +43,26 @@ object OcsCredentials {
 
   }
 
+  object Ags {
+
+    def common_credentials(version: Version) = AppConfig(
+      id = "common_credentials",
+      props = Map(
+        "org.ops4j.pax.web.ssl.keypassword"           -> "",
+        "org.ops4j.pax.web.ssl.password"              -> ""
+      )
+    )
+
+    def with_gogo_credentials(version: Version) = AppConfig(
+      id = "with-gogo-credentials"
+    )
+
+    // WITH-REMOTE-GOGO
+    def with_remote_gogo_credentials(version: Version) = AppConfig(
+      id = "with-remote-gogo-credentials"
+    )
+  }
+
   object Spdb {
 
     // COMMON


### PR DESCRIPTION
This allows the `ags` app to work with both http and https at the port used by the PIT.  It required corresponding updates to the svn `ocs-credentials` project.  Once merged, the production `gn` and `gs` configuration distributions need to be tested on the build machine.