### PR TITLE
REL-3841 Fix http/https calls to the archive

### DIFF
--- a/bundle/edu.gemini.gsa.query/src/main/scala/edu/gemini/gsa/query/GsaQuery.scala
+++ b/bundle/edu.gemini.gsa.query/src/main/scala/edu/gemini/gsa/query/GsaQuery.scala
@@ -79,10 +79,16 @@ private [query] object GsaQuery {
       try { s.mkString } finally { s.close() }
     }
 
-    val con = url.openConnection().asInstanceOf[HttpsURLConnection]
+    val con = url.openConnection() match {
+      // Order is important as HttpsURLConnection extends HttpURLConnection
+      case con: HttpsURLConnection =>
+        con.setSSLSocketFactory(GemSslSocketFactory.get)
+        con
+      case con: HttpURLConnection =>
+        con
+    }
     con.setConnectTimeout(ConnectTimeout)
     con.setReadTimeout(ReadTimeout)
-    con.setSSLSocketFactory(GemSslSocketFactory.get)
     con.setRequestProperty("Accept-Charset", Cset)
 
     prep(con)


### PR DESCRIPTION
The fix for REL-3826 also fixed REL-3841, see:
https://github.com/gemini-hlsw/ocs/commit/47d7a38a5f820249657ac20866e6e4411a2d7762

However there are still some plain `http` queries done in the context of `dataman` that got broken in the process.

This PR fixes that setting the custom `keystore` only for `https` calls
