### PR TITLE
REL-3924: Switch to new catalog server for all Gemini catalogs

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableClient.scala
@@ -193,8 +193,9 @@ case object ConeSearchBackend extends CachedBackend with RemoteCallBackend {
 
   override val catalogUrls: NonEmptyList[URL] =
     NonEmptyList(
-      new URL("http://gscatalog.gemini.edu"),
-      new URL("http://gncatalog.gemini.edu")
+        new URL("http://mkocatalog-lv2.hi.gemini.edu")
+//      new URL("http://gscatalog.gemini.edu"),
+//      new URL("http://gncatalog.gemini.edu")
     )
 
   private def format(a: Angle)= f"${a.toDegrees}%4.03f"


### PR DESCRIPTION
When the GAIA @ Gemini server is put into production, it will also handle queries for all existing catalogs.  This update temporarily switches to the new test server for the UCAC, PPMXL, etc. catalogs. 