### PR TITLE
WIP:  REL-3580 - ITC support for exact IQ and CC

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
@@ -10,7 +10,9 @@ final case class ObservingConditions(
                       cc: CloudCover,
                       wv: WaterVapor,
                       sb: SkyBackground,
-                      airmass: Double)
+                      airmass: Double,
+                      exactiq: Double,
+                      exactcc: Double)
 
 // ==== Source definition
 final case class SourceDefinition(

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -100,6 +100,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2021-Mar-09</footer>
+<footer>Last updated 2021-Aug-23</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
@@ -322,65 +322,64 @@
                 <td colspan="4">Wavefront sensor for tip-tilt compensation: PWFS <i>(only)</i>
                     <input value="PWFS" name="Type" type="hidden"></td>
 
-    </tr>
-    <tr>
-      <td colspan="4">
-          <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
-      </td>
-    </tr>
-  </table>
-  <p>
-  &nbsp;
-  </p>
+            </tr>
+            <tr>
+                <td colspan="4">
+                    <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
+                </td>
+            </tr>
+        </table>
+        <p>
+            &nbsp;
+        </p>
 
-<!-- Observing conditions definition-->
-  <p>
-      <font color="#FF0000"><b>Observing condition constraints</b></font>
-  </p>
-  <table border="0" width="100%" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" cellpadding="6" cellspacing="0">
-      <tbody>
-    <tr>
-      <td colspan="6">Please read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory notes</a>
-          for the meaning of the percentiles and to ensure that your selected conditions
-          are appropriate for the observing wavelength. Further details are
-          available on the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10781#ImageQuality','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">observing condition constraints</a> pages. </td>
-    </tr>
-      <tr>
-          <td><b>Image Quality:</b></td>
-          <td><input name="ImageQuality" value="PERCENT_20" type="radio" /> 20%/Best</td>
-          <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
-          <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked/> 85%/Poor</td>
-          <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
-          <td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​</td>
-      </tr>
-      <tr>
-          <td><b>Cloud Cover:</b></td>
-          <td><input name="CloudCover" value="PERCENT_50" type="radio" /> 50%/Clear</td>
-          <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
-          <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
-          <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
-		  <td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
-      </tr>
-      <tr>
-          <td><b>Water Vapor:</b></td>
-          <td><input name="WaterVapor" value="PERCENT_20" type="radio" /> 20%/Low</td>
-          <td><input name="WaterVapor" value="PERCENT_50" type="radio" /> 50%/Median</td>
-          <td><input name="WaterVapor" value="PERCENT_80" type="radio" /> 80%/High</td>
-          <td><input name="WaterVapor" value="ANY"        type="radio" checked /> Any</td>
-      </tr>
-      <tr>
-          <td><b>Sky Background:</b></td>
-          <td><input name="SkyBackground" value="PERCENT_20" type="radio" /> 20%/Darkest</td>
-          <td><input name="SkyBackground" value="PERCENT_50" type="radio" /> 50%/Dark</td>
-          <td><input name="SkyBackground" value="PERCENT_80" type="radio" checked /> 80%/Grey</td>
-          <td><input name="SkyBackground" value="ANY"        type="radio" /> Any/Bright</td>
-      </tr>
-      <tr>
-          <td><b>Airmass:</b></td>
-          <td><input name="Airmass" value="1.2" type="radio" /> &lt;1.2</td>
-          <td><input name="Airmass" value="1.5" type="radio" checked /> 1.5</td>
-          <td><input name="Airmass" value="2.0" type="radio" /> 2.0</td>
-      </tr>
+        <!-- Observing conditions definition-->
+        <p>
+            <font color="#FF0000"><b>Observing condition constraints</b></font>
+        </p>
+        <table border="0" width="100%" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" cellpadding="6" cellspacing="0">
+            <tbody>
+            <tr>
+                <td colspan="6">Please read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory notes</a>
+                    for the meaning of the percentiles and to ensure that your selected conditions
+                    are appropriate for the observing wavelength. Further details are
+                    available on the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10781#ImageQuality','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">observing condition constraints</a> pages. </td>
+            </tr>
+            <tr>
+                <td><b>Image Quality:</b></td>
+                <td><input name="ImageQuality" value="PERCENT_20" type="radio" /> 20%/Best</td>
+                <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
+                <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked/> 85%/Poor</td>
+                <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+                <td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="0.8" size="4"> arcsec</td>
+            </tr>
+            <tr>
+                <td><b>Cloud Cover:</b></td>
+                <td><input name="CloudCover" value="PERCENT_50" type="radio" /> 50%/Clear</td>
+                <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
+                <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
+                <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+                <td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
+            </tr>
+            <tr>
+                <td><b>Water Vapor:</b></td>
+                <td><input name="WaterVapor" value="PERCENT_20" type="radio" /> 20%/Low</td>
+                <td><input name="WaterVapor" value="PERCENT_50" type="radio" /> 50%/Median</td>
+                <td><input name="WaterVapor" value="PERCENT_80" type="radio" /> 80%/High</td>
+                <td><input name="WaterVapor" value="ANY"        type="radio" checked /> Any</td>
+            </tr>
+            <tr>
+                <td><b>Sky Background:</b></td>
+                <td><input name="SkyBackground" value="PERCENT_20" type="radio" /> 20%/Darkest</td>
+                <td><input name="SkyBackground" value="PERCENT_50" type="radio" /> 50%/Dark</td>
+                <td><input name="SkyBackground" value="PERCENT_80" type="radio" checked /> 80%/Grey</td>
+                <td><input name="SkyBackground" value="ANY"        type="radio" /> Any/Bright</td>
+            </tr>
+            <tr>
+                <td><b>Airmass:</b></td>
+                <td><input name="Airmass" value="1.2" type="radio" /> &lt;1.2</td>
+                <td><input name="Airmass" value="1.5" type="radio" checked /> 1.5</td>
+                <td><input name="Airmass" value="2.0" type="radio" /> 2.0</td>
             </tr>
 
             <tr>
@@ -401,24 +400,6 @@
         <table border="0" width="100%" height="70" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif"
                cellpadding="6" cellspacing="0">
             <tr>
-    <tr>
-      <td colspan="6">
-          <p align="right">
-              <input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
-          </p>
-      </td>
-    </tr>
-      </tbody>
-  </table>
-  <p>
-  &nbsp;
-  </p>
-
-<!-- Observation method and output control-->
-  <p><font color="#FF0000"><b>Details of observation</b></font></p>
-  <table border="0" width="100%" height="70" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif"
-  cellpadding="6" cellspacing="0">
-    <tr>
 
                 <td height="50" valign="bottom" colspan="3"><b>Calculation method:</b><i><font size="-1">(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</font></i><br>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
@@ -322,6 +322,65 @@
                 <td colspan="4">Wavefront sensor for tip-tilt compensation: PWFS <i>(only)</i>
                     <input value="PWFS" name="Type" type="hidden"></td>
 
+    </tr>
+    <tr>
+      <td colspan="4">
+          <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
+      </td>
+    </tr>
+  </table>
+  <p>
+  &nbsp;
+  </p>
+
+<!-- Observing conditions definition-->
+  <p>
+      <font color="#FF0000"><b>Observing condition constraints</b></font>
+  </p>
+  <table border="0" width="100%" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" cellpadding="6" cellspacing="0">
+      <tbody>
+    <tr>
+      <td colspan="6">Please read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory notes</a>
+          for the meaning of the percentiles and to ensure that your selected conditions
+          are appropriate for the observing wavelength. Further details are
+          available on the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10781#ImageQuality','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">observing condition constraints</a> pages. </td>
+    </tr>
+      <tr>
+          <td><b>Image Quality:</b></td>
+          <td><input name="ImageQuality" value="PERCENT_20" type="radio" /> 20%/Best</td>
+          <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
+          <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked/> 85%/Poor</td>
+          <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+          <td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​</td>
+      </tr>
+      <tr>
+          <td><b>Cloud Cover:</b></td>
+          <td><input name="CloudCover" value="PERCENT_50" type="radio" /> 50%/Clear</td>
+          <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
+          <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
+          <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+		  <td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
+      </tr>
+      <tr>
+          <td><b>Water Vapor:</b></td>
+          <td><input name="WaterVapor" value="PERCENT_20" type="radio" /> 20%/Low</td>
+          <td><input name="WaterVapor" value="PERCENT_50" type="radio" /> 50%/Median</td>
+          <td><input name="WaterVapor" value="PERCENT_80" type="radio" /> 80%/High</td>
+          <td><input name="WaterVapor" value="ANY"        type="radio" checked /> Any</td>
+      </tr>
+      <tr>
+          <td><b>Sky Background:</b></td>
+          <td><input name="SkyBackground" value="PERCENT_20" type="radio" /> 20%/Darkest</td>
+          <td><input name="SkyBackground" value="PERCENT_50" type="radio" /> 50%/Dark</td>
+          <td><input name="SkyBackground" value="PERCENT_80" type="radio" checked /> 80%/Grey</td>
+          <td><input name="SkyBackground" value="ANY"        type="radio" /> Any/Bright</td>
+      </tr>
+      <tr>
+          <td><b>Airmass:</b></td>
+          <td><input name="Airmass" value="1.2" type="radio" /> &lt;1.2</td>
+          <td><input name="Airmass" value="1.5" type="radio" checked /> 1.5</td>
+          <td><input name="Airmass" value="2.0" type="radio" /> 2.0</td>
+      </tr>
             </tr>
             <tr>
                 <td colspan="4">
@@ -398,6 +457,24 @@
         <table border="0" width="100%" height="70" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif"
                cellpadding="6" cellspacing="0">
             <tr>
+    <tr>
+      <td colspan="6">
+          <p align="right">
+              <input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
+          </p>
+      </td>
+    </tr>
+      </tbody>
+  </table>
+  <p>
+  &nbsp;
+  </p>
+
+<!-- Observation method and output control-->
+  <p><font color="#FF0000"><b>Details of observation</b></font></p>
+  <table border="0" width="100%" height="70" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif"
+  cellpadding="6" cellspacing="0">
+    <tr>
 
                 <td height="50" valign="bottom" colspan="3"><b>Calculation method:</b><i><font size="-1">(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</font></i><br>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
@@ -382,62 +382,6 @@
           <td><input name="Airmass" value="2.0" type="radio" /> 2.0</td>
       </tr>
             </tr>
-            <tr>
-                <td colspan="4">
-                    <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
-                </td>
-            </tr>
-        </table>
-        <p>
-            &nbsp;
-        </p>
-
-        <!-- Observing conditions definition-->
-        <p>
-            <font color="#FF0000"><b>Observing condition constraints</b></font>
-        </p>
-        <table border="0" width="100%" background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" cellpadding="6" cellspacing="0">
-            <tbody>
-            <tr>
-                <td colspan="6">Please read the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">explanatory notes</a>
-                    for the meaning of the percentiles and to ensure that your selected conditions
-                    are appropriate for the observing wavelength. Further details are
-                    available on the <a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10781#ImageQuality','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">observing condition constraints</a> pages. </td>
-            </tr>
-            <tr>
-                <td><b>Image Quality:</b></td>
-                <td><input name="ImageQuality" value="PERCENT_20" type="radio" /> 20%/Best</td>
-                <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
-                <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked/> 85%/Poor</td>
-                <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
-            </tr>
-            <tr>
-                <td><b>Cloud Cover:</b></td>
-                <td><input name="CloudCover" value="PERCENT_50" type="radio" /> 50%/Clear</td>
-                <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
-                <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
-                <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
-            </tr>
-            <tr>
-                <td><b>Water Vapor:</b></td>
-                <td><input name="WaterVapor" value="PERCENT_20" type="radio" /> 20%/Low</td>
-                <td><input name="WaterVapor" value="PERCENT_50" type="radio" /> 50%/Median</td>
-                <td><input name="WaterVapor" value="PERCENT_80" type="radio" /> 80%/High</td>
-                <td><input name="WaterVapor" value="ANY"        type="radio" checked /> Any</td>
-            </tr>
-            <tr>
-                <td><b>Sky Background:</b></td>
-                <td><input name="SkyBackground" value="PERCENT_20" type="radio" /> 20%/Darkest</td>
-                <td><input name="SkyBackground" value="PERCENT_50" type="radio" /> 50%/Dark</td>
-                <td><input name="SkyBackground" value="PERCENT_80" type="radio" checked /> 80%/Grey</td>
-                <td><input name="SkyBackground" value="ANY"        type="radio" /> Any/Bright</td>
-            </tr>
-            <tr>
-                <td><b>Airmass:</b></td>
-                <td><input name="Airmass" value="1.2" type="radio" /> &lt;1.2</td>
-                <td><input name="Airmass" value="1.5" type="radio" checked /> 1.5</td>
-                <td><input name="Airmass" value="2.0" type="radio" /> 2.0</td>
-            </tr>
 
             <tr>
                 <td colspan="6">

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -416,6 +416,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​</td>
             </tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>
@@ -423,6 +424,7 @@
                 <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
                 <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
                 <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+				<td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
             </tr>
             <tr>
                 <td><b>Water Vapor:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -416,7 +416,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
-				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec</td>
             </tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -513,19 +513,16 @@
 		<tbody>
 			<tr>
 				<td colspan="2" height="50" valign="bottom"><b>Calculation method:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no');return false">more info</a>)</span></i><br />
-
 				<i>Select calculation method (note: second method is not available for spectroscopy)</i></td>
 			</tr>
 			<tr>
 				<td><input value="s2n" name="calcMethod" checked="checked" type="radio" /></td>
 				<td>Total S/N ratio resulting from <input name="numExpA" size="5" value="1" type="text" />
 				exposures each having an exposure time of <input name="expTimeA" size="5" value="900" type="text" /> secs and with a fraction <input name="fracOnSourceA" size="4" value="1.0" type="text" /> of exposures that observe the source </td>
-
 			</tr>
 			<tr>
 				<td><input value="intTime" name="calcMethod" type="radio" /></td>
 				<td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" /> using an exposure time for each exposure of <input name="expTimeC" size="5" value="900" type="text" /> secs and with a fraction <input name="fracOnSourceC" size="4" value="1.0" type="text" /> of exposures that observe the source </td>
-
 			</tr>
 			<tr>
 				<td colspan="2" height="40" valign="bottom"><b>Telescope offset:</b><i><span>(<a href="#" onclick="window.open('https://www.gemini.edu/sciops/instruments/gmos','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -460,6 +460,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec</td>
             </tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>
@@ -467,6 +468,8 @@
                 <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
                 <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
                 <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+                <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+				<td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
             </tr>
             <tr>
                 <td><b>Water Vapor:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -468,7 +468,6 @@
                 <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
                 <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
                 <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
-                <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
 				<td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
             </tr>
             <tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -462,6 +462,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec</td>
             </tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>
@@ -469,6 +470,7 @@
                 <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
                 <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
                 <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+				<td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
             </tr>
             <tr>
                 <td><b>Water Vapor:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -466,13 +466,15 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
-            </tr>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec
+			</tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>
                 <td><input name="CloudCover" value="PERCENT_50" type="radio" /> 50%/Clear</td>
                 <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
                 <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
                 <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+				<td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
             </tr>
             <tr>
                 <td><b>Water Vapor:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -466,7 +466,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" checked /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
-				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="1.1" size="4"> arcsec</td>
 			</tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
@@ -406,6 +406,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" checked /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="0.8" size="4"> arcsec</td>
             </tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>
@@ -413,6 +414,7 @@
                 <td><input name="CloudCover" value="PERCENT_70" type="radio" /> 70%/Cirrus</td>
                 <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
                 <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+				<td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.0" size="4"> mag</td>
             </tr>
             <tr>
                 <td><b>Water Vapor:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -367,7 +367,8 @@
                 <td><input name="SkyBackground" value="PERCENT_20" type="radio" disabled /> 20%/Darkest</td>
                 <td><input name="SkyBackground" value="PERCENT_50" type="radio" disabled /> 50%/Dark</td>
                 <td><input name="SkyBackground" value="PERCENT_80" type="radio" disabled /> 80%/Grey</td>
-				<td colspan="2"><input name="SkyBackground" value="ANY" type="radio" checked /> Any/Bright (<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>explanatory notes</span></a>)</td>
+				<td colspan="2"><input name="SkyBackground" value="ANY" type="radio" checked /> Any/Bright
+					(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>explanatory notes</span></a>)</td>
             </tr>
             <tr>
                 <td><b>Airmass:</b></td>
@@ -394,21 +395,20 @@
 	</p>
 	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
 		<tbody>
-
 			<tr>
 				<td colspan="2" height="50" valign="bottom"><b>Calculation method:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i><br />
 				<i>Select the calculation method (note: second method is not available for spectroscopy)</i></td>
 			</tr>
 			<tr>
-				<td > <input value="s2n" name="calcMethod" checked="checked" type="radio" /><input name="numExpA" value="0" type="hidden" />
-				Total S/N ratio resulting from a total time of <input name="expTimeA" size="5" value="1800" type="text" /> secs and with a fraction <input name="fracOnSourceA" size="4" value="0.5" type="text" /> of exposures that observe the source (number of individual
-				exposures will be calculated from assumed frame time) </td>
-
+				<td> <input value="s2n" name="calcMethod" checked="checked" type="radio" /><input name="numExpA" value="0" type="hidden" /></td>
+				<td>Total S/N ratio resulting from a total time of <input name="expTimeA" size="5" value="1800" type="text" />
+					secs and with a fraction <input name="fracOnSourceA" size="4" value="0.5" type="text" />
+					of exposures that observe the source (number of individual exposures will be calculated from assumed frame time) </td>
 			</tr>
 			<tr>
-				<td > <input value="intTime" name="calcMethod" type="radio" /><input name="expTimeC" value="0" type="hidden" />
-				Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />  and with a fraction <input name="fracOnSourceC" size="4" value="0.5" type="text" /> of exposures that observe the source </td>
-
+				<td> <input value="intTime" name="calcMethod" type="radio" /><input name="expTimeC" value="0" type="hidden" /></td>
+				<td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
+					and with a fraction <input name="fracOnSourceC" size="4" value="0.5" type="text" /> of exposures that observe the source </td>
 			</tr>
 			<tr>
 				<td colspan="2" height="40" valign="bottom"><b>Telescope offset:</b><i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/sciops/instruments/gnirs/spectroscopy/observing-strategies#offsetting','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>
@@ -421,18 +421,18 @@
 				<td colspan="2" height="50" valign="bottom"><b>Analysis method:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256#analysis','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
 			</tr>
 			<tr>
-				<td ><input value="autoAper" name="analysisMethod" checked="checked" type="radio" />
-				Software aperture that gives 'optimum' S/N ratio and with a sky aperture <input name="autoSkyAper" size="4" value="5" type="text" /> times the target aperture </td>
+				<td ><input value="autoAper" name="analysisMethod" checked="checked" type="radio" /></td>
+				<td>Software aperture that gives 'optimum' S/N ratio and with a sky aperture <input name="autoSkyAper" size="4" value="5" type="text" /> times the target aperture </td>
 			</tr>
 			<tr>
-				<td ><input value="userAper" name="analysisMethod" type="radio" /> Software aperture of diameter (or slit length) <input name="userAperDiam" size="4" value="2" type="text" /> arcsec and with a sky aperture <input name="userSkyAper" size="4" value="5" type="text" /> times the target aperture</td>
+				<td ><input value="userAper" name="analysisMethod" type="radio" /></td>
+				<td>Software aperture of diameter (or slit length) <input name="userAperDiam" size="4" value="2" type="text" /> arcsec and with a sky aperture <input name="userSkyAper" size="4" value="5" type="text" /> times the target aperture</td>
 			</tr>
 			<tr>
 				<td colspan="2" height="50" valign="bottom"><b>Output:</b> </td>
 			</tr>
 			<tr>
 				<td colspan="2">For spectroscopy, <input value="AUTO" name="PlotLimits" checked="checked" type="radio" /> autoscale or <input value="USER" name="PlotLimits" type="radio" /> specify limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="0.500" type="text" /> µm and upper wavelength <input name="plotWavelengthU" size="6" value="0.900" type="text" /> µm) </td>
-
 			</tr>
 			<tr>
 				<td colspan="2">
@@ -441,7 +441,6 @@
 					</p>
 				</td>
 			</tr>
-
 		</tbody>
 	</table>
 	<div align="center">

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -345,7 +345,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" checked /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
-				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="0.8" size="4"> arcsec​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="0.8" size="4"> arcsec</td>
             </tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -345,6 +345,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" checked /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="0.8" size="4"> arcsec​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​</td>
             </tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>
@@ -352,6 +353,7 @@
                 <td><input name="CloudCover" value="PERCENT_70" type="radio" /> 70%/Cirrus</td>
                 <td><input name="CloudCover" value="PERCENT_80" type="radio" disabled /> 80%/Cloudy</td>
                 <td><input name="CloudCover" value="ANY"        type="radio" disabled /> Any</td>
+				<td><input name="CloudCover" value="EXACT"      type="radio" > <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
             </tr>
             <tr>
                 <td><b>Water Vapor:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
@@ -398,6 +398,7 @@
 				<td><input name="ImageQuality" value="PERCENT_70" type="radio" checked /> 70%/Good</td>
 				<td><input name="ImageQuality" value="PERCENT_85" type="radio" /> 85%/Poor</td>
 				<td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="0.8" size="4"> arcsec</td>
 			</tr>
 			<tr>
 				<td><b>Cloud Cover:</b></td>
@@ -405,6 +406,7 @@
 				<td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
 				<td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
 				<td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+				<td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
 			</tr>
 			<tr>
 				<td><b>Water Vapor:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
@@ -215,7 +215,6 @@
 						<option value="T0800K">800K</option>
 						<option value="T0600K">600K</option>
 						<option value="T0400K">400K</option>
-
 					</select> star (300 nm - 6 µm)
 				</td>
 			</tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
@@ -215,7 +215,7 @@
 						<option value="T0800K">800K</option>
 						<option value="T0600K">600K</option>
 						<option value="T0400K">400K</option>
-						
+
 					</select> star (300 nm - 6 µm)
 				</td>
 			</tr>
@@ -469,6 +469,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" checked /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="0.8" size="4"> arcsec</td>
             </tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>
@@ -476,6 +477,7 @@
                 <td><input name="CloudCover" value="PERCENT_70" type="radio" checked /> 70%/Cirrus</td>
                 <td><input name="CloudCover" value="PERCENT_80" type="radio" /> 80%/Cloudy</td>
                 <td><input name="CloudCover" value="ANY"        type="radio" /> Any</td>
+				<td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
             </tr>
             <tr>
                 <td><b>Water Vapor:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
@@ -381,7 +381,8 @@
                 <td><input name="SkyBackground" value="PERCENT_20" type="radio" disabled /> 20%/Darkest</td>
                 <td><input name="SkyBackground" value="PERCENT_50" type="radio" disabled /> 50%/Dark</td>
                 <td><input name="SkyBackground" value="PERCENT_80" type="radio" disabled /> 80%/Grey</td>
-                <td><input name="SkyBackground" value="ANY"        type="radio" checked /> Any/Bright</td>
+				<td colspan="2"><input name="SkyBackground" value="ANY"        type="radio" checked /> Any/Bright
+					(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10272','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>explanatory notes</span></a>)</td>
             </tr>
             <tr>
                 <td><b>Airmass:</b></td>
@@ -408,21 +409,20 @@
 	</p>
 	<table background="https://www.gemini.edu/sciops/instruments/itc/mez-green-bckgrnd.gif" border="0" cellpadding="6" cellspacing="0" height="70" width="100%">
 		<tbody>
-
 			<tr>
 				<td colspan="2" height="50" valign="bottom"><b>Calculation method:</b> <i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i><br />
 				<i>Select the calculation method (note: second method is not available for spectroscopy)</i></td>
 			</tr>
 			<tr>
 				<td><input value="s2n" name="calcMethod" checked="checked" type="radio" /><input name="numExpA" value="0" type="hidden" /></td>
-				<td>Total S/N ratio resulting from a total time of <input name="expTimeA" size="5" value="1800" type="text" /> secs and with a fraction <input name="fracOnSourceA" size="4" value="0.5" type="text" /> of exposures that observe the source (number of individual
-				exposures will be calculated from assumed frame time) </td>
-
+				<td>Total S/N ratio resulting from a total time of <input name="expTimeA" size="5" value="1800" type="text" />
+					secs and with a fraction <input name="fracOnSourceA" size="4" value="0.5" type="text" />
+					of exposures that observe the source (number of individual exposures will be calculated from assumed frame time) </td>
 			</tr>
 			<tr>
 				<td><input value="intTime" name="calcMethod" type="radio" /><input name="expTimeC" value="0" type="hidden" /></td>
-				<td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />  and with a fraction <input name="fracOnSourceC" size="4" value="0.5" type="text" /> of exposures that observe the source </td>
-
+				<td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
+					and with a fraction <input name="fracOnSourceC" size="4" value="0.5" type="text" /> of exposures that observe the source </td>
 			</tr>
 			<tr>
 				<td colspan="2" height="40" valign="bottom"><b>Telescope offset:</b><i><span>(<a href="#" onclick="window.open('http://www.gemini.edu/sciops/instruments/gnirs/spectroscopy/observing-strategies#offsetting','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>
@@ -435,14 +435,12 @@
 				<td colspan="2" height="50" valign="bottom"><b>Analysis method:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256#analysis','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
 			</tr>
 			<tr>
-
 				<td><input value="autoAper" name="analysisMethod" checked="checked" type="radio" /></td>
 				<td>Software aperture that gives 'optimum' S/N ratio and with a sky aperture <input name="autoSkyAper" size="4" value="5" type="text" /> times the target aperture</td>
 			</tr>
 			<tr>
 				<td><input value="userAper" name="analysisMethod" type="radio" /></td>
 				<td>Software aperture of diameter (or slit length) <input name="userAperDiam" size="4" value="2" type="text" /> arcsec and with a sky aperture <input name="userSkyAper" size="4" value="5" type="text" /> times the target aperture</td>
-
 			</tr>
 			<tr>
 				<td colspan="2" height="50" valign="bottom"><b>Output:</b> </td>
@@ -450,7 +448,6 @@
 			<tr>
 				<td colspan="2">For spectroscopy, <input value="AUTO" name="PlotLimits" checked="checked" type="radio" /> autoscale or <input value="USER" name="PlotLimits" type="radio" /> specify
 				limits for plotted spectra (lower wavelength <input name="plotWavelengthL" size="6" value="8.0" type="text" /> µm and upper wavelength <input name="plotWavelengthU" size="6" value="13.000" type="text" /> µm) </td>
-
 			</tr>
 			<tr>
 				<td colspan="2">
@@ -459,7 +456,6 @@
 					</p>
 				</td>
 			</tr>
-
 		</tbody>
 	</table>
 	<div align="center">

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCtrecs.html
@@ -359,6 +359,7 @@
                 <td><input name="ImageQuality" value="PERCENT_70" type="radio" checked /> 70%/Good</td>
                 <td><input name="ImageQuality" value="PERCENT_85" type="radio" /> 85%/Poor</td>
                 <td><input name="ImageQuality" value="ANY"        type="radio" /> Any</td>
+				<td><input name="ImageQuality" value="EXACT"      type="radio" /> <input name="ExactIQ" type="text" value="0.8" size="4"> arcsec</td>
             </tr>
             <tr>
                 <td><b>Cloud Cover:</b></td>
@@ -366,6 +367,7 @@
                 <td><input name="CloudCover" value="PERCENT_70" type="radio" /> 70%/Cirrus</td>
                 <td><input name="CloudCover" value="PERCENT_80" type="radio" disabled /> 80%/Cloudy</td>
                 <td><input name="CloudCover" value="ANY"        type="radio" disabled /> Any</td>
+				<td><input name="CloudCover" value="EXACT"      type="radio" /> <input name="ExactCC" type="text" value="0.3" size="4"> mag</td>
             </tr>
             <tr>
                 <td><b>Water Vapor:</b></td>
@@ -376,10 +378,10 @@
             </tr>
             <tr>
                 <td><b>Sky Background:</b></td>
-                <td><input name="SkyBackground" value="PERCENT_20" type="radio"/> 20%/Darkest</td>
-                <td><input name="SkyBackground" value="PERCENT_50" type="radio" checked/> 50%/Dark</td>
-                <td><input name="SkyBackground" value="PERCENT_80" type="radio"/> 80%/Grey</td>
-                <td><input name="SkyBackground" value="ANY"        type="radio"/> Any/Bright</td>
+                <td><input name="SkyBackground" value="PERCENT_20" type="radio" disabled /> 20%/Darkest</td>
+                <td><input name="SkyBackground" value="PERCENT_50" type="radio" disabled /> 50%/Dark</td>
+                <td><input name="SkyBackground" value="PERCENT_80" type="radio" disabled /> 80%/Grey</td>
+                <td><input name="SkyBackground" value="ANY"        type="radio" checked /> Any/Bright</td>
             </tr>
             <tr>
                 <td><b>Airmass:</b></td>

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -113,7 +113,9 @@ object ITCRequest {
     val wv      = r.enumParameter(classOf[SPSiteQuality.WaterVapor])
     val sb      = r.enumParameter(classOf[SPSiteQuality.SkyBackground])
     val airmass = r.doubleParameter("Airmass")
-    ObservingConditions(iq, cc, wv, sb, airmass)
+    val exactiq = r.doubleParameter("ExactIQ")
+    val exactcc = r.doubleParameter("ExactCC")
+    ObservingConditions(iq, cc, wv, sb, airmass, exactiq, exactcc)
   }
 
   def instrumentName(r: ITCRequest): String =

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/json/ObservingConditionsCodec.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/json/ObservingConditionsCodec.scala
@@ -12,14 +12,15 @@ trait ObservingConditionsCodec {
   private implicit val WaterVaporCodec = enumCodec[WaterVapor]
   private implicit val SkyBackgroundCodec = enumCodec[SkyBackground]
 
-
   implicit val ObservingConditionsCodec: CodecJson[ObservingConditions] =
-    casecodec5(ObservingConditions.apply, ObservingConditions.unapply)(
+    casecodec7(ObservingConditions.apply, ObservingConditions.unapply)(
       "iq",
       "cc",
       "wv",
       "sb",
-      "airmass"
+      "airmass",
+      "exactiq",
+      "exactcc"
     )
 
 }

--- a/bundle/edu.gemini.itc.web/src/test/scala/edu/gemini/itc/web/arb/ArbObservingConditions.scala
+++ b/bundle/edu.gemini.itc.web/src/test/scala/edu/gemini/itc/web/arb/ArbObservingConditions.scala
@@ -15,8 +15,10 @@ trait ArbObservingConditions {
       cc <- arbitrary[CloudCover]
       wv <- arbitrary[WaterVapor]
       sb <- arbitrary[SkyBackground]
-      am <- arbitrary[Double]
-    } yield ObservingConditions(iq, cc, wv, sb, am)
+      am <- arbitrary[Double]       // should be in the range 1.0 - 3.0
+      exactiq <- arbitrary[Double]  // should be in the range 0.05 - 5.0
+      exactcc <- arbitrary[Double]  // should be in the range 0.0 - 5.0
+    } yield ObservingConditions(iq, cc, wv, sb, am, exactiq, exactcc)
 
   implicit val arbObservingConditions: Arbitrary[ObservingConditions] =
     Arbitrary(genObservingConditions)

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
@@ -252,7 +252,7 @@ public final class SEDFactory {
         // inputs: SED, AIRMASS, sky emmision file, mirror configuration,
         // output: SED and sky background as they arrive at instruments
 
-        final SampledSpectrumVisitor clouds = CloudTransmissionVisitor.create(odp.cc());
+        final SampledSpectrumVisitor clouds = CloudTransmissionVisitor.create(odp.cc(), odp.exactcc());
         sed.accept(clouds);
 
         final SampledSpectrumVisitor water = WaterTransmissionVisitor.create(

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/CloudTransmissionVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/CloudTransmissionVisitor.java
@@ -1,9 +1,10 @@
 package edu.gemini.itc.operation;
 
+import edu.gemini.itc.base.DefaultArraySpectrum;
 import edu.gemini.itc.base.ITCConstants;
 import edu.gemini.itc.base.TransmissionElement;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
-
+import java.util.logging.Logger;
 
 /**
  * The CloudTransmissionVisitor is designed to adjust the SED for
@@ -11,15 +12,33 @@ import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
  */
 public final class CloudTransmissionVisitor {
     private static final String FILENAME = "cloud_trans";
-
     private CloudTransmissionVisitor() {
     }
+
+    private static final Logger Log = Logger.getLogger( CloudTransmissionVisitor.class.getName() );
 
     /**
      * Constructs transmission visitor for clouds.
      */
-    public static TransmissionElement create(final SPSiteQuality.CloudCover cc) {
-        return new TransmissionElement(ITCConstants.TRANSMISSION_LIB + "/" + FILENAME +
-                "_" + cc.sequenceValue() + ITCConstants.DATA_SUFFIX);
+    public static TransmissionElement create(final SPSiteQuality.CloudCover cc, double exactcc) {
+
+        if (cc == SPSiteQuality.CloudCover.EXACT) {
+
+            if (exactcc < 0.0) throw new IllegalArgumentException("Exact Cloud Cover must be >= zero magnitudes.");
+            final double[][] data = new double[2][2];
+            data[0][0] = 300.0;                      // x = wavelength
+            data[0][1] = 30000.0;
+            data[1][0] = Math.pow(10, exactcc/-2.5); // y = transmission
+            data[1][1] = data[1][0];
+            Log.fine(String.format("Exact cloud transmission = %.2f mag = %.4f", exactcc, data[1][0]));
+            final TransmissionElement te;
+            te = new TransmissionElement(new DefaultArraySpectrum(data));
+            return te;
+
+        } else {
+
+            return new TransmissionElement(ITCConstants.TRANSMISSION_LIB + "/" + FILENAME +
+                    "_" + cc.sequenceValue() + ITCConstants.DATA_SUFFIX);
+        }
     }
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculation.java
@@ -5,11 +5,13 @@ import edu.gemini.itc.base.DefaultArraySpectrum;
 import edu.gemini.itc.base.ITCConstants;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.guide.GuideProbe;
+import java.util.logging.Logger;
 
 public class ImageQualityCalculation implements ImageQualityCalculatable {
 
     private String im_qual_model_file;
     private double airmass, effectiveWavelength, im_qual;
+    private static final Logger Log = Logger.getLogger( ImageQualityCalculation.class.getName() );
 
     public ImageQualityCalculation(final GuideProbe.Type wfs,
                                    final SPSiteQuality.ImageQuality iq,
@@ -25,6 +27,7 @@ public class ImageQualityCalculation implements ImageQualityCalculatable {
     public void calculate() {
         ArraySpectrum im_qual_model = new DefaultArraySpectrum(im_qual_model_file);
         im_qual = im_qual_model.getY(effectiveWavelength) * (Math.pow(airmass, 0.6));
+        Log.fine(String.format("Image quality = %.5f arcseconds at airmass = %.2f", im_qual, airmass));
     }
 
     public double getImageQuality() {

--- a/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
+++ b/bundle/edu.gemini.itc/src/test/scala/edu/gemini/itc/baseline/util/Fixture.scala
@@ -230,7 +230,7 @@ object Fixture {
       (iq, cc, wv)  <- weatherConditions
       sb            <- List(PERCENT_50, PERCENT_80) // SB20=1, SB50=2, SB80=3, ANY=4
       am            <- List(1.5)                    // airmass 1.0, 1.5, 2.0 (relevant levels: < 1.26; 1.26..1.75, > 1.75)
-    } yield new ObservingConditions(iq, cc, wv, sb, am)
+    } yield new ObservingConditions(iq, cc, wv, sb, am, 0.0, 0.0)
 
   // Defines a set of relevant telescope configurations; total 1*2*2=4 configurations
   // NOTE: looking at TeleParameters.getWFS() it seems that AOWFS is always replaced with OIWFS

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPSiteQuality.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPSiteQuality.java
@@ -304,8 +304,7 @@ public class SPSiteQuality extends AbstractDataObject implements PropertyProvide
             @Override public boolean isObsolete() { return true; }
         },
         ANY(       "Any",       100, -3.0),
-        ;
-
+        EXACT(     "Exact",       0,  0.0);
 
         /** The default CloudCover value **/
         public static CloudCover DEFAULT = ANY;
@@ -366,7 +365,8 @@ public class SPSiteQuality extends AbstractDataObject implements PropertyProvide
         PERCENT_20("20%/Best",  20,  0.5),
         PERCENT_70("70%/Good",  70,  0.0),
         PERCENT_85("85%/Poor",  85, -0.5),
-        ANY(       "Any",      100, -1.0);
+        ANY(       "Any",      100, -1.0),
+        EXACT(     "Exact",      0,  0.0);
 
         /** The default ImageQuality value **/
         public static ImageQuality DEFAULT = ANY;
@@ -385,7 +385,6 @@ public class SPSiteQuality extends AbstractDataObject implements PropertyProvide
         public byte getPercentage() {
             return _percentage;
         }
-
 
         public String displayValue() {
             return _displayValue;
@@ -417,7 +416,6 @@ public class SPSiteQuality extends AbstractDataObject implements PropertyProvide
         public static Option<ImageQuality> read(String s) {
             return SPSiteQuality.read(s, values());
         }
-
 
         @Override
         public double getAdjustment(final BandsList bl) {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/itc/ConditionsPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/itc/ConditionsPanel.scala
@@ -63,7 +63,8 @@ final class ConditionsPanel(owner: EdIteratorFolder) extends GridBagPanel {
     cc.selection.item,
     wv.selection.item,
     sb.selection.item,
-    am.selection.item)
+    am.selection.item, 0.0, 0.0
+  )
 
   def update() = {
     // Note: site quality node can be missing (i.e. null)


### PR DESCRIPTION
This PR adds the ability to set exact IQ and CC in the ITC web form.  This is done by adding a new accepted value "EXACT" to the list of allowed IQ and CC web form options.  When this option is selected the web form provides values for ExactIQ and ExactCC.  The exactcc value is used to calculate the atmospheric transmission (CloudTransmissionVisitor.java).  The exactiq is treated as a Gaussian source of the specified size (ImageQualityCalculationFactory.java).  This all seems to work as expected, and the usual baseline tests all pass.  However, one of the JsonServletSpec tests fail:

> project bundle_edu_gemini_itc_web
[info] Set current project to edu.gemini.itc.web (in build file:/home/astephens/ocs/ocs/)
> test
...
[info] JsonServletSpec
[info] 
[info] JsonServlet should
[info]   + return SC_BAD_REQUEST with an error message in the case of malformed Json
[info]   + return SC_BAD_REQUEST with an error message in the case of incorrect Json
[error]   x return SC_OK with a valid response for a valid request
[error]    Falsified after 4 passed tests.
[error]    > ARG_0: ObservingConditions(IQ 0,CC90,WV50,SB20,2.6285854169719077E303,-7.275257229517602E-167,-6.8277559092249724E-124)
[error]    > ARG_1: TelescopeDetails(SILVER, Up-looking, PWFS)
[error]    > ARG_2: NiriParameters(BBF_J,WOLLASTON,F32_PV,IMAG_SPEC_3TO5,DEEP,MASK_9,CENTRAL_256,Some(AltairParameters(4.567890646741859E-117,1.2959084932867202E-182,OUT,NGS)))
[error]    The seed is jqj1852W9BLjBWl6BVYInYW6VfR6GBDn1KzzKciekyM=
[error]    
[error]    > 'text/html; charset=UTF-8' != 'text/json; charset=UTF-8' (JsonServletSpec.scala:116)
[error] Actual:   text/[html]; cha...
[error] Expected: text/[json]; cha...
