### PR TITLE
REL-3869: show visitor instrument name

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/instrument/InstViewAdvisor.java
@@ -143,7 +143,7 @@ public class InstViewAdvisor implements IViewAdvisor, PropertyChangeListener {
                 while (e.hasMoreElements()) {
                     final OutlineNode n = (OutlineNode) e.nextElement();
                     final Object      o = n.getUserObject();
-                    if (o != null && o instanceof Enum) {
+                    if (o instanceof Enum) {
                         ImOption.apply(m.get((Enum) o)).foreach(a ->
                             n.setSelectedCorrectly(a == Availability.Installed)
                         );

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Obs.java
@@ -209,6 +209,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
     private final Conds conditions;
     private final PlannedStepSummary steps;
     private final SPComponentType[] instrument;
+    private final Option<String> visitorName;
     private final Set<Enum<?>> options = new TreeSet<>(new HeterogeneousEnumComparator());
     private final Group group;
     private final boolean inProgress;
@@ -427,6 +428,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
             ObsClass obsClass,
             TargetEnvironment targetEnvironment,
             SPComponentType[] instrument,
+            Option<String> visitorName,
             Set<Enum<?>> options,
             String customMask,
             Double centralWavelength,
@@ -490,6 +492,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
 
         this.wavefrontSensors = wfs;
         this.instrument = instrument;
+        this.visitorName = visitorName;
         this.options.addAll(options);
 
         int firstStep = 0;
@@ -539,6 +542,7 @@ public final class Obs implements Serializable, Comparable<Obs> {
         this.elapsedTime = 0;
         this.remainingTime = 0;
         this.instrument = null;
+        this.visitorName = None.instance();
         this.wavefrontSensors = null;
         this.firstStep = 0;
         this.priority = null;
@@ -693,6 +697,8 @@ public final class Obs implements Serializable, Comparable<Obs> {
         for (SPComponentType t: instrument) {
             if (InstAltair.SP_TYPE.equals(t)) {
                 buf.append("+AO");
+            } else if (SPComponentType.INSTRUMENT_VISITOR.equals(t) && visitorName.exists(s -> s.length() > 0)) {
+                buf.append(visitorName.getValue());
             } else {
                 if (buf.length() != 0) buf.append(" + ");
                 buf.append(t.readableStr);
@@ -705,6 +711,10 @@ public final class Obs implements Serializable, Comparable<Obs> {
         String s = getOptionsString();
         s = s.length() == 0 ? getInstrumentString() : (getInstrumentString() + " / " + s);
         return s;
+    }
+
+    public Option<String> getVisitorName() {
+        return visitorName;
     }
 
     public int getFirstUnexecutedStep() {

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/ObsQueryFunctor.java
@@ -7,6 +7,7 @@ import edu.gemini.pot.spdb.IDBDatabaseService;
 import edu.gemini.shared.util.TimeValue;
 import edu.gemini.shared.util.immutable.ApplyOp;
 import edu.gemini.shared.util.immutable.DefaultImList;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.spModel.core.Semester;
@@ -30,6 +31,7 @@ import edu.gemini.spModel.gemini.obscomp.SPProgram;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.gemini.texes.InstTexes;
 import edu.gemini.spModel.gemini.trecs.InstTReCS;
+import edu.gemini.spModel.gemini.visitor.VisitorInstrument;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.obs.ObsClassService;
 import edu.gemini.spModel.obs.ObsTimesService;
@@ -368,7 +370,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor implements Iterable<
     }
 
     @SuppressWarnings("unchecked")
-    private SPComponentType[] instrument(ISPObservation obsShell) throws RemoteException {
+    private static SPComponentType[] instrument(ISPObservation obsShell) {
 
         // For each obs, we can have an inst and an AO
         SPComponentType inst = null;
@@ -404,8 +406,15 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor implements Iterable<
 
     }
 
+    private static Option<String> getVisitorName(ISPObsComponent shell) {
+        final Object d = shell.getDataObject();
+        return (d instanceof VisitorInstrument)                                         ?
+            ImOption.apply(((VisitorInstrument) d).getName()).filter(n -> !n.isEmpty()) :
+            ImOption.empty();
+    }
+
     @SuppressWarnings("unchecked")
-    private Double centralWavelength(ISPObservation obsShell) throws RemoteException {
+    private Double centralWavelength(ISPObservation obsShell) {
         for (ISPObsComponent comp: obsShell.getObsComponents()) {
             SPComponentType type = comp.getType();
 
@@ -879,6 +888,7 @@ public class ObsQueryFunctor extends DBAbstractQueryFunctor implements Iterable<
             obsClass,
             targetEnv,
             instrument(obsShell),
+            getVisitorName(inst),
             options(obsShell),
             customMask(obsShell),
             centralWavelength(obsShell),

--- a/bundle/edu.gemini.qpt.shared/src/test/scala/edu/gemini/qpt/shared/util/ObsBuilder.scala
+++ b/bundle/edu.gemini.qpt.shared/src/test/scala/edu/gemini/qpt/shared/util/ObsBuilder.scala
@@ -4,6 +4,7 @@ import edu.gemini.ags.api.AgsAnalysis
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.qpt.shared.sp.{Group, Obs, Prog}
 import edu.gemini.shared.util.immutable.{None => JNone, DefaultImList}
+import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.core.{Declination, RightAscension, Coordinates, SPProgramID}
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
 import edu.gemini.spModel.obs.plannedtime.{ PlannedStepSummary, SetupTime }
@@ -49,6 +50,7 @@ case class ObsBuilder(
   customMask: String = null,
   options: Set[Enum[_]] = Set(),
   instrument: Array[SPComponentType] = Array(),
+  visitorName: Option[String] = None,
   analysis: List[AgsAnalysis] = Nil
 )
 {
@@ -69,6 +71,7 @@ case class ObsBuilder(
       obsClass,
       targetEnvironment,
       instrument,
+      visitorName.asGeminiOpt,
       ObsBuilder.javaOptionsSet(options),
       customMask,
       centralWavelength,
@@ -101,6 +104,7 @@ case class ObsBuilder(
   def setTargetEnvironment(t: TargetEnvironment) = copy(targetEnvironment = t)
   def setInstrument(i: Array[SPComponentType]) = copy(instrument = i)
   def setInstrument(i: SPComponentType) = copy(instrument = Array(i))
+  def setVisitorName(n: Option[String]) = copy(visitorName = n)
   def setOptions(o: Set[Enum[_]]) = copy(options = o)
   def setCustomMask(m: String) = copy(customMask = m)
   def setCentralWavelength(w: Double) = copy(centralWavelength = w)

--- a/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/ObservationProvider.scala
+++ b/bundle/edu.gemini.qv.plugin/src/main/scala/edu/gemini/qv/plugin/data/ObservationProvider.scala
@@ -104,6 +104,7 @@ object FoldedTargetsProvider {
         headObs.getObsClass,
         headObs.getTargetEnvironment,
         headObs.getInstruments.map(o => o.getSpType),
+        headObs.getVisitorName,
         headObs.getOptions,
         headObs.getCustomMask,
         headObs.getCentralWavelength,


### PR DESCRIPTION
Shows the visitor instrument name instead of "Visitor Instrument" in the QPT and published plan.  Sadly all visitor instruments are otherwise treated the same so ICTD availability and filtering in the "Instruments" tab may be confusing.