### PR TITLE
REL-3900: IGRINS template updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "ocs"
 organization in Global := "edu.gemini.ocs"
 
 // true indicates a test release, and false indicates a production release
-ocsVersion in ThisBuild := OcsVersion("2020A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2021B", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2021B", false, 2, 1, 1)
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/VISITOR_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/VISITOR_BP.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
 
 <document>
-  <container kind="program" type="Program" version="2014A-1" subtype="basic" key="8cb94378-4312-4c80-bf31-cfb499213980" name="VISITOR-BP">
+  <container kind="program" type="Program" version="2020A-1" subtype="basic" key="8cb94378-4312-4c80-bf31-cfb499213980" name="VISITOR-BP">
     <paramset name="Science Program" kind="dataObj">
       <param name="title" value="VISITOR INSTRUMENT PHASE I/II MAPPING BPS"/>
       <param name="programMode" value="QUEUE"/>
@@ -22,11 +22,31 @@
       <param name="fetched" value="yes"/>
       <param name="completed" value="false"/>
       <param name="notifyPi" value="NO"/>
+      <param name="timingWindowNotification" value="true"/>
     </paramset>
     <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="3bcbd49f-4345-4b5a-8ae0-f789b9bfb294" name="Note">
       <paramset name="Note" kind="dataObj">
         <param name="title" value="Next libID = 2"/>
         <param name="NoteText" value=""/>
+      </paramset>
+    </container>
+    <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="fd02f63e-ab1a-471f-8efe-0e0be790a78f" name="Note">
+      <paramset name="Note" kind="dataObj">
+        <param name="title" value="IGRINS Observing Details"/>
+        <param name="NoteText">
+          <value>1. Exposure time = xxx sec per frame and Expected SNR ~XXX per ABBA sequence in H or K-band
+2. If the sequence is &gt;1.5hr: Can it be interrupted or not be interrupted?
+3. Telluric standard needed or not needed</value>
+        </param>
+      </paramset>
+    </container>
+    <container kind="obsComp" type="Info" version="2009A-1" subtype="schedNote" key="23324909-d6f3-4d32-b230-3cc3ae5f37ec" name="Scheduling Note">
+      <paramset name="Scheduling Note" kind="dataObj">
+        <param name="title" value="IGRINS Scheduling Details"/>
+        <param name="NoteText">
+          <value>1. Any timing constrains? Yes/No
+2. List timing windows in UT</value>
+        </param>
       </paramset>
     </container>
     <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="82afc875-b577-42e4-af8c-c0a02403dfe7" name="VISITOR-BP-1">
@@ -38,6 +58,7 @@
         <param name="phase2Status" value="PI_TO_COMPLETE"/>
         <param name="qaState" value="UNDEFINED"/>
         <param name="overrideQaState" value="false"/>
+        <param name="setupTimeType" value="FULL"/>
       </paramset>
       <container kind="obsComp" type="Instrument" version="2009A-1" subtype="Visitor" key="2f19cf5b-8398-4a21-8db8-41b517192db9" name="Visitor Instrument">
         <paramset name="Visitor Instrument" kind="dataObj">
@@ -91,12 +112,25 @@
       <param name="9d0ad4ed-79a1-4d1c-8d52-a099553d5c2e" value="1"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="fd02f63e-ab1a-471f-8efe-0e0be790a78f"/>
+      <param name="17aa09c4-1dc4-4260-bdeb-027833cd9bf2" value="38"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b26d1687-61b9-4e09-bbbb-b4ec637084ce"/>
+      <param name="17aa09c4-1dc4-4260-bdeb-027833cd9bf2" value="13"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="8cb94378-4312-4c80-bf31-cfb499213980"/>
       <param name="9d0ad4ed-79a1-4d1c-8d52-a099553d5c2e" value="1"/>
+      <param name="17aa09c4-1dc4-4260-bdeb-027833cd9bf2" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="5d10fe08-22a2-4b62-8fee-be986d69a37c"/>
       <param name="9d0ad4ed-79a1-4d1c-8d52-a099553d5c2e" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="23324909-d6f3-4d32-b230-3cc3ae5f37ec"/>
+      <param name="17aa09c4-1dc4-4260-bdeb-027833cd9bf2" value="28"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="82afc875-b577-42e4-af8c-c0a02403dfe7"/>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/Visitor.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/Visitor.scala
@@ -14,4 +14,5 @@ case class Visitor(blueprint: SpVisitorBlueprint) extends VisitorBase {
   // SET Name from Phase-I
   forObs(sci: _*)(setName fromPI)
   forObs(sci: _*)(setWavelength fromPI)
+  forObs(sci: _*)(setPosAngle fromPI)
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
@@ -10,26 +10,39 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
   val seqConfigCompType = VisitorInstrument.SP_TYPE
 
   val AlopekeWavelength: Double = 0.674
-  val ZorroWavelength: Double   = 0.674
   val DssiWavelength: Double    = 0.700
+  val IgrinsWavelength: Double  = 2.100
+  val ZorroWavelength: Double   = 0.674
 
   private val WavelengthMapping: List[(String, Double)] =
     List(
       "alopeke" -> AlopekeWavelength,
-      "zorro"   -> ZorroWavelength,
-      "dssi"    -> DssiWavelength
-  )
+      "dssi"    -> DssiWavelength,
+      "igrins"  -> IgrinsWavelength,
+      "zorro"   -> ZorroWavelength
+    )
 
+  val IgrinsPosAngle: Double = 90.0
+
+  private val PosAngleMapping: List[(String, Double)] =
+    List(
+      "igrins"  -> IgrinsPosAngle
+    )
 
   implicit def pimpInst(obs: ISPObservation) = new {
 
-    val ed = StaticObservationEditor[edu.gemini.spModel.gemini.visitor.VisitorInstrument](obs, instrumentType)
+    val ed: StaticObservationEditor[VisitorInstrument] =
+      StaticObservationEditor[VisitorInstrument](obs, instrumentType)
 
     def setName(n: String): Either[String, Unit] =
       ed.updateInstrument(_.setName(n))
 
     def setWavelength(microns: Double): Either[String, Unit] =
       ed.updateInstrument(_.setWavelength(microns))
+
+    def setPosAngle(degrees: Double): Either[String, Unit] =
+      ed.updateInstrument(_.setPosAngleDegrees(degrees))
+
   }
 
   // HACK: override superclass initialize to hang onto db reference
@@ -47,16 +60,22 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
     e =>
       e.printStackTrace()
       e.getMessage
-  }
+    }
 
   // DSL Setters
