### PR TITLE
Capture HorizonsDesignation in PIT

### DIFF
--- a/bundle/edu.gemini.model.p1.targetio/src/main/scala/edu/gemini/model/p1/targetio/impl/HorizonsEphemerisParser.scala
+++ b/bundle/edu.gemini.model.p1.targetio/src/main/scala/edu/gemini/model/p1/targetio/impl/HorizonsEphemerisParser.scala
@@ -108,7 +108,7 @@ object HorizonsEphemerisParser extends JavaTokenParsers {
   def header: Parser[String] = headerSection~>name<~headerSection
 
   def target: Parser[NonSiderealTarget] = header~ephemerisSection ^^ {
-    case n~e => NonSiderealTarget(UUID.randomUUID(), n, e, J_2000)
+    case n~e => NonSiderealTarget(UUID.randomUUID(), n, e, J_2000, None)
   }
 
   def read(file: File): Either[TargetIoError, NonSiderealTarget] =

--- a/bundle/edu.gemini.model.p1.targetio/src/main/scala/edu/gemini/model/p1/targetio/impl/NonSiderealReader.scala
+++ b/bundle/edu.gemini.model.p1.targetio/src/main/scala/edu/gemini/model/p1/targetio/impl/NonSiderealReader.scala
@@ -36,7 +36,7 @@ object NonSiderealReader extends TargetReader[NonSiderealTarget] {
 
     val groupedElements = ephrows.groupBy(_.ord)
     val targets = groupedElements mapValues { lst =>
-      NonSiderealTarget(UUID.randomUUID(), lst.head.name, lst.map(_.element).sortBy(_.validAt), J_2000)
+      NonSiderealTarget(UUID.randomUUID(), lst.head.name, lst.map(_.element).sortBy(_.validAt), J_2000, None)
     }
 
     case class Order(targetList: List[NonSiderealTarget], viewed: Set[Int]) {

--- a/bundle/edu.gemini.model.p1.targetio/src/test/scala/edu/gemini/model/p1/targetio/impl/TargetUtil.scala
+++ b/bundle/edu.gemini.model.p1.targetio/src/test/scala/edu/gemini/model/p1/targetio/impl/TargetUtil.scala
@@ -26,7 +26,7 @@ object TargetUtil {
     EphemerisElement(Coordinates(RightAscension.fromAngle(Angle.parseHMS(ra).getOrElse(Angle.zero)), Declination.fromAngle(Angle.parseDMS(dec).getOrElse(Angle.zero)).getOrElse(Declination.zero)), Some(mag), utc(year, month, day, hour, min))
 
   def mkTarget(name: String, elements: List[EphemerisElement]): NonSiderealTarget =
-    NonSiderealTarget(UUID.randomUUID(), name, elements, J_2000)
+    NonSiderealTarget(UUID.randomUUID(), name, elements, J_2000, None)
 
   def mkMag(value: Double, band: MagnitudeBand, system: MagnitudeSystem = MagnitudeSystem.default): Magnitude =
     new Magnitude(value, band, system)

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Target.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Target.scala
@@ -129,13 +129,14 @@ case class SiderealTarget (
 
 object NonSiderealTarget extends UuidCache[M.NonSiderealTarget] {
 
-  def empty = apply(UUID.randomUUID(), "Untitled", List.empty, CoordinatesEpoch.J_2000)
+  def empty = apply(UUID.randomUUID(), "Untitled", List.empty, CoordinatesEpoch.J_2000, None)
 
   def apply(m: M.NonSiderealTarget): NonSiderealTarget = new NonSiderealTarget(
     uuid(m),
     m.getName,
     m.getEphemeris.asScala.map(EphemerisElement(_)).toList,
-    m.getEpoch)
+    m.getEpoch,
+    Option(m.getHorizonsDesignation))
 
 }
 
@@ -143,7 +144,9 @@ case class NonSiderealTarget(
   uuid:UUID,
   name: String,
   ephemeris: List[EphemerisElement],
-  epoch: CoordinatesEpoch) extends Target {
+  epoch: CoordinatesEpoch,
+  horizonsDesignation: Option[String]
+) extends Target {
 
   def isEmpty = ephemeris.isEmpty
 
@@ -153,6 +156,7 @@ case class NonSiderealTarget(
     m.setName(name)
     m.getEphemeris.addAll(ephemeris.map(_.mutable).asJava)
     m.setEpoch(epoch)
+    m.setHorizonsDesignation(horizonsDesignation.orNull)
     m
   }
 

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Target.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Target.xsd
@@ -60,6 +60,7 @@
                     <xsd:element name="ephemeris" type="EphemerisElement" minOccurs="2" maxOccurs="unbounded"/>
                 </xsd:sequence>
                 <xsd:attribute name="epoch" type="CoordinatesEpoch" default="J2000"/>
+                <xsd:attribute name="horizonsDesignation" type="xsd:token"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/HorizonsLookup.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/HorizonsLookup.scala
@@ -95,7 +95,7 @@ final class HorizonsLookup(editor: TargetEditor, site: Site, when: Long) {
   private def handleSingleResult(r: Row[_ <: HorizonsDesignation]): HS2[Unit] =
     for {
       e <- fetchEphemeris(r.a)
-      t <- p1target(r.name, e)
+      t <- p1target(r.name, r.a.show, e)
       _ <- onEDT(editor.close(TargetEditor.Replace(t)))
     } yield ()
 
@@ -110,7 +110,7 @@ final class HorizonsLookup(editor: TargetEditor, site: Site, when: Long) {
         map(e => Ephemeris(site, e.data))
 
   /** Create a new phase 1 target from a name and phase-2 (!) ephemeris. */
-  def p1target(name: String, ephemeris: Ephemeris): HS2[NonSiderealTarget] =
+  def p1target(name: String, horizonsDesignation: String, ephemeris: Ephemeris): HS2[NonSiderealTarget] =
     HS2.delay {
       NonSiderealTarget(
         UUID.randomUUID, // side-effect, so need delay above
@@ -118,7 +118,8 @@ final class HorizonsLookup(editor: TargetEditor, site: Site, when: Long) {
         ephemeris.data.toAscList.map {
           case (t, cd) => EphemerisElement(cd, None, t) // no magnitude info
         },
-        CoordinatesEpoch.J_2000
+        CoordinatesEpoch.J_2000,
+        Some(horizonsDesignation)
       )
     }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -158,13 +158,13 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     } yield new Problem(Severity.Error, msg, "Targets", s.inTargetsView(_.edit(t)))
 
     private lazy val emptyEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _) <- p.targets
       if e.isEmpty
       msg = s"""Ephemeris for target "$n" is undefined."""
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
     private lazy val singlePointEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _) <- p.targets
       if e.size == 1
       msg = s"""Ephemeris for target "$n" contains only one point; please specify at least two."""
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
@@ -172,7 +172,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     lazy val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd").withZone(ZoneId.of("UTC"))
 
     private lazy val initialEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _) <- p.targets
       if e.nonEmpty
       ds = e.map(_.validAt) if ds.size > 1
       dsMin = ds.min
@@ -187,7 +187,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
     private lazy val finalEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _) <- p.targets
       if e.nonEmpty
       ds = e.map(_.validAt) if ds.size > 1
       dsMax = ds.max

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/P1TargetConverter.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/P1TargetConverter.scala
@@ -4,6 +4,7 @@ import edu.gemini.model.p1.immutable._
 import edu.gemini.spModel.core
 
 import scalaz._, Scalaz._
+import edu.gemini.spModel.core.HorizonsDesignation
 
 /**
  * Converts a P1 Target to an SPTarget.
@@ -34,6 +35,7 @@ object P1TargetConverter {
       _ <- core.NonSiderealTarget.name       := nsid.name
       _ <- core.NonSiderealTarget.ephemeris  := toCoreEphemeris(s, nsid.ephemeris)
       _ <- core.NonSiderealTarget.magnitudes := nsid.magnitude(time).map(apparentMag).toList
+      _ <- core.NonSiderealTarget.horizonsDesignation := nsid.horizonsDesignation.flatMap(HorizonsDesignation.read)
     } yield ()
 
   private def initSidereal(sid: SiderealTarget): State[core.SiderealTarget, Unit] =


### PR DESCRIPTION
This change:

- Adds `horizonsDesignation` as an optional attribute for `NonSiderealTarget` in the Phase 1 schema. 
- Captures this value after a successful Horizons lookup in the PIT target editor.
- Preserves the value through skeleton generation.

Note that this change does _not_ attempt to parse the designation from imported ephemeris files. I think this is probably impossible in general because you need to know what kind of search you were doing in order to interpret the header.