### PR TITLE
REL-3913: remove the 'r' from rollover semester

### DIFF
--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/QueueProgramStatusExternalTable.java
@@ -144,7 +144,7 @@ public final class QueueProgramStatusExternalTable extends AbstractTable {
     // 2004A => [r05A]
     private static String getRollover(final Semester semester) {
         return String.format(
-                "[r%s]",
+                "[%s]",
                 RolloverPeriod.beginning(semester).endSemester().toShortString()
         );
     }


### PR DESCRIPTION
Rollover is now called "persistent" in official documentation so 'r' doesn't correspond.  The request then was to remove 'r' from the rollover semester in reports and leave it at, for example, `[21B]` so that it survives the next name change.