### PR TITLE
REL-3924: switch all the catalogs to VO Table 1.3

### DIFF
--- a/bundle/edu.gemini.ags/src/test/resources/beta_pictoris.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/beta_pictoris.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/beta_pictoris_shifted.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/beta_pictoris_shifted.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/f2_oiwfs.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/f2_oiwfs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/f2_pwfs2.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/f2_pwfs2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gems_TYC_8345_1155_1.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gems_TYC_8345_1155_1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gems_bpm_37093.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gems_bpm_37093.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gems_m6.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gems_m6.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gems_pal1.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gems_pal1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gems_rel2941.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gems_rel2941.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gems_rel2941_2.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gems_rel2941_2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.2.4
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gems_sn1987A.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gems_sn1987A.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gemscatalogresultsquery.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gemscatalogresultsquery.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gemsstrategyquery.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gemsstrategyquery.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gemsvotablecatalogquery.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gemsvotablecatalogquery.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gmosn_oiwfs.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gmosn_oiwfs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gmosn_pwfs2.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gmosn_pwfs2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gmoss_oiwfs.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gmoss_oiwfs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gmoss_pwfs2.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gmoss_pwfs2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gnirs_1.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gnirs_1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/gnirs_2.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/gnirs_2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/mascotquery.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/mascotquery.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/ngs2_mag.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/ngs2_mag.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.2.4
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/niri_pwfs1.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/niri_pwfs1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/niri_pwfs2.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/niri_pwfs2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/ocsadv-245-lgs.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/ocsadv-245-lgs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.ags/src/test/resources/ocsadv245.xml
+++ b/bundle/edu.gemini.ags/src/test/resources/ocsadv245.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -27,7 +27,7 @@ sealed abstract class CatalogName(val id: String, val displayName: String) exten
     MagnitudeBand.UC
 
   def voTableVersion: VersionToken =
-    VersionToken.unsafeFromIntegers(1, 2)
+    VersionToken.unsafeFromIntegers(1, 3)
 
 }
 
@@ -63,9 +63,6 @@ object CatalogName {
 
     override val rBand: MagnitudeBand =
       MagnitudeBand.R
-
-    override val voTableVersion: VersionToken =
-      VersionToken.unsafeFromIntegers(1, 3)
 
   }
 

--- a/bundle/edu.gemini.catalog/src/test/resources/fmag.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/fmag.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.catalog/src/test/resources/simbad-J000008.13.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/simbad-J000008.13.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.2" version="1.2">
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3" version="1.3">
 <DEFINITIONS>
 <COOSYS ID="COOSYS" equinox="2000" epoch="J2000" system="ICRS"/>
 </DEFINITIONS>

--- a/bundle/edu.gemini.catalog/src/test/resources/simbad_hip43018.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/simbad_hip43018.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.2" version="1.2">
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3" version="1.3">
 <DEFINITIONS>
 <COOSYS ID="COOSYS" equinox="2000" epoch="J2000" system="ICRS"/>
 </DEFINITIONS>

--- a/bundle/edu.gemini.catalog/src/test/resources/sloan.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/sloan.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.catalog/src/test/resources/votable-non-validating.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/votable-non-validating.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.2.4
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <resource type="results">
   <TABLE>
    <FIELD ID="gmag_err" datatype="double" name="gmag_err" ucd="stat.error;phot.mag;em.opt.g"/>

--- a/bundle/edu.gemini.catalog/src/test/resources/votable-ppmxl-proper-motion.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/votable-ppmxl-proper-motion.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.catalog/src/test/resources/votable-ppmxl.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/votable-ppmxl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.catalog/src/test/resources/votable-ucac4.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/votable-ucac4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.3.2
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="jmag" datatype="double" name="jmag" ucd="phot.mag;em.IR.J"/>

--- a/bundle/edu.gemini.catalog/src/test/resources/votable-unknown.xml
+++ b/bundle/edu.gemini.catalog/src/test/resources/votable-unknown.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 0.2.4
      http://www.astropy.org/ -->
-<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.2">
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <FIELD ID="gmag_err" datatype="double" name="gmag_err" ucd="stat.error;phot.mag;em.opt.g"/>


### PR DESCRIPTION
Along with GAIA all the catalogs have been updated in the catalog server.  To make it work we need to match the VO Table version being served or else the output doesn't validate.