### PR TITLE
REL-3955: initialization issue in DHS_WRITE_TIME

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -851,7 +851,7 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         times.add(CategorizedTime.fromSeconds(Category.READOUT, mode.readoutTimeSec()));
         times.add(CategorizedTime.fromSeconds(Category.EXPOSURE, ExposureCalculator.instance.exposureTimeSec(cur)));
 
-        times.add(DHS_WRITE_TIME); // REL-1678
+        times.add(getDhsWriteTime()); // REL-1678
 
         return CommonStepCalculator.instance.calc(cur, prev).addAll(times);
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -1331,7 +1331,7 @@ public abstract class InstGmosCommon<
         double readoutTime = GmosReadoutTime.getReadoutOverhead(cur, getCustomROIs());
         times.add(CategorizedTime.fromSeconds(Category.READOUT, readoutTime));
 
-        times.add(DHS_WRITE_TIME);
+        times.add(getDhsWriteTime());
 
         return CommonStepCalculator.instance.calc(cur, prev).addAll(times);
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
@@ -2297,7 +2297,7 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
         final double totalExposureTime = rawExposureTime * coadds;
         times.add(CategorizedTime.fromSeconds(Category.EXPOSURE, totalExposureTime));
 
-        times.add(DHS_WRITE_TIME); // REL-1678
+        times.add(getDhsWriteTime()); // REL-1678
 
         return CommonStepCalculator.instance.calc(cur, prev).addAll(times);
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
@@ -821,8 +821,8 @@ public final class Gsaoi extends SPInstObsComp
         // Add readout overhead
         int lowNoiseReads = getNonDestructiveReads();
 
-        times.add(CategorizedTime.fromSeconds(Category.READOUT, readout(coadds, lowNoiseReads)).add(- DHS_WRITE_TIME.time)); // REL-1678
-        times.add(DHS_WRITE_TIME); // REL-1678
+        times.add(CategorizedTime.fromSeconds(Category.READOUT, readout(coadds, lowNoiseReads)).add(- getDhsWriteTime().time)); // REL-1678
+        times.add(getDhsWriteTime()); // REL-1678
 
         return commonGroup(cur, prev).addAll(times);
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/InstNIFS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/InstNIFS.java
@@ -178,7 +178,7 @@ public final class InstNIFS extends SPInstObsComp implements PropertyProvider, G
         final double readoutTime      = (readMode.getMinExp() + COADD_CONSTANT) * coadds;
         final CategorizedTime readOut = CategorizedTime.fromSeconds(Category.READOUT, readoutTime);
 
-        return CommonStepCalculator.instance.calc(cur, prev).addAll(expTime, readOut, DHS_WRITE_TIME);
+        return CommonStepCalculator.instance.calc(cur, prev).addAll(expTime, readOut, getDhsWriteTime());
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
@@ -436,7 +436,8 @@ public abstract class SPInstObsComp extends AbstractDataObject {
         );
     }
 
-    public final PlannedTime.CategorizedTime DHS_WRITE_TIME =
-        DHS_WRITE_TIMES.get(getInstrument());
+    public final PlannedTime.CategorizedTime getDhsWriteTime() {
+        return DHS_WRITE_TIMES.get(getInstrument());
+    }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
@@ -15,6 +15,7 @@ import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.util.Angle;
 
 import java.beans.PropertyDescriptor;
+import java.io.IOException;
 import java.time.Duration;
 import java.text.NumberFormat;
 import java.util.*;
@@ -434,6 +435,21 @@ public abstract class SPInstObsComp extends AbstractDataObject {
            .stream()
            .collect(Collectors.toMap(Map.Entry::getKey, e -> PlannedTime.CategorizedTime.apply(PlannedTime.Category.DHS_WRITE, e.getValue().toMillis())))
         );
