### PR TITLE
REL-3940: make QPT scheduled visit Observation column bigger

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/VisitViewAdvisor.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/view/visit/VisitViewAdvisor.java
@@ -37,21 +37,21 @@ import edu.gemini.ui.workspace.util.Factory;
 public class VisitViewAdvisor implements IViewAdvisor, PropertyChangeListener {
 
     // The viewer, which is the main thing here.
-    GTableViewer<Variant, Alloc, VisitAttribute> viewer = 
+    GTableViewer<Variant, Alloc, VisitAttribute> viewer =
         new GTableViewer<Variant, Alloc, VisitAttribute>(new VisitController());
-    
+
     // More UI stuff
     JScrollPane scroll = Factory.createStrippedScrollPane(viewer.getTable());
-    
+
     public VisitViewAdvisor() {
-        
+
         // Set up the viewer
         viewer.setColumns(Group, Start, Dur, BG, Observation, Steps, Inst, Config, WFS, Target);
-        viewer.setColumnSize(Group, 10);        
+        viewer.setColumnSize(Group, 10);
         viewer.setColumnSize(Start, 35);
         viewer.setColumnSize(Dur, 35);
         viewer.setColumnSize(BG, 30);
-        viewer.setColumnSize(Observation, 110);
+        viewer.setColumnSize(Observation, 125, Integer.MAX_VALUE);
         viewer.setColumnSize(Steps, 45);
         viewer.setColumnSize(Inst, 50);
         viewer.setColumnSize(Config, 50, Integer.MAX_VALUE);
@@ -59,16 +59,16 @@ public class VisitViewAdvisor implements IViewAdvisor, PropertyChangeListener {
         viewer.setDecorator(new VisitDecorator());
         viewer.setTranslator(new VisitTranslator());
         viewer.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
-        
+
         viewer.getTable().setShowGrid(false); // ?
         viewer.getTable().setIntercellSpacing(new Dimension(0, 0));
-        
+
         // Set up the scroll bar
         ScrollPanes.setViewportHeight(scroll, 5);
-        
+
     }
-    
-    
+
+
     @SuppressWarnings("serial")
     public void open(IViewContext context) {
 
@@ -77,13 +77,13 @@ public class VisitViewAdvisor implements IViewAdvisor, PropertyChangeListener {
         context.setSelectionBroker(viewer);
         context.setContent(scroll);
         context.getShell().addPropertyChangeListener(IShell.PROP_MODEL, this);
-        
+
         context.addRetargetAction(CommonActions.CUT, new CutAction(context.getShell(), viewer));
         context.addRetargetAction(CommonActions.COPY, new CopyAction(context.getShell(), viewer));
         context.addRetargetAction(CommonActions.PASTE, new PasteAction(context.getShell(), viewer));
         context.addRetargetAction(CommonActions.DELETE, new DeleteAction(context.getShell(), viewer));
         context.addRetargetAction(CommonActions.SELECT_ALL, new SelectAllAction(viewer));
-        
+
     }
 
     public void close(IViewContext context) {
@@ -95,24 +95,24 @@ public class VisitViewAdvisor implements IViewAdvisor, PropertyChangeListener {
     }
 
     public void propertyChange(PropertyChangeEvent evt) {
-        
+
         if (IShell.PROP_MODEL.equals(evt.getPropertyName())) {
-            
+
             // Move the listeners
             Schedule prev = (Schedule) evt.getOldValue();
             Schedule next = (Schedule) evt.getNewValue();
             if (prev != null) prev.removePropertyChangeListener(Schedule.PROP_CURRENT_VARIANT, this);
             if (next != null) next.addPropertyChangeListener(Schedule.PROP_CURRENT_VARIANT, this);
-            
+
             // Initialize the viewer
             viewer.setModel(next == null ? null : next.getCurrentVariant());
-            
+
         } else if (Schedule.PROP_CURRENT_VARIANT.equals(evt.getPropertyName())) {
-            
+
             // New variant is current
             viewer.setModel((Variant) evt.getNewValue());
-            
-        }        
+
+        }
     }
 
 }


### PR DESCRIPTION
Observation IDs have gotten longer since the QPT was first released.  In particular all program ids have indices of at least 3 digits now.  This made it so the typical observation id is truncated in the Scheduled Visits table.

This PR makes the minimum size observation id slightly bigger to accommodate the new program id standard and makes the column resizable as requested. 