### PR TITLE
REL-3926: change prog cal proprietary period

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/dataflow/GsaSequenceEditor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/dataflow/GsaSequenceEditor.java
@@ -25,7 +25,7 @@ public enum GsaSequenceEditor {
     }
 
     public void addProprietaryPeriod(IConfig c, GsaAspect gsa, ObsClass obsClass) {
-        final int m = (obsClass.shouldChargeProgram() || gsa.isHeaderPrivate()) ? gsa.getProprietaryMonths() : 0;
+        final int m = (obsClass.respectsProprietaryPeriod() || gsa.isHeaderPrivate()) ? gsa.getProprietaryMonths() : 0;
         c.putParameter(OBSERVE_CONFIG_NAME, DefaultParameter.getInstance(PROPRIETARY_MONTHS, m));
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsclass/ObsClass.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsclass/ObsClass.java
@@ -19,6 +19,7 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
             action.science();
         }
         public boolean isCalibration() { return false; }
+        public boolean respectsProprietaryPeriod() { return true; }
     },
 
     /**
@@ -29,6 +30,7 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
             action.progCal();
         }
         public boolean isCalibration() { return true; }
+        public boolean respectsProprietaryPeriod() { return false; }
     },
 
     /**
@@ -39,6 +41,7 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
             action.partnerCal();
         }
         public boolean isCalibration() { return true; }
+        public boolean respectsProprietaryPeriod() { return false; }
     },
 
     /**
@@ -49,6 +52,7 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
             action.acq();
         }
         public boolean isCalibration() { return false; }
+        public boolean respectsProprietaryPeriod() { return true; }
     },
 
     /**
@@ -59,6 +63,7 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
             action.acqCal();
         }
         public boolean isCalibration() { return true; }
+        public boolean respectsProprietaryPeriod() { return false; }
     },
 
     /**
@@ -69,6 +74,7 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
             action.dayCal();
         }
         public boolean isCalibration() { return true; }
+        public boolean respectsProprietaryPeriod() { return false; }
     },
 
     ;
@@ -99,11 +105,11 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
         void dayCal();
     }
 
-    private String _headerValue;
-    private String _displayValue;
-    private int _priority;
-    private ChargeClass _charge;
-    private String _logValue;
+    private final String _headerValue;
+    private final String _displayValue;
+    private final int _priority;
+    private final ChargeClass _charge;
+    private final String _logValue;
 
 
     ObsClass(String headerVal, String displayVal, int priority, ChargeClass charge, String logValue) {
@@ -116,6 +122,7 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
 
     public abstract void doAction(ObsClass.Action action);
     public abstract boolean isCalibration();
+    public abstract boolean respectsProprietaryPeriod();
 
     public String displayValue() {
         return _displayValue;
@@ -158,15 +165,6 @@ public enum ObsClass implements DisplayableSpType, LoggableSpType, SequenceableS
 
     public String toString() {
         return displayValue();
-    }
-
-    /**
-     * This method is needed by the data manager and was added to merge the FITS ObsClass with this one.
-     * The only programs that are charged are those in ChargeClass PROGRAM.
-     * @return
-     */
-    public boolean shouldChargeProgram() {
-        return _charge.equals(ChargeClass.PROGRAM);
     }
 
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/dataflow/ProprietaryTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/dataflow/ProprietaryTest.scala
@@ -77,6 +77,17 @@ class ProprietaryTest extends InstrumentSequenceTestBase[Flamingos2, SeqConfigFl
     doTest(PUBLIC, 12, 0)
   }
 
+  // REL-3926
+  @Test def testProgramCal(): Unit = {
+    val o2 = addSeqComponent(getInstSeqComp, SeqRepeatObserve.SP_TYPE)
+    o2.dataObject = new SeqRepeatObserve <| (_.setObsClass(ObsClass.PROG_CAL))
+
+    val o3 = addSeqComponent(getInstSeqComp, SeqRepeatObserve.SP_TYPE)
+    o3.dataObject = new SeqRepeatObserve <| (_.setObsClass(ObsClass.SCIENCE))
+
+    doTest(PUBLIC, 12, 0, 12)
+  }
+
   @Test def testDefaultPeriods(): Unit =
     ProgramType.All.foreach { pt =>
       val pid = pt.isScience ? s"GS-2015B-${pt.abbreviation}-1" | s"GS-${pt.abbreviation}20150102"


### PR DESCRIPTION
Program calibrations should henceforth have no proprietary period.  To make this more clear, I replaced `shouldChargeProgram` (which included program calibrations naturally) with `respectsProprietaryPeriod`.