### PR TITLE
Horizon fix without updating the model version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization in Global := "edu.gemini.ocs"
 // true indicates a test release, and false indicates a production release
 ocsVersion in ThisBuild := OcsVersion("2020A", true, 1, 1, 1)
 
-pitVersion in ThisBuild := OcsVersion("2021B", false, 2, 1, 1)
+pitVersion in ThisBuild := OcsVersion("2021B", false, 2, 1, 2)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion

--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -391,7 +391,6 @@ object HorizonsService2 {
       LOG.info(s"Horizons request $url")
       val conn = url.openConnection().asInstanceOf[HttpsURLConnection]
       conn.setHostnameVerifier(hostnameVerifier)
-      conn.setSSLSocketFactory(GemSslSocketFactory.get)
       conn.setReadTimeout(timeout)
       ConnectionCharset.set(conn)
       ResponseStream(conn.getInputStream, ConnectionCharset.get(conn))

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/ShellAdvisor.scala
@@ -161,7 +161,7 @@ class ShellAdvisor(
         case versionRegex(_, s, m) => s"$s.$m"
         case x                        => x
       }
-      context.title = s"$name$mod - Gemini PIT ${Semester.current.year}${Semester.current.half}.$minorVersion$tac$test"
+      context.title = s"$name$mod - Gemini PIT ${Semester.current.year}${Semester.current.half}.$minorVersion.2$tac$test"
       if (Platform.IS_MAC)
         shell.peer.getRootPane.putClientProperty("Window.documentModified", shell.isModified)
     }


### PR DESCRIPTION
Fix for the horizons lookup without a model change
The version number on the UI was hardcoded for better usability
