### PR TITLE
[REL-3792] (3) add query string to target editor

### DIFF
--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-NOAO.xml
@@ -1514,7 +1514,14 @@
                                 <fo:block margin-left="1cm">
                                     Non-sidereal target (coordinates valid at:&#160;
                                     <xsl:variable name="date" select="$target/ephemeris/@validAt"/>
-                                    <xsl:value-of select="substring($date, 0, 11)"/>)
+                                    <xsl:value-of select="substring($date, 0, 11)"/>
+                                    <xsl:variable name="horizonsQuery" select="$target/@horizonsQuery"/>
+                                    <xsl:if test="$horizonsQuery != ''">
+                                        <fo:inline>
+                                            <xsl:text>; query: </xsl:text>
+                                            <xsl:value-of select="$horizonsQuery"/>
+                                        </fo:inline>
+                                    </xsl:if>)
                                 </fo:block>
                             </xsl:if>
 

--- a/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
+++ b/bundle/edu.gemini.model.p1.pdf/src/main/resources/edu/gemini/model/p1/pdf/templates/xsl-default.xml
@@ -1570,7 +1570,14 @@
                                     <fo:inline font-weight="bold">Non-sidereal target</fo:inline>
                                     &#160;(coordinates valid at:&#160;
                                     <xsl:variable name="date" select="$target/ephemeris/@validAt"/>
-                                    <xsl:value-of select="substring($date, 0, 11)"/>)
+                                    <xsl:value-of select="substring($date, 0, 11)"/>
+                                    <xsl:variable name="horizonsQuery" select="$target/@horizonsQuery"/>
+                                    <xsl:if test="$horizonsQuery != ''">
+                                        <fo:inline>
+                                            <xsl:text>; query: </xsl:text>
+                                            <xsl:value-of select="$horizonsQuery"/>
+                                        </fo:inline>
+                                    </xsl:if>)
                                 </fo:block>
                             </xsl:if>
 