+    }
+
+    // REL-3955: Initialization issues prompted a switch to add and use
+    // 'getDhsWriteTime()` below instead of referring to a public field
+    // DHS_WRITE_TIME. The class has a `serialVersionUID` and not-updated
+    // clients will be expecting a DHS_WRITE_TIME field. Adding a `readObject`
+    // to initialize the value for not-updated clients.
+    private PlannedTime.CategorizedTime DHS_WRITE_TIME;
+
+    private void readObject(java.io.ObjectInputStream in)
+        throws IOException, ClassNotFoundException {
+
+        in.defaultReadObject();
+
+        DHS_WRITE_TIME = getDhsWriteTime();
     }
 
     public final PlannedTime.CategorizedTime getDhsWriteTime() {

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/flamingos2/PlannedTimeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/flamingos2/PlannedTimeTest.java
@@ -84,7 +84,7 @@ public final class PlannedTimeTest {
 
     @Test
     public void testEmptySequence() throws Exception {
-        final double readout = f2DataObject.getReadMode().readoutTimeSec() + f2DataObject.DHS_WRITE_TIME.timeSeconds();
+        final double readout = f2DataObject.getReadMode().readoutTimeSec() + f2DataObject.getDhsWriteTime().timeSeconds();
 
         // Imaging setup time.
         verify(Flamingos2.getImagingSetup(obs).getSeconds() + readout);
@@ -99,7 +99,7 @@ public final class PlannedTimeTest {
     @Test
     public void testImagingSetup() throws Exception {
         // Defaulting to PWFS2
-        final double readout = f2DataObject.getReadMode().readoutTimeSec() + f2DataObject.DHS_WRITE_TIME.timeSeconds();
+        final double readout = f2DataObject.getReadMode().readoutTimeSec() + f2DataObject.getDhsWriteTime().timeSeconds();
 
         // Imaging setup time.
         verify(Flamingos2.getImagingSetup(obs).getSeconds() + readout);
@@ -160,7 +160,7 @@ public final class PlannedTimeTest {
         f2SeqDataObject.setSysConfig(sc);
         f2SeqComponent.setDataObject(f2SeqDataObject);
 
-        final double base = Flamingos2.getImagingSetup(obs).getSeconds() + 60 + f2DataObject.DHS_WRITE_TIME.timeSeconds();
+        final double base = Flamingos2.getImagingSetup(obs).getSeconds() + 60 + f2DataObject.getDhsWriteTime().timeSeconds();
 
         for (Flamingos2.ReadMode mode : Flamingos2.ReadMode.values()) {
             final Flamingos2 obj = (Flamingos2) f2ObsComponent.getDataObject();
@@ -183,7 +183,7 @@ public final class PlannedTimeTest {
         // Account for setup, exposure time, and readout time for the 2 steps
         final double time = Flamingos2.getSpectroscopySetup().getSeconds() + 60.0 * 2
                 + f2DataObject.getReadMode().readoutTimeSec() * 2
-                + f2DataObject.DHS_WRITE_TIME.timeSeconds() * 2;
+                + f2DataObject.getDhsWriteTime().timeSeconds() * 2;
 
         // Account for the change
         verify(time + overhead);
@@ -235,7 +235,7 @@ public final class PlannedTimeTest {
         // Account for setup, exposure time, and readout time for the 2 steps.
         final double time = Flamingos2.getSpectroscopySetup().getSeconds() + 60.0 * 2
                 + f2DataObject.getReadMode().readoutTimeSec() * 2
-                + f2DataObject.DHS_WRITE_TIME.timeSeconds() * 2;
+                + f2DataObject.getDhsWriteTime().timeSeconds() * 2;
 
         // Figure out the overhead for the change.
         double over = Flamingos2.getFpuChangeOverheadSec();
@@ -264,7 +264,7 @@ public final class PlannedTimeTest {
         // Account for setup, exposure time, and readout time for the 3 steps.
         final double time = Flamingos2.getSpectroscopySetup().getSeconds() + 60.0 * 3
                 + f2DataObject.getReadMode().readoutTimeSec() * 3
-                + f2DataObject.DHS_WRITE_TIME.timeSeconds() * 3;
+                + f2DataObject.getDhsWriteTime().timeSeconds() * 3;
 
         // Figure out the overhead for the single filter change.
         final double over = Flamingos2.getFilterChangeOverheadSec();

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gpi/PlannedTimeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/gpi/PlannedTimeTest.java
@@ -86,7 +86,7 @@ public final class PlannedTimeTest {
         verify(Gpi.getImagingSetup().getSeconds() +
                 Gpi.READOUT_PER_EXPOSURE_MS/1000.0 +
                 Gpi.READOUT_OVERHEAD_SEC +
-                gpiDataObject.DHS_WRITE_TIME.timeSeconds());
+                gpiDataObject.getDhsWriteTime().timeSeconds());
     }
 
     /*
@@ -145,7 +145,7 @@ public final class PlannedTimeTest {
         double time = Gpi.getImagingSetup().getSeconds();
         time += (EXP_TIME + Gpi.READOUT_PER_EXPOSURE_MS/1000.0) * 2;
         time += Gpi.READOUT_OVERHEAD_SEC * 2;
-        time += gpiDataObject.DHS_WRITE_TIME.timeSeconds() * 2;
+        time += gpiDataObject.getDhsWriteTime().timeSeconds() * 2;
 
         // Account for the change
         verify(time + overhead);
@@ -187,7 +187,7 @@ public final class PlannedTimeTest {
 
         time += (Gpi.READOUT_PER_EXPOSURE_MS/1000.0 + EXP_TIME) * 2;
         time += Gpi.READOUT_OVERHEAD_SEC * 2;
-        time += gpiDataObject.DHS_WRITE_TIME.timeSeconds() * 2;
+        time += gpiDataObject.getDhsWriteTime().timeSeconds() * 2;
 
         double over = Gpi.MULTI_CHANGE_OVERHEAD_SECS;
         verify(time + over);
@@ -211,7 +211,7 @@ public final class PlannedTimeTest {
 
         time += (Gpi.READOUT_PER_EXPOSURE_MS/1000.0 + EXP_TIME) * 3;
         time += Gpi.READOUT_OVERHEAD_SEC * 3;
-        time += gpiDataObject.DHS_WRITE_TIME.timeSeconds() * 3;
+        time += gpiDataObject.getDhsWriteTime().timeSeconds() * 3;
 
         double overhead = 2 * Gpi.HALFWAVE_PLATE_CHANGE_OVERHEAD_SECS;
         verify(time + overhead);
@@ -236,7 +236,7 @@ public final class PlannedTimeTest {
 
         time += (Gpi.READOUT_PER_EXPOSURE_MS/1000.0 + EXP_TIME) * 2;
         time += Gpi.READOUT_OVERHEAD_SEC * 2;
-        time += gpiDataObject.DHS_WRITE_TIME.timeSeconds() * 2;
+        time += gpiDataObject.getDhsWriteTime().timeSeconds() * 2;
 
         // The filter change dominates the half wave plate angle change
         double overhead = Gpi.SINGLE_CHANGE_OVERHEAD_SECS;
@@ -264,7 +264,7 @@ public final class PlannedTimeTest {
 
         time += (Gpi.READOUT_PER_EXPOSURE_MS/1000.0 + EXP_TIME) * 3;
         time += Gpi.READOUT_OVERHEAD_SEC * 3;
-        time += gpiDataObject.DHS_WRITE_TIME.timeSeconds() * 3;
+        time += gpiDataObject.getDhsWriteTime().timeSeconds() * 3;
 
         double over = Gpi.SINGLE_CHANGE_OVERHEAD_SECS;
         verify(time + over);
@@ -297,7 +297,7 @@ public final class PlannedTimeTest {
         double time = Gpi.getImagingSetup().getSeconds();
         time += (2.0 + Gpi.READOUT_PER_EXPOSURE_MS/1000.0) * 5;
         time += Gpi.READOUT_OVERHEAD_SEC;
-        time += gpiDataObject.DHS_WRITE_TIME.timeSeconds();
+        time += gpiDataObject.getDhsWriteTime().timeSeconds();
         time += GcalStepCalculator.SCIENCE_FOLD_MOVE_TIME/1000.0;
 
         verify(time);

--- a/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nifs/PlannedTimeTest.java
+++ b/bundle/edu.gemini.pot/src/test/java/edu/gemini/spModel/gemini/nifs/PlannedTimeTest.java
@@ -30,7 +30,7 @@ public class PlannedTimeTest extends InstrumentSequenceTestBase<InstNIFS, SeqCon
 
         final double base = getInstDataObj().getSetupTime(getObs()).getSeconds()
                 + 100.0 + InstNIFS.COADD_CONSTANT
-                + getInstDataObj().DHS_WRITE_TIME.timeSeconds();
+                + getInstDataObj().getDhsWriteTime().timeSeconds();
 
         for (final ReadMode mode : ReadMode.values()) {
             getInstDataObj().setReadMode(mode);
@@ -52,7 +52,7 @@ public class PlannedTimeTest extends InstrumentSequenceTestBase<InstNIFS, SeqCon
 
         final double base = getInstDataObj().getSetupTime(getObs()).getSeconds();
         final double coaddConst = InstNIFS.COADD_CONSTANT;
-        final double dhs = getInstDataObj().DHS_WRITE_TIME.timeSeconds();
+        final double dhs = getInstDataObj().getDhsWriteTime().timeSeconds();
 
         final double exp1 = dhs + 2*(88.0 + ReadMode.FAINT_OBJECT_SPEC.getMinExp()  + coaddConst);
         final double exp2 = dhs + 3*(22.0 + ReadMode.MEDIUM_OBJECT_SPEC.getMinExp() + coaddConst);
@@ -75,7 +75,7 @@ public class PlannedTimeTest extends InstrumentSequenceTestBase<InstNIFS, SeqCon
         final double base = getInstDataObj().getSetupTime(getObs()).getSeconds();
 
         final double minExp = getInstDataObj().getReadMode().getMinExp();
-        final double dhs = getInstDataObj().DHS_WRITE_TIME.timeSeconds();
+        final double dhs = getInstDataObj().getDhsWriteTime().timeSeconds();
         final double exp1 = dhs + 3*(10.0 + minExp + InstNIFS.COADD_CONSTANT);
         final double exp2 = dhs + 5*(12.0 + minExp + InstNIFS.COADD_CONSTANT);
 
@@ -97,7 +97,7 @@ public class PlannedTimeTest extends InstrumentSequenceTestBase<InstNIFS, SeqCon
         getObserveSeqComp().setDataObject(sro);
 
         final double base = getInstDataObj().getSetupTime(getObs()).getSeconds();
-        final double dhs = getInstDataObj().DHS_WRITE_TIME.timeSeconds();
+        final double dhs = getInstDataObj().getDhsWriteTime().timeSeconds();
         final double common = 100.0 + dhs + InstNIFS.COADD_CONSTANT;
         final double bright = common + ReadMode.BRIGHT_OBJECT_SPEC.getMinExp();
         final double faint  = common + ReadMode.FAINT_OBJECT_SPEC.getMinExp();


### PR DESCRIPTION
Changes a constant to a method call to solve an initialization issue.  In particular, a `static` block was not being initialized before referenced in `SPInstObsComp`.