### PR TITLE
REL-3849: G480 => B480

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
@@ -78,7 +78,7 @@ public class GmosNorthType {
         },
         B600_G5307(  "B600_G5307",  "B600",  600, Ictd.track("B600")),
         R600_G5304(  "R600_G5304",  "R600",  600, Ictd.track("R600")),
-        G480_G5309(  "G480_G5309",  "G480",  480, Ictd.track("G480")),
+        G480_G5309(  "B480_G5309",  "B480",  480, Ictd.track("B480")),
         R400_G5305(  "R400_G5305",  "R400",  400, Ictd.track("R400")),
         R150_G5306(  "R150_G5306",  "R150",  150, Ictd.unavailable()) {
             @Override public boolean isObsolete() { return true; }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
@@ -76,7 +76,7 @@ public class GmosSouthType {
         R831_G5322(  "R831_G5322",  "R831",  831, Ictd.track( "R831")),
         B600_G5323(  "B600_G5323",  "B600",  600, Ictd.track( "B600")),
         R600_G5324(  "R600_G5324",  "R600",  600, Ictd.track( "R600")),
-        G480_G5327(  "G480_G5327",  "G480",  480, Ictd.track( "G480")),
+        G480_G5327(  "B480_G5327",  "B480",  480, Ictd.track( "B480")),
         R400_G5325(  "R400_G5325",  "R400",  400, Ictd.track( "R400")),
         R150_G5326(  "R150_G5326",  "R150",  150, Ictd.track( "R150")),
         ;


### PR DESCRIPTION
A "very blue blaze" has changed the name of "G480" to "B480".  From Bryan:

> We've decide to rename the grating B480 because of the very blue blaze. Therefore, I've changes 'G480' to 'B480' in the description.