### PR TITLE
update telnet ip

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -548,7 +548,7 @@ def gsodb(version: Version) = AppConfig(
     "edu.gemini.oodb.mail.smtpHost"        -> "smtp.cl.gemini.edu",
     "edu.gemini.spdb.dir"                  -> "/mount/petrohue/odbhome/ugemini/spdb/spdb.active",
     "edu.gemini.util.trpc.name"            -> "Gemini South ODB",
-    "osgi.shell.telnet.ip"                 -> "172.17.5.77"
+    "osgi.shell.telnet.ip"                 -> "172.16.76.71"
   ),
   bundles = List(
     BundleSpec(50, "edu.gemini.smartgcal.servlet", version)


### PR DESCRIPTION
Updates the `osgi.shell.telnet.ip` property for the base-facility ODB.  This had been done in the production configuration for 2020B release, but not updated in GitHub.

> **Be aware** The remote shell does not listen on all interfaces by default; it only listens on the localhost. That is, by default the remote shell is only accessible from the host on which the remote shell is running. To access the system from another host, you have to configure the IP address of the interface to which the remote shell should be attached.