### PR TITLE
Don't install a custom SSL factory for horizons

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -391,7 +391,6 @@ object HorizonsService2 {
       LOG.info(s"Horizons request $url")
       val conn = url.openConnection().asInstanceOf[HttpsURLConnection]
       conn.setHostnameVerifier(hostnameVerifier)
-      conn.setSSLSocketFactory(GemSslSocketFactory.get)
       conn.setReadTimeout(timeout)
       ConnectionCharset.set(conn)
       ResponseStream(conn.getInputStream, ConnectionCharset.get(conn))


### PR DESCRIPTION
This seems to break horizons now, and in any case is no longer needed.