-  def setName = Setter[String](blueprint.name)(_.setName(_))
+  def setName: Setter[String] =
+    Setter[String](blueprint.name)(_.setName(_))
 
-  private def wavelength: Double = {
+  private def lookup[A](mapping: List[(String, A)], default: A): A = {
     val inst = blueprint.name.toLowerCase
-    WavelengthMapping.collectFirst { case (n, w) if inst.contains(n) => w }
-      .getOrElse(0.0)
+    mapping
+      .collectFirst { case (n, w) if inst.contains(n) => w }
+      .getOrElse(default)
   }
 
-  def setWavelength = Setter[Double](wavelength)(_.setWavelength(_))
+  def setWavelength: Setter[Double] =
+    Setter[Double](lookup(WavelengthMapping, 0.0))(_.setWavelength(_))
+
+  def setPosAngle: Setter[Double] =
+    Setter[Double](lookup(PosAngleMapping, 0.0))(_.setPosAngle(_))
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorInst.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorInst.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.phase2.template.factory.impl.visitor
+
+import edu.gemini.spModel.core.{Angle, Wavelength}
+
+import scalaz._
+import Scalaz._
+
+/**
+ * An enumeration of expected visitor instruments and any template
+ * specialization associated with each.
+ */
+sealed trait VisitorInst extends Product with Serializable {
+
+  def name: String
+
+  def wavelength: Wavelength =
+    Wavelength.zero
+
+  def positionAngle: Angle =
+    Angle.zero
+
+  def noteTitles: List[String] =
+    Nil
+
+}
+
+object VisitorInst {
+
+  case object Alopeke extends VisitorInst {
+
+    override def name: String = "alopeke"
+
+    override def wavelength: Wavelength =
+      Wavelength.fromNanometers(674)
+
+  }
+
+  case object Dssi extends VisitorInst {
+
+    override def name: String = "dssi"
+
+    override def wavelength: Wavelength =
+      Wavelength.fromNanometers(700)
+
+  }
+
+  case object Igrins extends VisitorInst {
+
+    override def name: String = "igrins"
+
+    override def wavelength: Wavelength =
+      Wavelength.fromNanometers(2100)
+
+    override def positionAngle: Angle =
+      Angle.fromDegrees(90.0)
+
+    override def noteTitles: List[String] =
+      List(
+        "IGRINS Observing Details",
+        "IGRINS Scheduling Details"
+      )
+
+  }
+
+  case object Zorro extends VisitorInst {
+
+    override def name: String = "zorro"
+
+    override def wavelength: Wavelength =
+      Wavelength.fromNanometers(674)
+
+  }
+
+  implicit val EqVisitorInst: Equal[VisitorInst] =
+    Equal.equalBy(_.name)
+
+  val All: List[VisitorInst] =
+    List(
+      Alopeke,
+      Dssi,
+      Igrins,
+      Zorro
+    )
+
+  def findByName(name: String): Option[VisitorInst] =
+    All.find(_.name.equalsIgnoreCase(name))
+
+}

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/TemplateSpec.scala
@@ -98,6 +98,10 @@ abstract class TemplateSpec(xmlName: String) { this: SpecificationLike =>
       .asScala
       .toList
 
+  /** Return the list of all `ISPObservation`s in the template groups of the program. */
+  def templateObservations(sp: ISPProgram): List[ISPObservation] =
+    groups(sp).flatMap(_.getAllObservations.asScala.toList)
+
   /** Assert that the given library IDs are included and excluded; call within a `should`. */
   def checkLibs(label: String, tg: ISPTemplateGroup, incl: Set[Int], excl: Set[Int]) = {
     val ls = libs(tg)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/VisitorBlueprintSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/VisitorBlueprintSpec.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.phase2.skeleton.factory
+
+import edu.gemini.model.p1.immutable.{Site, VisitorBlueprint}
+import edu.gemini.phase2.template.factory.impl.visitor.VisitorInst
+import edu.gemini.pot.sp.{ISPProgram, SPComponentType}
+import edu.gemini.spModel.core.MagnitudeBand
+import edu.gemini.spModel.gemini.visitor.VisitorInstrument
+import edu.gemini.spModel.rich.pot.sp._
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2.ScalaCheck
+import org.specs2.mutable.SpecificationLike
+
+class VisitorBlueprintSpec extends TemplateSpec("VISITOR_BP.xml") with SpecificationLike with ScalaCheck {
+
+  implicit val ArbitraryVisitorBlueprint: Arbitrary[VisitorBlueprint] =
+    Arbitrary {
+      for {
+        s <- Gen.oneOf(Site.GN, Site.GS)
+        n <- Gen.oneOf(VisitorInst.All.map(_.name))
+      } yield VisitorBlueprint(s, n)
+    }
+
+  def visitorInstrumentComponents(sp: ISPProgram): List[VisitorInstrument] =
+    templateObservations(sp).flatMap { obs =>
+      obs.findDescendant(_.getDataObject.getType == SPComponentType.INSTRUMENT_VISITOR).toList
+    }.map(_.getDataObject.asInstanceOf[VisitorInstrument])
+
+
+  "Visitor" should {
+
+    "include all notes" in {
+      forAll { (b: VisitorBlueprint) =>
+        expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
+          val notes = VisitorInst.findByName(b.customName).toList.flatMap(_.noteTitles)
+          groups(sp).forall(tg => notes.forall(existsNote(tg, _)))
+        }
+      }
+    }
+
+    "set the position angle" in {
+      forAll { (b: VisitorBlueprint) =>
+        expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
+          visitorInstrumentComponents(sp).forall { vi =>
+            vi.getPosAngleDegrees == VisitorInst.findByName(b.customName).map(_.positionAngle.toDegrees).getOrElse(0.0)
+          }
+        }
+      }
+    }
+
+    "set the wavelength" in {
+      forAll { (b: VisitorBlueprint) =>
+        expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
+          visitorInstrumentComponents(sp).forall { vi =>
+            vi.getWavelength == VisitorInst.findByName(b.customName).map(_.wavelength.toMicrons).getOrElse(0.0)
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/RichNode.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/RichNode.scala
@@ -64,7 +64,7 @@ final class RichNode(val node: ISPNode) extends AnyVal {
 
   def toStream: Stream[ISPNode] =
     node match {
-      case c: ISPContainerNode => c #:: c.children.toStream.map(_.toStream).flatten
+      case c: ISPContainerNode => c #:: c.children.toStream.flatMap(_.toStream)
       case n                   => Stream(n)
     }
 


### PR DESCRIPTION
Makes a couple of changes to the visitor blueprint / template code:

1. Adds the ability to assign a position angle based on visitor instrument name
2. Adds the ability to include notes based on visitor instrument name

Updates the visitor template with a couple of IGRINS notes.

Because there are now a handful of visitor-instrument specific specializations, I collected them all in a new `VisitorInst` type.