### PR TITLE
Catalog URL update for testing

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -190,7 +190,13 @@ trait RemoteCallBackend { this: CachedBackend =>
 
 case object ConeSearchBackend extends CachedBackend with RemoteCallBackend {
   val instance = this
-  override val catalogUrls = NonEmptyList(new URL("http://gscatalog.gemini.edu"), new URL("http://gncatalog.gemini.edu"))
+
+  override val catalogUrls: NonEmptyList[URL] =
+    NonEmptyList(
+//      new URL("http://gscatalog.gemini.edu"),
+//      new URL("http://gncatalog.gemini.edu")
+      new URL("http://mkocatalog-lv2.hi.gemini.edu")
+    )
 
   private def format(a: Angle)= f"${a.toDegrees}%4.03f"
 


### PR DESCRIPTION
Updates the non-GAIA Gemini catalog URL to a test server version.  It turns out that the addition of GAIA brings with it an updated catalog server in general which impacts all catalogs.  In this version, catalogs (and AGS) will require the VPN or be inside the firewall.  Before the release, another PR will need to be made going back to the public server address.