### PR TITLE
REL-3863: controlled pos angle update

### DIFF
--- a/bundle/edu.gemini.util.skycalc/src/main/scala/edu/gemini/util/skycalc/calc/TargetCalculator.scala
+++ b/bundle/edu.gemini.util.skycalc/src/main/scala/edu/gemini/util/skycalc/calc/TargetCalculator.scala
@@ -10,11 +10,11 @@ import edu.gemini.util.skycalc.calc.TargetCalculator.Fields
  * Target calculator that allows to calculate different attributes of a target for a given interval at a given sampling
  * rate. The purpose of this trait is twofold:
  * <ul>
- *   <li>It is a Scala facade to the Java skycalc code in {@see edu.gemini.skycalc.ImprovedSkyCalc}.</li>
+ *   <li>It is a Scala facade to the Java skycalc code in `edu.gemini.skycalc.ImprovedSkyCalc`.</li>
  *   <li>It caches the values for a target for a given interval and sampling rate; this is relevant for places
  *       where these values are needed repetitively because the calculation is pretty complex and slow.</li>
  * </ul>
- * If in doubt use {@link isDefinedAt} to make sure that values for a given time are actually calculated before
+ * If in doubt use `isDefinedAt` to make sure that values for a given time are actually calculated before
  * accessing them, otherwise an out of bounds exception will be thrown.
  */
 trait TargetCalculator extends Calculator {
@@ -109,7 +109,7 @@ trait TargetCalculator extends Calculator {
    * Calculates all values for the given times.
    * @return
    */
-  protected def calculate() = {
+  protected def calculate(): Vector[Vector[Double]] = {
     val skycalc = new ImprovedSkyCalc(site)
 
     // prepare temporary data structure
@@ -123,7 +123,7 @@ trait TargetCalculator extends Calculator {
       new Array[Double](samples)
     )
     // fill temporary data structure with calculated values
-    for (ix <- 0 to samples-1) {
+    for (ix <- 0 until samples) {
       val t = times(ix)
       skycalc.calculate(targetLocation(t), new Date(t), true)
       values(Elevation.id)(ix) = skycalc.getAltitude
@@ -164,14 +164,13 @@ object TargetCalculator {
     val Elevation, Azimuth, Airmass, LunarDistance, ParallacticAngle, HourAngle, SkyBrightness = Value
   }
 
-  def apply(site: Site, targetLocation: Long => Coordinates, defined: Interval, rate: Long = TimeUtils.seconds(30)) = {
-    new IntervalTargetCalculator(site, targetLocation, defined, rate)
-  }
-  def apply(site: Site, targetLocation: Long => Coordinates, time: Long): TargetCalculator = {
-    new SingleValueTargetCalculator(site, targetLocation, time)
-  }
-  def apply(site: Site, targetLocation: Long => Coordinates, times: Vector[Long]): TargetCalculator = {
-    new SampleTargetCalculator(site, targetLocation, times)
-  }
+  def apply(site: Site, targetLocation: Long => Coordinates, defined: Interval, rate: Long = TimeUtils.seconds(30)): TargetCalculator =
+    IntervalTargetCalculator(site, targetLocation, defined, rate)
+
+  def apply(site: Site, targetLocation: Long => Coordinates, time: Long): TargetCalculator =
+    SingleValueTargetCalculator(site, targetLocation, time)
+
+  def apply(site: Site, targetLocation: Long => Coordinates, times: Vector[Long]): TargetCalculator =
+    SampleTargetCalculator(site, targetLocation, times)
 }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/parallacticangle/PositionAnglePanel.scala
@@ -107,7 +107,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
 
     // Parallactic angle controls, if needed. This is an ugly hack because we only know if an instrument
     // supports parallactic angle by its type.
-    val parallacticAngleControlsOpt = {
+    val parallacticAngleControlsOpt: Option[ParallacticAngleControls] = {
       val supportsParallacticAngle = Set(SPComponentType.INSTRUMENT_FLAMINGOS2,
                                          SPComponentType.INSTRUMENT_GMOS,
                                          SPComponentType.INSTRUMENT_GMOSSOUTH,
@@ -186,10 +186,10 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     val instrument = e.getDataObject
 
     // Turn off the parallactic angle changing event handling as it triggers an AGS lookup.
-    ui.parallacticAngleControlsOpt.foreach(p => {
+    ui.parallacticAngleControlsOpt.foreach { p =>
       deafTo(p)
       p.init(e, s, numberFormatter)
-    })
+    }
 
     // Reset the combo box so that all of the options are enabled by default.
     // TODO: When background AGS is implemented, we can remove the deafTo + listenTo lines, as well as the
@@ -229,7 +229,7 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
     }
   }
 
-  private def updatePATextFieldEditableState(pac: PosAngleConstraint) =
+  private def updatePATextFieldEditableState(pac: PosAngleConstraint): Unit =
     ui.positionAngleTextField.editable = !pac.isCalculated
 
   private def setInstPosAngle(newAngleDegrees: Double): Unit =
@@ -241,14 +241,13 @@ class PositionAnglePanel[I <: SPInstObsComp with PosAngleConstraintAware,
   /**
     * Copies the position angle in the data object to the position angle text field.
     */
-  private def copyPosAngleToTextField(): Unit = {
+  private def copyPosAngleToTextField(): Unit =
     editor.foreach { e =>
       val newAngleStr = numberFormatter.format(e.getDataObject.getPosAngleDegrees)
       val oldAngleStr = ui.positionAngleTextField.text
       if (!newAngleStr.equals(oldAngleStr))
         ui.positionAngleTextField.text = newAngleStr
     }
-  }
 
   /**
     * Called whenever a selection is made in the position angle constraint combo box.


### PR DESCRIPTION
Going well beyond just touching the third rail, this PR would update `BagsManager` to:

* make its update to the target environment and position angle consistent by holding a write lock
* only performing the update if the observation is in the expected state as it was when the AGS calculation was kicked off

This is to address the complaint about the position angle in the OT reverting to previous values when typing quickly.  I could not reproduce this issue but these changes _may_ help and _seem_ like the right thing to do regardless. 

There are also a handful of inconsequential updates made while browsing the code as well.  I'll mark the important bits.