### PR TITLE
REL-3985: fix time accounting summary report

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpProgramFactory.scala
@@ -12,7 +12,7 @@ import edu.gemini.model.p1.mutable.TooOption
 import edu.gemini.spModel.gemini.obscomp.SPProgram
 import edu.gemini.spModel.gemini.obscomp.SPProgram.{PIInfo, ProgramMode}
 import edu.gemini.shared.util.TimeValue
-
+import edu.gemini.spModel.gemini.phase1.GsaPhase1Data.Keyword
 import edu.gemini.spModel.timeacct.{TimeAcctAllocation, TimeAcctAward, TimeAcctCategory}
 import edu.gemini.spModel.gemini.phase1.{GsaPhase1Data => Gsa}
 
@@ -285,7 +285,7 @@ object SpProgramFactory {
     val category = new Gsa.Category(~proposal.category.map(_.value()))
     val pi       = gsaPhase1DataInvestigator(proposal.investigators.pi)
     val cois     = proposal.investigators.cois.map(gsaPhase1DataInvestigator).asJava
-    new Gsa(abstrakt, category, pi, cois)
+    new Gsa(abstrakt, category, java.util.Collections.emptyList[Keyword], pi, cois)
   }
 
   private def gsaPhase1DataInvestigator(inv: Investigator): Gsa.Investigator =

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phase1/GsaPhase1Data.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phase1/GsaPhase1Data.java
@@ -39,6 +39,7 @@ public final class GsaPhase1Data implements Serializable {
     public static final GsaPhase1Data EMPTY = new GsaPhase1Data(
             Abstract.EMPTY,
             Category.EMPTY,
+            Collections.emptyList(),
             Investigator.EMPTY,
             Collections.emptyList()
     );
@@ -163,12 +164,14 @@ public final class GsaPhase1Data implements Serializable {
 
     private final String abstrakt;
     private final String category;
+    private final List<String> keywords;  // TODO: REMOVE ME
     private final Investigator pi;
     private final List<Investigator> cois;
 
-    public GsaPhase1Data(Abstract abstrakt, Category cat, Investigator pi, Collection<Investigator> cois) {
+    public GsaPhase1Data(Abstract abstrakt, Category cat, Collection<Keyword> keywords, Investigator pi, Collection<Investigator> cois) {
         if (abstrakt == null) abstrakt = new Abstract("");
         if (cat == null) cat = new Category("");
+        this.keywords = Collections.emptyList();
         if (pi == null) pi = Investigator.EMPTY;
         if (cois == null) cois = Collections.emptyList();
 
@@ -187,6 +190,7 @@ public final class GsaPhase1Data implements Serializable {
     public GsaPhase1Data(ParamSet pset) {
         this.abstrakt = Pio.getValue(pset, ABSTRACT_PARAM, "");
         this.category = Pio.getValue(pset, CATEGORY_PARAM, "");
+        this.keywords = Collections.emptyList();
 
         ParamSet invsPset = pset.getParamSet(INVESTIGATORS_PARAM_SET);
         if (invsPset == null) {
@@ -214,6 +218,9 @@ public final class GsaPhase1Data implements Serializable {
 
     public Abstract getAbstract() { return new Abstract(abstrakt); }
     public Category getCategory() { return new Category(category); }
+    public List<Keyword> getKeywords() {
+        return new ArrayList<>();
+    }
     public Investigator getPi() { return pi; }
     public List<Investigator> getCois() { return cois; }
 

--- a/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
+++ b/bundle/edu.gemini.spModel.io/src/main/java/edu/gemini/spModel/io/impl/PioSpXmlParser.java
@@ -319,6 +319,7 @@ public final class PioSpXmlParser {
         return new GsaPhase1Data(
                 getP1Abstract(c),
                 getP1Category(c),
+                Collections.emptyList(),
                 getP1Pi(c),
                 getP1Cois(c)
         );

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TimeAccountingSummaryTable.java
@@ -227,19 +227,21 @@ public class TimeAccountingSummaryTable extends AbstractTable {
                 // Get accounts string
                 final TimeAcctCategory cat = ratioEntry.getKey();
                 final double ratio = ratioEntry.getValue();
-                final String account = cat.name();
+                if (ratio > 0.0) {
+                    final String account = cat.name();
 
-                // We can create a table row now!
-                final Map<IColumn, Object> row = createRow();
-                row.put(Columns.DATE, night.getNightString());
-                row.put(Columns.PROGRAM_ID, id);
-                row.put(Columns.INSTRUMENT, instrumentsString);
-                row.put(Columns.PRG, prg * ratio);
-                row.put(Columns.CAL, cal * ratio);
-                row.put(Columns.TOTAL, total * ratio);
-                row.put(Columns.ACCOUNT, account);
-                if (comment != null) row.put(Columns.COMMENT, comment);
-                rows.add(row);
+                    // We can create a table row now!
+                    final Map<IColumn, Object> row = createRow();
+                    row.put(Columns.DATE, night.getNightString());
+                    row.put(Columns.PROGRAM_ID, id);
+                    row.put(Columns.INSTRUMENT, instrumentsString);
+                    row.put(Columns.PRG, prg * ratio);
+                    row.put(Columns.CAL, cal * ratio);
+                    row.put(Columns.TOTAL, total * ratio);
+                    row.put(Columns.ACCOUNT, account);
+                    if (comment != null) row.put(Columns.COMMENT, comment);
+                    rows.add(row);
+                }
             }
         }
 	}


### PR DESCRIPTION
It's unclear why, but the 2021B programs began to include time accounting summary report rows for all partners instead of only those which allocated time.  This update:

1. Limits the report to only partners which allocated time
2. Replaces keywords in `GsaPhase1Data`.  We don't use this information any longer, but including it (for now) allows a patch release to be created from `develop` without serialization issues.