--- a/bundle/edu.gemini.model.p1.targetio/src/main/scala/edu/gemini/model/p1/targetio/impl/HorizonsEphemerisParser.scala
+++ b/bundle/edu.gemini.model.p1.targetio/src/main/scala/edu/gemini/model/p1/targetio/impl/HorizonsEphemerisParser.scala
@@ -108,7 +108,7 @@ object HorizonsEphemerisParser extends JavaTokenParsers {
   def header: Parser[String] = headerSection~>name<~headerSection
 
   def target: Parser[NonSiderealTarget] = header~ephemerisSection ^^ {
-    case n~e => NonSiderealTarget(UUID.randomUUID(), n, e, J_2000, None)
+    case n~e => NonSiderealTarget(UUID.randomUUID(), n, e, J_2000, None, None)
   }
 
   def read(file: File): Either[TargetIoError, NonSiderealTarget] =

--- a/bundle/edu.gemini.model.p1.targetio/src/main/scala/edu/gemini/model/p1/targetio/impl/NonSiderealReader.scala
+++ b/bundle/edu.gemini.model.p1.targetio/src/main/scala/edu/gemini/model/p1/targetio/impl/NonSiderealReader.scala
@@ -36,7 +36,7 @@ object NonSiderealReader extends TargetReader[NonSiderealTarget] {
 
     val groupedElements = ephrows.groupBy(_.ord)
     val targets = groupedElements mapValues { lst =>
-      NonSiderealTarget(UUID.randomUUID(), lst.head.name, lst.map(_.element).sortBy(_.validAt), J_2000, None)
+      NonSiderealTarget(UUID.randomUUID(), lst.head.name, lst.map(_.element).sortBy(_.validAt), J_2000, None, None)
     }
 
     case class Order(targetList: List[NonSiderealTarget], viewed: Set[Int]) {

--- a/bundle/edu.gemini.model.p1.targetio/src/test/scala/edu/gemini/model/p1/targetio/impl/TargetUtil.scala
+++ b/bundle/edu.gemini.model.p1.targetio/src/test/scala/edu/gemini/model/p1/targetio/impl/TargetUtil.scala
@@ -26,7 +26,7 @@ object TargetUtil {
     EphemerisElement(Coordinates(RightAscension.fromAngle(Angle.parseHMS(ra).getOrElse(Angle.zero)), Declination.fromAngle(Angle.parseDMS(dec).getOrElse(Angle.zero)).getOrElse(Declination.zero)), Some(mag), utc(year, month, day, hour, min))
 
   def mkTarget(name: String, elements: List[EphemerisElement]): NonSiderealTarget =
-    NonSiderealTarget(UUID.randomUUID(), name, elements, J_2000, None)
+    NonSiderealTarget(UUID.randomUUID(), name, elements, J_2000, None, None)
 
   def mkMag(value: Double, band: MagnitudeBand, system: MagnitudeSystem = MagnitudeSystem.default): Magnitude =
     new Magnitude(value, band, system)

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Target.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Target.scala
@@ -129,14 +129,15 @@ case class SiderealTarget (
 
 object NonSiderealTarget extends UuidCache[M.NonSiderealTarget] {
 
-  def empty = apply(UUID.randomUUID(), "Untitled", List.empty, CoordinatesEpoch.J_2000, None)
+  def empty = apply(UUID.randomUUID(), "Untitled", List.empty, CoordinatesEpoch.J_2000, None, None)
 
   def apply(m: M.NonSiderealTarget): NonSiderealTarget = new NonSiderealTarget(
     uuid(m),
     m.getName,
     m.getEphemeris.asScala.map(EphemerisElement(_)).toList,
     m.getEpoch,
-    Option(m.getHorizonsDesignation))
+    Option(m.getHorizonsDesignation),
+    Option(m.getHorizonsQuery()))
 
 }
 
@@ -145,7 +146,8 @@ case class NonSiderealTarget(
   name: String,
   ephemeris: List[EphemerisElement],
   epoch: CoordinatesEpoch,
-  horizonsDesignation: Option[String]
+  horizonsDesignation: Option[String],
+  horizonsQuery: Option[String]
 ) extends Target {
 
   def isEmpty = ephemeris.isEmpty
@@ -157,6 +159,7 @@ case class NonSiderealTarget(
     m.getEphemeris.addAll(ephemeris.map(_.mutable).asJava)
     m.setEpoch(epoch)
     m.setHorizonsDesignation(horizonsDesignation.orNull)
+    m.setHorizonsQuery(horizonsQuery.orNull)
     m
   }
 

--- a/bundle/edu.gemini.model.p1/src/main/xsd/Target.xsd
+++ b/bundle/edu.gemini.model.p1/src/main/xsd/Target.xsd
@@ -61,6 +61,7 @@
                 </xsd:sequence>
                 <xsd:attribute name="epoch" type="CoordinatesEpoch" default="J2000"/>
                 <xsd:attribute name="horizonsDesignation" type="xsd:token"/>
+                <xsd:attribute name="horizonsQuery" type="xsd:token"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/HorizonsLookup.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/HorizonsLookup.scala
@@ -95,7 +95,7 @@ final class HorizonsLookup(editor: TargetEditor, site: Site, when: Long) {
   private def handleSingleResult(query: String, r: Row[_ <: HorizonsDesignation]): HS2[Unit] =
     for {
       e <- fetchEphemeris(r.a)
-      t <- p1target(query, r.a.show, e)
+      t <- p1target(query, r.a.show, r.a.queryString, e)
       _ <- onEDT(editor.close(TargetEditor.Replace(t)))
     } yield ()
 
@@ -110,7 +110,7 @@ final class HorizonsLookup(editor: TargetEditor, site: Site, when: Long) {
         map(e => Ephemeris(site, e.data))
 
   /** Create a new phase 1 target from a name and phase-2 (!) ephemeris. */
-  def p1target(name: String, horizonsDesignation: String, ephemeris: Ephemeris): HS2[NonSiderealTarget] =
+  def p1target(name: String, horizonsDesignation: String, horizonsQuery: String, ephemeris: Ephemeris): HS2[NonSiderealTarget] =
     HS2.delay {
       NonSiderealTarget(
         UUID.randomUUID, // side-effect, so need delay above
@@ -119,7 +119,8 @@ final class HorizonsLookup(editor: TargetEditor, site: Site, when: Long) {
           case (t, cd) => EphemerisElement(cd, None, t) // no magnitude info
         },
         CoordinatesEpoch.J_2000,
-        Some(horizonsDesignation)
+        Some(horizonsDesignation),
+        Some(horizonsQuery)
       )
     }
 

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/editor/TargetEditor.scala
@@ -30,6 +30,7 @@ import java.awt.Color
 import edu.gemini.pit.ui.util.ToolButton
 
 import swing._
+import scala.swing.Swing.EmptyIcon
 import scala.swing.event.{ButtonClicked, SelectionChanged, ValueChanged}
 import javax.swing.{BorderFactory, Icon, ListSelectionModel, SwingUtilities}
 import java.text.DecimalFormat
@@ -402,8 +403,20 @@ class TargetEditor private (semester:Semester, target:Target, canEdit:Boolean) e
       object Header extends GridBagPanel with Rows {
 
         // Content, defined below.
+        addRow(new Label("Query:"), Query)
         addRow(new Label("Epoch:"), NsEpoch)
 
+      }
+
+      // Our Query String label.
+      object Query extends Label("", EmptyIcon, Alignment.Left) {
+        tooltip    = "HORIZONS query for this target."
+        foreground = Color.GRAY
+        text       = target match {
+          case ns: NonSiderealTarget =>
+            ns.horizonsDesignation.flatMap(HorizonsDesignation.read).foldMap(_.queryString)
+          case _ => ""
+        }
       }
 
       // Our epoch dropdown.

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -158,13 +158,13 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     } yield new Problem(Severity.Error, msg, "Targets", s.inTargetsView(_.edit(t)))
 
     private lazy val emptyEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _, _) <- p.targets
       if e.isEmpty
       msg = s"""Ephemeris for target "$n" is undefined."""
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
     private lazy val singlePointEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _, _) <- p.targets
       if e.size == 1
       msg = s"""Ephemeris for target "$n" contains only one point; please specify at least two."""
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
@@ -172,7 +172,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     lazy val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd").withZone(ZoneId.of("UTC"))
 
     private lazy val initialEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _, _) <- p.targets
       if e.nonEmpty
       ds = e.map(_.validAt) if ds.size > 1
       dsMin = ds.min
@@ -187,7 +187,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
     private lazy val finalEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _, _) <- p.targets
       if e.nonEmpty
       ds = e.map(_.validAt) if ds.size > 1
       dsMax = ds.max

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/target/TargetView.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/view/target/TargetView.scala
@@ -73,7 +73,7 @@ class TargetView(val shellAdvisor:ShellAdvisor) extends BorderPanel with BoundVi
     def size(m:Model) = targets.size
 
     object columns extends Enumeration {
-      val Name, RA, Dec, PM, /* Epoch, */ Magnitudes = Value
+      val Name, RA, Dec, PM, /* Epoch, */ Magnitudes, Query = Value
     }
     import columns._
 
@@ -106,6 +106,7 @@ class TargetView(val shellAdvisor:ShellAdvisor) extends BorderPanel with BoundVi
       case Dec  => (90, 90)
       case PM   => (25, 25)
       case Magnitudes => (100, Integer.MAX_VALUE)
+      case Query => (100, Integer.MAX_VALUE)
     }
 
     def text(e:Target) =
@@ -122,6 +123,10 @@ class TargetView(val shellAdvisor:ShellAdvisor) extends BorderPanel with BoundVi
           case t:SiderealTarget    => t.magnitudes.map(_.band.name).sorted.mkString(" ")
           case t:NonSiderealTarget => t.magnitude(semester.midPoint).map(d => "*").orNull
           case t:TooTarget         => null
+        }
+        case Query => e match {
+          case t:NonSiderealTarget => t.horizonsQuery.orNull
+          case _                   => null
         }
       } else {
         case Name => e.name


### PR DESCRIPTION
In response to Bryan's concern about target names being ambiguous, this PR

- adds the query string to the editor popup, which brings the behavior mostly into parity with what the OT does.

<img width="586" alt="image" src="https://user-images.githubusercontent.com/1200131/108267514-eb00d000-7130-11eb-9c4c-81ada616d27a.png">

- adds a Query column to the target view.

<img width="736" alt="image" src="https://user-images.githubusercontent.com/1200131/108281648-c2370580-7145-11eb-97bc-56255f7b4fef.png">

- It also adds the query string to the PDF, when present. Implemented for Gemini ...

<img width="606" alt="image" src="https://user-images.githubusercontent.com/1200131/108280775-4b4d3d00-7144-11eb-99be-e21b65a73870.png">

- and NOAO

<img width="606" alt="image" src="https://user-images.githubusercontent.com/1200131/108280814-599b5900-7144-11eb-9c47-f983e1e7df97.png">


