### PR TITLE
bump versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ name := "ocs"
 organization in Global := "edu.gemini.ocs"
 
 // true indicates a test release, and false indicates a production release
-ocsVersion in ThisBuild := OcsVersion("2021B", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2021B", true, 1, 1, 2)
 
-pitVersion in ThisBuild := OcsVersion("2022A", false, 1, 1, 1)
+pitVersion in ThisBuild := OcsVersion("2022A", false, 1, 1, 2)
 
 // Bundles by default use the ocsVersion; this is overridden in bundles used only by the PIT
 version in ThisBuild := ocsVersion.value.toOsgiVersion


### PR DESCRIPTION
I'm going to publish the 2.13 versions of the p1 model and related modules for ITAC, so I need to bump the versions. @cquiroz is this sensible?