### PR TITLE
REL-3899: update GMOS TCC config

### DIFF
--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosNorthSupportTest.java
@@ -113,16 +113,40 @@ public final class GmosNorthSupportTest extends InstrumentSupportTestBase<InstGm
         verifyInstrumentConfig(getNorthResults(), "AO2GMOS");
     }
 
+    @Test public void testSideLookingP1() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addGuideStar(PwfsGuideProbe.pwfs1);
+        verifyInstrumentConfig(getNorthResults(), "GMOS5_P1");
+    }
+
     @Test public void testSideLookingP2() throws Exception {
         setPort(IssPort.SIDE_LOOKING);
         addGuideStar(PwfsGuideProbe.pwfs2);
         verifyInstrumentConfig(getNorthResults(), "GMOS5_P2");
     }
 
+    @Test public void testSideLookingOI() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addGuideStar(GmosOiwfsGuideProbe.instance);
+        verifyInstrumentConfig(getNorthResults(), "GMOS5_OI");
+    }
+
+    @Test public void testUpLookingP1() throws Exception {
+        setPort(IssPort.UP_LOOKING);
+        addGuideStar(PwfsGuideProbe.pwfs1);
+        verifyInstrumentConfig(getNorthResults(), "GMOS_P1");
+    }
+
     @Test public void testUpLookingP2() throws Exception {
         setPort(IssPort.UP_LOOKING);
         addGuideStar(PwfsGuideProbe.pwfs2);
         verifyInstrumentConfig(getNorthResults(), "GMOS_P2");
+    }
+
+    @Test public void testUpLookingOI() throws Exception {
+        setPort(IssPort.UP_LOOKING);
+        addGuideStar(GmosOiwfsGuideProbe.instance);
+        verifyInstrumentConfig(getNorthResults(), "GMOS_OI");
     }
 
 }

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosSouthSupportTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/GmosSouthSupportTest.java
@@ -5,6 +5,7 @@
 package edu.gemini.wdba.tcc;
 
 import edu.gemini.spModel.gemini.altair.AltairParams;
+import edu.gemini.spModel.gemini.gmos.GmosOiwfsGuideProbe;
 import edu.gemini.spModel.gemini.gmos.GmosSouthType;
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
 import edu.gemini.spModel.target.obsComp.PwfsGuideProbe;
@@ -32,6 +33,15 @@ public final class GmosSouthSupportTest extends InstrumentSupportTestBase<InstGm
         verifyPointOrig(getSouthResults(), "gmos_ifu");
     }
 
+    @Test public void testIfuP1PointOrig() throws Exception {
+        InstGmosSouth gmos = getInstrument();
+        gmos.setFPUnit(GmosSouthType.FPUnitSouth.IFU_1);
+        setInstrument(gmos);
+        addGuideStar(PwfsGuideProbe.pwfs1);
+
+        verifyPointOrig(getSouthResults(), "gmos_ifu_p1");
+    }
+
     @Test public void testLgsPointOrig() throws Exception {
         // probably not even legal, but there it is ...
         addGems(); verifyPointOrig(getSouthResults(), "lgs2gmos");
@@ -48,10 +58,29 @@ public final class GmosSouthSupportTest extends InstrumentSupportTestBase<InstGm
         verifyInstrumentConfig(getSouthResults(), "GMOS3");
     }
 
+    @Test public void testSideLookingP1() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addGuideStar(PwfsGuideProbe.pwfs1);
+        verifyInstrumentConfig(getSouthResults(), "GMOS3_P1");
+    }
+
     @Test public void testSideLookingP2() throws Exception {
         setPort(IssPort.SIDE_LOOKING);
         addGuideStar(PwfsGuideProbe.pwfs2);
         verifyInstrumentConfig(getSouthResults(), "GMOS3_P2");
+    }
+
+    @Test public void testSideLookingO1() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addGuideStar(GmosOiwfsGuideProbe.instance);
+        verifyInstrumentConfig(getSouthResults(), "GMOS3_OI");
+    }
+
+    @Test public void testSideLookingP1O1() throws Exception {
+        setPort(IssPort.SIDE_LOOKING);
+        addGuideStar(PwfsGuideProbe.pwfs1);
+        addGuideStar(GmosOiwfsGuideProbe.instance);
+        verifyInstrumentConfig(getSouthResults(), "GMOS3_P1_OI");
     }
 
     @Test public void testUpLooking() throws Exception {


### PR DESCRIPTION
Updates the GMOS TCC configuration names to be uniform (also appending OI and P1 as appropriate). 