### PR TITLE
reference coordinates

### DIFF
--- a/PUBLISH.txt
+++ b/PUBLISH.txt
@@ -1,0 +1,32 @@
+
+LOCAL PUBLISHING OF 2.13 ARTIFACTS
+
+
+sbt -Dsbt.boot.directory=/tmp/boot1 -Dsbt.launcher.coursier=false
+
+
+++2.13.1
+bundle_edu_gemini_model_p1_pdf/publishLocal
+bundle_edu_gemini_model_p1_targetio/publishLocal
+bundle_edu_gemini_model_p1/publishLocal
+bundle_edu_gemini_pot/publishLocal
+bundle_edu_gemini_seqexec_odb/publishLocal
+bundle_edu_gemini_shared_skyobject/publishLocal
+bundle_edu_gemini_shared_util/publishLocal
+bundle_edu_gemini_spModel_core/publishLocal
+bundle_edu_gemini_spModel_io/publishLocal
+bundle_edu_gemini_spModel_pio/publishLocal
+bundle_edu_gemini_spModel_smartgcal/publishLocal
+bundle_edu_gemini_util_javax_mail/publishLocal
+bundle_edu_gemini_util_osgi/publishLocal
+bundle_edu_gemini_util_pdf/publishLocal
+bundle_edu_gemini_util_skycalc/publishLocal
+bundle_edu_gemini_util_ssl/publishLocal
+bundle_edu_gemini_util_ssl_apache/publishLocal
+bundle_edu_gemini_wdba_session_client/publishLocal
+bundle_edu_gemini_wdba_shared/publishLocal
+bundle_edu_gemini_wdba_xmlrpc_api/publishLocal
+bundle_jsky_coords/publishLocal
+bundle_jsky_util/publishLocal
+bundle_jsky_util_gui/publishLocal
+bundle_edu_gemini_epics_acm/publishLocal

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Observation.scala
@@ -23,7 +23,7 @@ object Observation {
 
   /**
    * @param referenceCoordinates optional coordinates that will overide the ephemeris for ITAC
-   *   bing-filling. This value is ignored unless the target is nonsidereal, is used only by
+   *   bin-filling. This value is ignored unless the target is nonsidereal, is used only by
    *   ITAC, and does not exist in Phase 2.
    */
   def apply(m:M.Observation, referenceCoordinates: Option[Coordinates]) = new Observation(m, referenceCoordinates)

--- a/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
+++ b/bundle/edu.gemini.pit/src/main/scala/edu/gemini/pit/ui/robot/ProblemRobot.scala
@@ -154,13 +154,13 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     } yield new Problem(Severity.Error, msg, "Targets", s.inTargetsView(_.edit(t)))
 
     private lazy val emptyEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _, _, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _, _, _) <- p.targets
       if e.isEmpty
       msg = s"""Ephemeris for target "$n" is undefined."""
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
     private lazy val singlePointEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _, _, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _, _, _) <- p.targets
       if e.size == 1
       msg = s"""Ephemeris for target "$n" contains only one point; please specify at least two."""
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
@@ -168,7 +168,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     lazy val dateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MMM-dd").withZone(ZoneId.of("UTC"))
 
     private lazy val initialEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _, _, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _, _, _) <- p.targets
       if e.nonEmpty
       ds = e.map(_.validAt) if ds.size > 1
       dsMin = ds.min
@@ -183,7 +183,7 @@ class ProblemRobot(s: ShellAdvisor) extends Robot {
     } yield new Problem(Severity.Warning, msg, "Targets", s.inTargetsView(_.edit(t)))
 
     private lazy val finalEphemerisCheck = for {
-      t @ NonSiderealTarget(_, n, e, _, _, _) <- p.targets
+      t @ NonSiderealTarget(_, n, e, _, _, _, _) <- p.targets
       if e.nonEmpty
       ds = e.map(_.validAt) if ds.size > 1
       dsMax = ds.max


### PR DESCRIPTION
ITAC users need a way to override the ephemeris for nonsidereal targets, because sometimes the reference point at mid-semester is in an RA bucket that's too full. This adds a `referenceCoordinates` method to the Phase 1 immutable `NonSiderealTarget`, which for various reasons is where it needs to go. I'm not proud of any of this.
