### PR TITLE
REL-3924: Prepare for 2021B

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -26,9 +26,6 @@ sealed abstract class CatalogName(val id: String, val displayName: String) exten
   def rBand: MagnitudeBand =
     MagnitudeBand.UC
 
-  def voTableVersion: VersionToken =
-    VersionToken.unsafeFromIntegers(1, 3)
-
 }
 
 object CatalogName {

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -193,9 +193,8 @@ case object ConeSearchBackend extends CachedBackend with RemoteCallBackend {
 
   override val catalogUrls: NonEmptyList[URL] =
     NonEmptyList(
-//      new URL("http://gscatalog.gemini.edu"),
-//      new URL("http://gncatalog.gemini.edu")
-      new URL("http://mkocatalog-lv2.hi.gemini.edu")
+      new URL("http://gscatalog.gemini.edu"),
+      new URL("http://gncatalog.gemini.edu")
     )
 
   private def format(a: Angle)= f"${a.toDegrees}%4.03f"

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -4,14 +4,19 @@ import java.io.{ByteArrayInputStream, InputStream}
 import edu.gemini.catalog.api.CatalogName
 import edu.gemini.spModel.core._
 
+import java.util.logging.Logger
+
 import scala.collection.immutable
 import scala.io.Source
+import scala.util.matching.Regex
 import scala.xml.XML
 import scala.xml.Node
 import scalaz._
 import Scalaz._
 
 object VoTableParser extends VoTableParser {
+  private val LOG: Logger = Logger.getLogger(this.getClass.getName)
+
   type CatalogResult = CatalogProblem \/ ParsedVoResource
 
   // by band
@@ -32,12 +37,47 @@ object VoTableParser extends VoTableParser {
   val UCD_MAG        = UcdWord("phot.mag")
   val STAT_ERR       = UcdWord("stat.error")
 
-  private def validate(catalogName: CatalogName, xmlText: String): CatalogProblem \/ Unit =
+  private val MinVersion: VersionToken = VersionToken.unsafeFromIntegers(1, 2)
+  private val MaxVersion: VersionToken = VersionToken.unsafeFromIntegers(1, 3)
+
+  private val VersionRegex: Regex =
+    """version="(\d+\.\d+)"""".r.unanchored
+
+  private val VoTableHeader: Regex =
+    """<VOTABLE([^>]*)>""".r.unanchored
+
+  private def extractHeader(catalogName: CatalogName, xmlText: String): CatalogProblem \/ String =
+    xmlText match {
+      case VoTableHeader(header) =>
+        \/-(header)
+      case _                    =>
+        LOG.warning(s"Couldn't find VOTABLE header in $catalogName catalog output.")
+        -\/(ValidationError(catalogName))
+    }
+
+  private def parseVersion(catalogName: CatalogName, header: String): CatalogProblem \/ VersionToken =
+    header match {
+      case VersionRegex(versionToken) =>
+        VersionToken.parse(versionToken).toRightDisjunction(ValidationError(catalogName))
+      case _                          =>
+        LOG.warning(s"Couldn't find version token in $catalogName catalog output.")
+        -\/(ValidationError(catalogName))
+    }
+
+  private def validateVersion(catalogName: CatalogName, version: VersionToken): CatalogProblem \/ Unit =
+    if (version.fallsInRange(MinVersion, MaxVersion))
+      \/-(())
+    else {
+      LOG.warning(s"$catalogName catalog returned unsupported version: ${version.format}")
+      -\/(ValidationError(catalogName))
+    }
+
+  private def versionedValidate(catalogName: CatalogName, xmlText: String, version: VersionToken): CatalogProblem \/ Unit =
     \/.fromTryCatchNonFatal {
       import javax.xml.transform.stream.StreamSource
       import javax.xml.validation.SchemaFactory
 
-      val xsd        = s"/votable-${catalogName.voTableVersion.format}.xsd"
+      val xsd        = s"/votable-${version.format}.xsd"
       val schemaLang = "http://www.w3.org/2001/XMLSchema"
       val factory    = SchemaFactory.newInstance(schemaLang)
       val schema     = factory.newSchema(new StreamSource(getClass.getResourceAsStream(xsd)))
@@ -45,6 +85,14 @@ object VoTableParser extends VoTableParser {
 
       validator.validate(new StreamSource(new ByteArrayInputStream(xmlText.getBytes(java.nio.charset.Charset.forName("UTF-8")))))
     }.leftMap(_ => ValidationError(catalogName))
+
+  private def validate(catalogName: CatalogName, xmlText: String): CatalogProblem \/ Unit =
+    for {
+      h <- extractHeader(catalogName, xmlText)
+      v <- parseVersion(catalogName, h)
+      _ <- validateVersion(catalogName, v)
+      _ <- versionedValidate(catalogName, xmlText, v)
+    } yield ()
 
   /**
    * parse takes an input stream and attempts to read the xml content and convert it to a VoTable resource

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/VersionToken.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/VersionToken.scala
@@ -19,6 +19,9 @@ sealed abstract case class VersionToken private (toNel: NonEmptyList[Int]) {
   def format: String =
     toNel.list.toList.mkString(".")
 
+  def fallsInRange(min: VersionToken, max: VersionToken): Boolean =
+    min <= this && this <= max
+
 }
 
 object VersionToken {

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -487,7 +487,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
     lazy val catalogBox: ComboBox[CatalogName] with TextRenderer[CatalogName] {
       def text(a: CatalogName): String
-    } = new ComboBox(List[CatalogName](UCAC4, PPMXL, GaiaEsa, GaiaGemini)) with TextRenderer[CatalogName] {
+    } = new ComboBox(List[CatalogName](UCAC4, PPMXL, GaiaEsa/*, GaiaGemini*/)) with TextRenderer[CatalogName] {
 
       override def text(a: CatalogName): String =
         Option(a).foldMap(_.displayName)


### PR DESCRIPTION
We're leaving GAIA @ Gemini and the new catalog server for December.  To facilitate the upgrade at a later date this PR:

* Accepts either VO table version 1.2 or 1.3
* Removes GAIA @ Gemini from the manual catalog search list only