### PR TITLE
REL-3924: Add GAIA @ Gemini

### DIFF
--- a/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsCatalogChoice.java
+++ b/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsCatalogChoice.java
@@ -1,12 +1,14 @@
 package edu.gemini.ags.gems;
 
 import edu.gemini.catalog.api.CatalogName;
-import edu.gemini.catalog.api.CatalogName.Gaia$;
+import edu.gemini.catalog.api.CatalogName.GaiaEsa$;
+import edu.gemini.catalog.api.CatalogName.GaiaGemini$;
 import edu.gemini.catalog.api.CatalogName.PPMXL$;
 import edu.gemini.catalog.api.CatalogName.UCAC4$;
 
 public enum GemsCatalogChoice {
-    GAIA_ESA(    Gaia$.MODULE$,  "Gaia at ESA"),
+    GAIA_ESA(GaiaEsa$.MODULE$, "Gaia at ESA"),
+    GAIA_Gemini(GaiaGemini$.MODULE$, "Gaia at Gemini"),
     PPMXL_GEMINI(PPMXL$.MODULE$, "PPMXL at Gemini"),
     UCAC4_GEMINI(UCAC4$.MODULE$, "UCAC4 at Gemini"),
     ;

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -1,7 +1,7 @@
 package edu.gemini.ags.impl
 
 import edu.gemini.ags.api.AgsStrategy
-import edu.gemini.catalog.api.CatalogName.Gaia
+import edu.gemini.catalog.api.CatalogName.GaiaEsa
 import edu.gemini.catalog.votable.ConeSearchBackend
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.spModel.ags.AgsStrategyKey
@@ -38,7 +38,7 @@ object Strategy {
   val NiciOiwfs       = ScienceTargetStrategy(NiciOiwfsKey,     NiciOiwfsGuideProbe.instance, NiciBandsList)
   val Off             = OffStrategy
 
-  val GemsNgs2        = Ngs2Strategy(Gaia, None)
+  val GemsNgs2        = Ngs2Strategy(GaiaEsa, None)
 
   /**
    * All strategies that correspond to top-level AGS queries. Internally, some

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -46,9 +46,8 @@ object CatalogName {
     override val  supportedBands = List(MagnitudeBand._g, MagnitudeBand._r, MagnitudeBand._i, MagnitudeBand.B, MagnitudeBand.V, MagnitudeBand.UC, MagnitudeBand.J, MagnitudeBand.H, MagnitudeBand.K)
   }
 
-  case object Gaia extends CatalogName("gaia", "GAIA @ ESA") {
+  sealed abstract class Gaia(id: String, displayName: String) extends CatalogName(id, displayName) {
 
-    // Gaia bands (why isn't this a Set?)
     override val supportedBands: List[MagnitudeBand] =
       List(
         MagnitudeBand.V,
@@ -69,6 +68,10 @@ object CatalogName {
       VersionToken.unsafeFromIntegers(1, 3)
 
   }
+
+  case object GaiaEsa extends Gaia("gaiaEsa", "GAIA @ ESA")
+
+  case object GaiaGemini extends Gaia("gaiaGemini", "GAIA @ Gemini")
 
   case object TWOMASS_PSC extends CatalogName("twomass_psc", "TwoMass PSC @ Gemini")
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -233,7 +233,7 @@ sealed trait GaiaBackend extends CachedBackend with RemoteCallBackend {
     val fields = gaia.allFields.map(_.id).mkString(",")
 
     f"""|SELECT TOP $MaxResultCount $fields
-        |      FROM ${gaia.tableName}
+        |      FROM gaiadr2.gaia_source
         |     WHERE CONTAINS(POINT('ICRS',${gaia.raField.id},${gaia.decField.id}),CIRCLE('ICRS', ${cs.base.ra.toDegrees}%9.8f, ${cs.base.dec.toDegrees}%9.8f, ${cs.radiusConstraint.maxLimit.toDegrees}%9.8f))=1
         |       AND (${gaia.plxField.id} > 0)
         |       AND (${gaia.gMagField.id} BETWEEN $BrightLimit AND $FaintLimit)

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -207,9 +207,9 @@ case object ConeSearchBackend extends CachedBackend with RemoteCallBackend {
   override def queryUrl(e: SearchKey): String = s"${e.url}/cgi-bin/conesearch.py"
 }
 
-case object GaiaBackend extends CachedBackend with RemoteCallBackend {
-  // For Java
-  val instance = this
+sealed trait GaiaBackend extends CachedBackend with RemoteCallBackend {
+
+  def gaia: CatalogAdapter.GaiaAdapter
 
   val MaxResultCount: Int         = 50000  // Arbitrary max limit -- for a crowded field this needs to be largish
   val BrightLimit: Int            =     9  // g GAIA bright limit
@@ -229,18 +229,17 @@ case object GaiaBackend extends CachedBackend with RemoteCallBackend {
     }
 
   def adql(cs: ConeSearchCatalogQuery): String = {
-    import CatalogAdapter.Gaia
 
-    val fields = Gaia.allFields.map(_.id).mkString(",")
+    val fields = gaia.allFields.map(_.id).mkString(",")
 
     f"""|SELECT TOP $MaxResultCount $fields
         |      FROM gaiadr2.gaia_source
-        |     WHERE CONTAINS(POINT('ICRS',${Gaia.raField.id},${Gaia.decField.id}),CIRCLE('ICRS', ${cs.base.ra.toDegrees}%9.8f, ${cs.base.dec.toDegrees}%9.8f, ${cs.radiusConstraint.maxLimit.toDegrees}%9.8f))=1
-        |       AND (${Gaia.plxField.id} > 0)
-        |       AND (${Gaia.gMagField.id} BETWEEN $BrightLimit AND $FaintLimit)
-        |       AND (${Gaia.bpRpField.id} IS NOT NULL)
-        |       AND (SQRT(POWER(${Gaia.pmRaField.id}, 2.0) + POWER(${Gaia.pmDecField.id}, 2.0)) < ${ProperMotionLimitMasYr})
-        |  ORDER BY ${Gaia.gMagField.id}
+        |     WHERE CONTAINS(POINT('ICRS',${gaia.raField.id},${gaia.decField.id}),CIRCLE('ICRS', ${cs.base.ra.toDegrees}%9.8f, ${cs.base.dec.toDegrees}%9.8f, ${cs.radiusConstraint.maxLimit.toDegrees}%9.8f))=1
+        |       AND (${gaia.plxField.id} > 0)
+        |       AND (${gaia.gMagField.id} BETWEEN $BrightLimit AND $FaintLimit)
+        |       AND (${gaia.bpRpField.id} IS NOT NULL)
+        |       AND (SQRT(POWER(${gaia.pmRaField.id}, 2.0) + POWER(${gaia.pmDecField.id}, 2.0)) < ${ProperMotionLimitMasYr})
+        |  ORDER BY ${gaia.gMagField.id}
       """.stripMargin
   }
 
@@ -260,11 +259,34 @@ case object GaiaBackend extends CachedBackend with RemoteCallBackend {
     }
 
 
+  override def queryUrl(e: SearchKey): String =
+    e.url.toExternalForm
+}
+
+case object GaiaEsaBackend extends GaiaBackend {
+
+  // For Java
+  val instance: GaiaBackend = this
+
+  override def gaia: CatalogAdapter.GaiaAdapter =
+    CatalogAdapter.GaiaEsa
+
   override val catalogUrls: NonEmptyList[URL] =
     NonEmptyList(new URL("https://gea.esac.esa.int/tap-server/tap/sync"))
 
-  override def queryUrl(e: SearchKey): String =
-    e.url.toExternalForm
+}
+
+case object GaiaGeminiBackend extends GaiaBackend {
+
+  // For Java
+  val instance: GaiaBackend = this
+
+  override def gaia: CatalogAdapter.GaiaAdapter =
+    CatalogAdapter.GaiaGemini
+
+  override val catalogUrls: NonEmptyList[URL] =
+    NonEmptyList(new URL("https://gncatalog.gemini.edu/gaia"), new URL("https://gscatalog.gemini.edu/gaia"))
+
 }
 
 case object SimbadNameBackend extends CachedBackend with RemoteCallBackend {
@@ -313,9 +335,10 @@ object VoTableClient extends VoTableClient {
 
   def defaultBackend(n: CatalogName): VoTableBackend =
     n match {
-      case CatalogName.Gaia   => GaiaBackend
-      case CatalogName.SIMBAD => SimbadNameBackend
-      case _                  => ConeSearchBackend
+      case CatalogName.GaiaEsa    => GaiaEsaBackend
+      case CatalogName.GaiaGemini => GaiaGeminiBackend
+      case CatalogName.SIMBAD     => SimbadNameBackend
+      case _                      => ConeSearchBackend
     }
 
   /**

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -233,7 +233,7 @@ sealed trait GaiaBackend extends CachedBackend with RemoteCallBackend {
     val fields = gaia.allFields.map(_.id).mkString(",")
 
     f"""|SELECT TOP $MaxResultCount $fields
-        |      FROM gaiadr2.gaia_source
+        |      FROM ${gaia.tableName}
         |     WHERE CONTAINS(POINT('ICRS',${gaia.raField.id},${gaia.decField.id}),CIRCLE('ICRS', ${cs.base.ra.toDegrees}%9.8f, ${cs.base.dec.toDegrees}%9.8f, ${cs.radiusConstraint.maxLimit.toDegrees}%9.8f))=1
         |       AND (${gaia.plxField.id} > 0)
         |       AND (${gaia.gMagField.id} BETWEEN $BrightLimit AND $FaintLimit)
@@ -285,7 +285,8 @@ case object GaiaGeminiBackend extends GaiaBackend {
     CatalogAdapter.GaiaGemini
 
   override val catalogUrls: NonEmptyList[URL] =
-    NonEmptyList(new URL("https://gncatalog.gemini.edu/gaia"), new URL("https://gscatalog.gemini.edu/gaia"))
+    NonEmptyList(new URL("http://mkocatalog-lv2.hi.gemini.edu/cgi-bin/conesearch.py/tap/sync"))
+//    NonEmptyList(new URL("https://gncatalog.gemini.edu/gaia"), new URL("https://gscatalog.gemini.edu/gaia"))
 
 }
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -93,13 +93,13 @@ sealed trait CatalogAdapter {
   def isMagnitudeField(v: (FieldId, String)): Boolean =
     containsMagnitude(v._1)                      &&
       !v._1.ucd.includes(VoTableParser.STAT_ERR) &&
-      v._2.nonEmpty
+      v._2.nonEmptyNonNan
 
   // Indicates if the field is a magnitude error
   def isMagnitudeErrorField(v: (FieldId, String)): Boolean =
     containsMagnitude(v._1)                     &&
       v._1.ucd.includes(VoTableParser.STAT_ERR) &&
-      v._2.nonEmpty
+      v._2.nonEmptyNonNan
 
   // Indicates if the field is a magnitude system
   def isMagnitudeSystemField(v: (FieldId, String)): Boolean =
@@ -390,7 +390,7 @@ object CatalogAdapter {
         OptionT[Try, Double](
           entries
             .get(f)
-            .filter(_.nonEmpty)
+            .filter(_.nonEmptyNonNan)
             .traverseU(CatalogAdapter.parseDoubleValue(f.ucd, _))
         )
 
@@ -457,7 +457,7 @@ object CatalogAdapter {
         v._1.ucd.includes(VoTableParser.STAT_ERR)  &&
         errorFluxID.findFirstIn(v._1.id).isDefined &&
         !ignoreMagnitudeField(v._1)                &&
-        v._2.nonEmpty
+        v._2.nonEmptyNonNan
 
     protected def findBand(band: String): Option[MagnitudeBand] =
       MagnitudeBand.all.find(_.name == band)
@@ -469,7 +469,7 @@ object CatalogAdapter {
 
     // Attempts to find the magnitude system for a band
     override def parseMagnitudeSys(p: (FieldId, String)): CatalogProblem \/ Option[(MagnitudeBand, MagnitudeSystem)] = {
-      val band = p._2.nonEmpty option {
+      val band = p._2.nonEmptyNonNan option {
         p._1.id match {
           case magSystemID(x) => findBand(x)
           case _              => None
@@ -554,7 +554,7 @@ trait VoTableParser {
       }
 
     def parseProperMotion(pm: (Option[String], Option[String]), epoch: Option[String]): CatalogProblem \/ Option[ProperMotion] =
-      (pm._1.filter(_.nonEmpty) |@| pm._2.filter(_.nonEmpty)) { (pmra, pmdec) =>
+      (pm._1.filter(_.nonEmptyNonNan) |@| pm._2.filter(_.nonEmptyNonNan)) { (pmra, pmdec) =>
         for {
           pmrav  <- adapter.parseAngularVelocity(VoTableParser.UCD_PMRA, pmra)
           pmra    = RightAscensionAngularVelocity(pmrav)
@@ -569,7 +569,7 @@ trait VoTableParser {
     )(
       f: Double => CatalogProblem \/ A
     ): CatalogProblem \/ Option[A] =
-      s.filter(_.nonEmpty).traverseU { ds =>
+      s.filter(_.nonEmptyNonNan).traverseU { ds =>
         for {
           d <- CatalogAdapter.parseDoubleValue(u, ds)
           a <- f(d)

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -290,10 +290,7 @@ object CatalogAdapter {
     }
   }
 
-  case object Gaia extends CatalogAdapter {
-
-    val catalog: CatalogName =
-      CatalogName.Gaia
+  sealed trait GaiaAdapter extends CatalogAdapter {
 
     override val idField    = FieldId("designation",     VoTableParser.UCD_OBJID)
     override val raField    = FieldId("ra",              VoTableParser.UCD_RA   )
@@ -405,6 +402,20 @@ object CatalogAdapter {
     }
   }
 
+  case object GaiaEsa extends GaiaAdapter {
+
+    override val catalog: CatalogName =
+      CatalogName.GaiaEsa
+
+  }
+
+  case object GaiaGemini extends GaiaAdapter {
+
+    override val catalog: CatalogName =
+      CatalogName.GaiaGemini
+
+  }
+
   case object Simbad extends CatalogAdapter {
 
     val catalog: CatalogName =
@@ -474,7 +485,7 @@ object CatalogAdapter {
   }
 
   val All: List[CatalogAdapter] =
-    List(UCAC4, PPMXL, Gaia, Simbad)
+    List(UCAC4, PPMXL, GaiaEsa, GaiaGemini, Simbad)
 
   def forCatalog(c: CatalogName): Option[CatalogAdapter] =
     All.find(_.catalog === c)

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -1,10 +1,10 @@
 package edu.gemini.catalog.votable
 
 import java.io.{ByteArrayInputStream, InputStream}
-
 import edu.gemini.catalog.api.CatalogName
 import edu.gemini.spModel.core._
 
+import scala.collection.immutable
 import scala.io.Source
 import scala.xml.XML
 import scala.xml.Node
@@ -292,17 +292,19 @@ object CatalogAdapter {
 
   sealed trait GaiaAdapter extends CatalogAdapter {
 
-    override val idField    = FieldId("designation",     VoTableParser.UCD_OBJID)
-    override val raField    = FieldId("ra",              VoTableParser.UCD_RA   )
-    override val decField   = FieldId("dec",             VoTableParser.UCD_DEC  )
-    override val pmRaField  = FieldId("pmra",            VoTableParser.UCD_PMRA )
-    override val pmDecField = FieldId("pmdec",           VoTableParser.UCD_PMDEC)
-    override val rvField    = FieldId("radial_velocity", VoTableParser.UCD_RV   )
-    override val plxField   = FieldId("parallax",        VoTableParser.UCD_PLX  )
+    def tableName: String
+
+    override val idField: FieldId    = FieldId("designation",     VoTableParser.UCD_OBJID)
+    override val raField: FieldId    = FieldId("ra",              VoTableParser.UCD_RA   )
+    override val decField: FieldId   = FieldId("dec",             VoTableParser.UCD_DEC  )
+    override val pmRaField: FieldId  = FieldId("pmra",            VoTableParser.UCD_PMRA )
+    override val pmDecField: FieldId = FieldId("pmdec",           VoTableParser.UCD_PMDEC)
+    override val rvField: FieldId    = FieldId("radial_velocity", VoTableParser.UCD_RV   )
+    override val plxField: FieldId   = FieldId("parallax",        VoTableParser.UCD_PLX  )
 
     // These are used to derive all other magnitude values.
-    val gMagField = FieldId("phot_g_mean_mag", Ucd("phot.mag;stat.mean;em.opt"))
-    val bpRpField = FieldId("bp_rp",           Ucd("phot.color"               ))
+    val gMagField: FieldId = FieldId("phot_g_mean_mag", Ucd("phot.mag;stat.mean;em.opt"))
+    val bpRpField: FieldId = FieldId("bp_rp",           Ucd("phot.color"               ))
 
     /**
      * List of all Gaia fields of interest.  These are used in forming the ADQL
@@ -407,12 +409,18 @@ object CatalogAdapter {
     override val catalog: CatalogName =
       CatalogName.GaiaEsa
 
+    override val tableName: String =
+      "gaiadr2.gaia_source"
+
   }
 
   case object GaiaGemini extends GaiaAdapter {
 
     override val catalog: CatalogName =
       CatalogName.GaiaGemini
+
+    override val tableName: String =
+      "gaia2"
 
   }
 
@@ -522,7 +530,7 @@ trait VoTableParser {
     TableRow(rows.flatten.toList)
   }
 
-  protected def parseTableRows(fields: List[FieldDescriptor], xml: Node)  =
+  protected def parseTableRows(fields: List[FieldDescriptor], xml: Node): immutable.Seq[TableRow] =
     for {
       table <-  xml   \\ "TABLEDATA"
       tr    <-  table \\ "TR"

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -292,8 +292,6 @@ object CatalogAdapter {
 
   sealed trait GaiaAdapter extends CatalogAdapter {
 
-    def tableName: String
-
     override val idField: FieldId    = FieldId("designation",     VoTableParser.UCD_OBJID)
     override val raField: FieldId    = FieldId("ra",              VoTableParser.UCD_RA   )
     override val decField: FieldId   = FieldId("dec",             VoTableParser.UCD_DEC  )
@@ -409,18 +407,12 @@ object CatalogAdapter {
     override val catalog: CatalogName =
       CatalogName.GaiaEsa
 
-    override val tableName: String =
-      "gaiadr2.gaia_source"
-
   }
 
   case object GaiaGemini extends GaiaAdapter {
 
     override val catalog: CatalogName =
       CatalogName.GaiaGemini
-
-    override val tableName: String =
-      "gaia2"
 
   }
 

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/package.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/package.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2018 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.catalog
+
+/**
+ *
+ */
+package object votable {
+
+  private[votable] implicit class StringOps(s: String) {
+
+    /**
+     * A predicate that determines whether a String is both non-empty and not
+     * "NaN".
+     */
+    def nonEmptyNonNan: Boolean =
+      s.nonEmpty && !"NaN".equals(s)
+
+  }
+
+}

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -681,7 +681,7 @@ class VoTableParserSpec extends Specification with VoTableParser {
     "be able to read Gaia results" in {
 
       // Extract just the targets.
-      val result = parse(CatalogAdapter.Gaia, voTableGaia).tables.head.rows.sequenceU.getOrElse(Nil)
+      val result = parse(CatalogAdapter.GaiaEsa, voTableGaia).tables.head.rows.sequenceU.getOrElse(Nil)
 
       // 6 targets (i.e., and no errors)
       result.size shouldEqual 4
@@ -697,7 +697,7 @@ class VoTableParserSpec extends Specification with VoTableParser {
       c.magnitudes.map(_.band).toSet shouldEqual Set(_g, _r, V, R, I, _i, K, H, J)
 
       // Final target has everything.
-      d.magnitudes.map(_.band).toSet shouldEqual CatalogName.Gaia.supportedBands.toSet
+      d.magnitudes.map(_.band).toSet shouldEqual CatalogName.GaiaEsa.supportedBands.toSet
 
       // Even radial velocity.
       ((d.redshift.get.z - 0.000068).abs < 0.000001) shouldEqual true

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -13,7 +13,7 @@ import edu.gemini.ags.api.GuideInFOV.{Outside, Inside}
 import edu.gemini.ags.api._
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.catalog.api._
-import edu.gemini.catalog.api.CatalogName.{PPMXL, UCAC4, Gaia}
+import edu.gemini.catalog.api.CatalogName.{PPMXL, UCAC4, GaiaEsa, GaiaGemini}
 import edu.gemini.catalog.ui.adapters.TableQueryResultAdapter
 import edu.gemini.catalog.ui.tpe.CatalogImageDisplay
 import edu.gemini.catalog.votable._
@@ -487,7 +487,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
     lazy val catalogBox: ComboBox[CatalogName] with TextRenderer[CatalogName] {
       def text(a: CatalogName): String
-    } = new ComboBox(List[CatalogName](UCAC4, PPMXL, Gaia)) with TextRenderer[CatalogName] {
+    } = new ComboBox(List[CatalogName](UCAC4, PPMXL, GaiaEsa, GaiaGemini)) with TextRenderer[CatalogName] {
 
       override def text(a: CatalogName): String =
         Option(a).foldMap(_.displayName)


### PR DESCRIPTION
Adds an additional catalog option for GAIA at Gemini.  I don't yet have the correct query URL for external users, but it can be tested by internal users.  A followup-up PR will be needed to correct the address.  It does show up in all the right places in the OT though.