### PR TITLE
REL-3945: Stop relying on visitor instrument name

### DIFF
--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/immutable/Instrument.scala
@@ -1,8 +1,8 @@
 package edu.gemini.model.p1.immutable
 
-sealed abstract class Instrument(val site: Site, val id: String, val display: String, val gsa: String) {
+sealed abstract class Instrument(val site: Site, val id: String, val display: String, val gsa: String) extends Product with Serializable {
   def this(site: Site, id: String) = this(site, id, id, id)
-  override def toString = display
+  override def toString: String = display
 }
 
 import Site._

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpBlueprintFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpBlueprintFactory.scala
@@ -1,29 +1,27 @@
 package edu.gemini.phase2.skeleton.factory
 
 import edu.gemini.model.p1.immutable._
-
 import edu.gemini.spModel.gemini.altair.AltairParams
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
-import edu.gemini.spModel.gemini.flamingos2.blueprint.{SpFlamingos2BlueprintMos, SpFlamingos2BlueprintLongslit, SpFlamingos2BlueprintImaging}
+import edu.gemini.spModel.gemini.flamingos2.blueprint.{SpFlamingos2BlueprintImaging, SpFlamingos2BlueprintLongslit, SpFlamingos2BlueprintMos}
 import edu.gemini.spModel.gemini.gmos.blueprint._
 import edu.gemini.spModel.gemini.gmos.{GmosCommonType, GmosNorthType, GmosSouthType}
 import edu.gemini.spModel.gemini.michelle.MichelleParams
-import edu.gemini.spModel.gemini.michelle.blueprint.{SpMichelleBlueprintSpectroscopy, SpMichelleBlueprintImaging}
+import edu.gemini.spModel.gemini.michelle.blueprint.{SpMichelleBlueprintImaging, SpMichelleBlueprintSpectroscopy}
 import edu.gemini.spModel.gemini.phoenix.PhoenixParams
 import edu.gemini.spModel.gemini.phoenix.blueprint.SpPhoenixBlueprint
-
 import edu.gemini.spModel.template.SpBlueprint
 
 import scala.collection.JavaConverters._
-import edu.gemini.spModel.gemini.altair.blueprint.{SpAltairLgs, SpAltairNgs, SpAltairNone, SpAltair}
+import edu.gemini.spModel.gemini.altair.blueprint.{SpAltair, SpAltairLgs, SpAltairNgs, SpAltairNone}
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams
-import edu.gemini.spModel.gemini.gnirs.blueprint.{SpGnirsBlueprintSpectroscopy, SpGnirsBlueprintImaging}
+import edu.gemini.spModel.gemini.gnirs.blueprint.{SpGnirsBlueprintImaging, SpGnirsBlueprintSpectroscopy}
 import edu.gemini.spModel.gemini.nici.NICIParams
-import edu.gemini.spModel.gemini.nici.blueprint.{SpNiciBlueprintStandard, SpNiciBlueprintCoronagraphic}
+import edu.gemini.spModel.gemini.nici.blueprint.{SpNiciBlueprintCoronagraphic, SpNiciBlueprintStandard}
 import edu.gemini.spModel.gemini.nifs.NIFSParams
-import edu.gemini.spModel.gemini.nifs.blueprint.{SpNifsBlueprintAo, SpNifsBlueprint}
+import edu.gemini.spModel.gemini.nifs.blueprint.{SpNifsBlueprint, SpNifsBlueprintAo}
 import edu.gemini.spModel.gemini.trecs.TReCSParams
-import edu.gemini.spModel.gemini.trecs.blueprint.{SpTrecsBlueprintSpectroscopy, SpTrecsBlueprintImaging}
+import edu.gemini.spModel.gemini.trecs.blueprint.{SpTrecsBlueprintImaging, SpTrecsBlueprintSpectroscopy}
 import edu.gemini.spModel.gemini.niri.blueprint.SpNiriBlueprint
 import edu.gemini.spModel.gemini.niri.Niri
 import edu.gemini.spModel.gemini.gsaoi.Gsaoi
@@ -34,6 +32,7 @@ import edu.gemini.spModel.gemini.visitor.blueprint.SpVisitorBlueprint
 import edu.gemini.spModel.gemini.gpi.Gpi
 import edu.gemini.spModel.gemini.gpi.blueprint.SpGpiBlueprint
 import edu.gemini.spModel.gemini.graces.blueprint.SpGracesBlueprint
+import edu.gemini.spModel.gemini.visitor.VisitorConfig
 
 object SpBlueprintFactory {
 
@@ -398,12 +397,12 @@ object SpBlueprintFactory {
   }
 
   object VisitorHandler {
-    def apply(b: VisitorBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.customName))
-    def apply(b: AlopekeBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name))
-    def apply(b: ZorroBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name))
-    def apply(b: DssiBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint("DSSI"))
-    def apply(b: IgrinsBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name))
-    def apply(b: MaroonXBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name))
+    def apply(b: VisitorBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.customName, None))
+    def apply(b: AlopekeBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name, Some(VisitorConfig.Alopeke)))
+    def apply(b: ZorroBlueprint):Either[String, SpVisitorBlueprint]   = Right(new SpVisitorBlueprint(b.name, Some(VisitorConfig.Zorro)))
+    def apply(b: DssiBlueprint):Either[String, SpVisitorBlueprint]    = Right(new SpVisitorBlueprint("DSSI", Some(VisitorConfig.Dssi)))
+    def apply(b: IgrinsBlueprint):Either[String, SpVisitorBlueprint]  = Right(new SpVisitorBlueprint(b.name, Some(VisitorConfig.Igrins)))
+    def apply(b: MaroonXBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name, Some(VisitorConfig.MaroonX)))
   }
 
   object GpiHandler {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpBlueprintFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpBlueprintFactory.scala
@@ -397,12 +397,12 @@ object SpBlueprintFactory {
   }
 
   object VisitorHandler {
-    def apply(b: VisitorBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.customName, None))
-    def apply(b: AlopekeBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name, Some(VisitorConfig.Alopeke)))
-    def apply(b: ZorroBlueprint):Either[String, SpVisitorBlueprint]   = Right(new SpVisitorBlueprint(b.name, Some(VisitorConfig.Zorro)))
-    def apply(b: DssiBlueprint):Either[String, SpVisitorBlueprint]    = Right(new SpVisitorBlueprint("DSSI", Some(VisitorConfig.Dssi)))
-    def apply(b: IgrinsBlueprint):Either[String, SpVisitorBlueprint]  = Right(new SpVisitorBlueprint(b.name, Some(VisitorConfig.Igrins)))
-    def apply(b: MaroonXBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name, Some(VisitorConfig.MaroonX)))
+    def apply(b: VisitorBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.customName, VisitorConfig.GenericVisitor))
+    def apply(b: AlopekeBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name, VisitorConfig.Alopeke))
+    def apply(b: ZorroBlueprint):Either[String, SpVisitorBlueprint]   = Right(new SpVisitorBlueprint(b.name, VisitorConfig.Zorro))
+    def apply(b: DssiBlueprint):Either[String, SpVisitorBlueprint]    = Right(new SpVisitorBlueprint("DSSI", VisitorConfig.Dssi))
+    def apply(b: IgrinsBlueprint):Either[String, SpVisitorBlueprint]  = Right(new SpVisitorBlueprint(b.name, VisitorConfig.Igrins))
+    def apply(b: MaroonXBlueprint):Either[String, SpVisitorBlueprint] = Right(new SpVisitorBlueprint(b.name, VisitorConfig.MaroonX))
   }
 
   object GpiHandler {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/Visitor.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/Visitor.scala
@@ -13,6 +13,7 @@ case class Visitor(blueprint: SpVisitorBlueprint) extends VisitorBase {
 
   // SET Name from Phase-I
   forObs(sci: _*)(setName fromPI)
+  forObs(sci: _*)(setVisitorConfig fromPI)
   forObs(sci: _*)(setWavelength fromPI)
   forObs(sci: _*)(setPosAngle fromPI)
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
@@ -4,7 +4,6 @@ import edu.gemini.phase2.template.factory.impl._
 import edu.gemini.spModel.gemini.visitor.blueprint.SpVisitorBlueprint
 import edu.gemini.spModel.gemini.visitor.{VisitorConfig, VisitorInstrument}
 import edu.gemini.pot.sp.{ISPGroup, ISPObservation, SPComponentType}
-import edu.gemini.shared.util.immutable.ImOption
 
 //noinspection MutatorLikeMethodIsParameterless
 trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl {
@@ -23,8 +22,8 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
     def setName(n: String): Either[String, Unit] =
       ed.updateInstrument(_.setName(n))
 
-    def setVisitorConfig(c: Option[VisitorConfig]): Either[String, Unit] =
-      ed.updateInstrument(_.setVisitorConfig(ImOption.fromScalaOpt(c)))
+    def setVisitorConfig(c: VisitorConfig): Either[String, Unit] =
+      ed.updateInstrument(_.setVisitorConfig(c))
 
     def setWavelength(microns: Double): Either[String, Unit] =
       ed.updateInstrument(_.setWavelength(microns))
@@ -55,18 +54,18 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
   def setName: Setter[String] =
     Setter[String](blueprint.name)(_.setName(_))
 
-  def setVisitorConfig: Setter[Option[VisitorConfig]] =
-    Setter[Option[VisitorConfig]](ImOption.toScalaOpt(blueprint.visitorConfig))(_.setVisitorConfig(_))
+  def setVisitorConfig: Setter[VisitorConfig] =
+    Setter[VisitorConfig](blueprint.visitorConfig)(_.setVisitorConfig(_))
 
-  def visitorConfig: Option[VisitorConfig] =
-    blueprint.scalaVisitorConfig
+  def visitorConfig: VisitorConfig =
+    blueprint.visitorConfig
 
   override def notes: List[String] =
-    visitorConfig.map(_.noteTitles).getOrElse(Nil)
+    visitorConfig.noteTitles
 
   def setWavelength: Setter[Double] =
-    Setter[Double](visitorConfig.map(_.wavelength.toMicrons).getOrElse(VisitorConfig.DefaultWavelength.toMicrons))(_.setWavelength(_))
+    Setter[Double](visitorConfig.wavelength.toMicrons)(_.setWavelength(_))
 
   def setPosAngle: Setter[Double] =
-    Setter[Double](visitorConfig.map(_.positionAngle.toDegrees).getOrElse(VisitorConfig.DefaultPositionAngle.toDegrees))(_.setPosAngle(_))
+    Setter[Double](visitorConfig.positionAngle.toDegrees)(_.setPosAngle(_))
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
@@ -4,6 +4,7 @@ import edu.gemini.phase2.template.factory.impl._
 import edu.gemini.spModel.gemini.visitor.blueprint.SpVisitorBlueprint
 import edu.gemini.spModel.gemini.visitor.{VisitorConfig, VisitorInstrument}
 import edu.gemini.pot.sp.{ISPGroup, ISPObservation, SPComponentType}
+import edu.gemini.shared.util.immutable.ImOption
 
 //noinspection MutatorLikeMethodIsParameterless
 trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl {
@@ -21,6 +22,9 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
 
     def setName(n: String): Either[String, Unit] =
       ed.updateInstrument(_.setName(n))
+
+    def setVisitorConfig(c: Option[VisitorConfig]): Either[String, Unit] =
+      ed.updateInstrument(_.setVisitorConfig(ImOption.fromScalaOpt(c)))
 
     def setWavelength(microns: Double): Either[String, Unit] =
       ed.updateInstrument(_.setWavelength(microns))
@@ -51,15 +55,18 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
   def setName: Setter[String] =
     Setter[String](blueprint.name)(_.setName(_))
 
-  def instrumentConfig: Option[VisitorConfig] =
+  def setVisitorConfig: Setter[Option[VisitorConfig]] =
+    Setter[Option[VisitorConfig]](ImOption.toScalaOpt(blueprint.visitorConfig))(_.setVisitorConfig(_))
+
+  def visitorConfig: Option[VisitorConfig] =
     blueprint.scalaVisitorConfig
 
   override def notes: List[String] =
-    instrumentConfig.map(_.noteTitles).getOrElse(Nil)
+    visitorConfig.map(_.noteTitles).getOrElse(Nil)
 
   def setWavelength: Setter[Double] =
-    Setter[Double](instrumentConfig.map(_.wavelength.toMicrons).getOrElse(VisitorConfig.DefaultWavelength))(_.setWavelength(_))
+    Setter[Double](visitorConfig.map(_.wavelength.toMicrons).getOrElse(VisitorConfig.DefaultWavelength.toMicrons))(_.setWavelength(_))
 
   def setPosAngle: Setter[Double] =
-    Setter[Double](instrumentConfig.map(_.positionAngle.toDegrees).getOrElse(VisitorConfig.DefaultPositionAngle))(_.setPosAngle(_))
+    Setter[Double](visitorConfig.map(_.positionAngle.toDegrees).getOrElse(VisitorConfig.DefaultPositionAngle.toDegrees))(_.setPosAngle(_))
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
@@ -41,8 +41,8 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
       this.db = None
     }
 
-  def attempt[A](a: => A) = tryFold(a) {
-    e =>
+  def attempt[A](a: => A): Either[String, A] =
+    tryFold(a) { e =>
       e.printStackTrace()
       e.getMessage
     }
@@ -51,15 +51,15 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
   def setName: Setter[String] =
     Setter[String](blueprint.name)(_.setName(_))
 
-  private def lookupInst: Option[VisitorConfig] =
-    VisitorConfig.findByName(blueprint.name)
+  def instrumentConfig: Option[VisitorConfig] =
+    blueprint.scalaVisitorConfig
 
   override def notes: List[String] =
-    lookupInst.map(_.noteTitles).getOrElse(Nil)
+    instrumentConfig.map(_.noteTitles).getOrElse(Nil)
 
   def setWavelength: Setter[Double] =
-    Setter[Double](lookupInst.map(_.wavelength.toMicrons).getOrElse(0.0))(_.setWavelength(_))
+    Setter[Double](instrumentConfig.map(_.wavelength.toMicrons).getOrElse(VisitorConfig.DefaultWavelength))(_.setWavelength(_))
 
   def setPosAngle: Setter[Double] =
-    Setter[Double](lookupInst.map(_.positionAngle.toDegrees).getOrElse(0.0))(_.setPosAngle(_))
+    Setter[Double](instrumentConfig.map(_.positionAngle.toDegrees).getOrElse(VisitorConfig.DefaultPositionAngle))(_.setPosAngle(_))
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/VisitorBlueprintSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/VisitorBlueprintSpec.scala
@@ -3,7 +3,7 @@
 
 package edu.gemini.phase2.skeleton.factory
 
-import edu.gemini.model.p1.immutable.{Site, VisitorBlueprint}
+import edu.gemini.model.p1.immutable.{AlopekeBlueprint, AlopekeMode, DssiBlueprint, GeminiBlueprintBase, IgrinsBlueprint, MaroonXBlueprint, Site, VisitorBlueprint, ZorroBlueprint, ZorroMode}
 import edu.gemini.pot.sp.{ISPProgram, SPComponentType}
 import edu.gemini.spModel.core.MagnitudeBand
 import edu.gemini.spModel.gemini.visitor.{VisitorConfig, VisitorInstrument}
@@ -15,12 +15,37 @@ import org.specs2.mutable.SpecificationLike
 
 class VisitorBlueprintSpec extends TemplateSpec("VISITOR_BP.xml") with SpecificationLike with ScalaCheck {
 
-  implicit val ArbitraryVisitorBlueprint: Arbitrary[VisitorBlueprint] =
-    Arbitrary {
-      for {
-        s <- Gen.oneOf(Site.GN, Site.GS)
-        n <- Gen.oneOf(VisitorConfig.All.map(_.name))
-      } yield VisitorBlueprint(s, n)
+  val GenAlopekeBlueprint: Gen[AlopekeBlueprint] =
+    Gen.oneOf(AlopekeMode.SPECKLE, AlopekeMode.WIDE_FIELD).map(m => AlopekeBlueprint(m))
+
+  val GenDssiBlueprint: Gen[DssiBlueprint] =
+    Gen.oneOf(Site.GN, Site.GS).map(s => DssiBlueprint(s))
+
+  val GenIgrinsBlueprint: Gen[IgrinsBlueprint] =
+    Gen.const(IgrinsBlueprint())
+
+  val GenMaroonXBlueprint: Gen[MaroonXBlueprint] =
+    Gen.const(MaroonXBlueprint())
+
+  val GenZorroBlueprint: Gen[ZorroBlueprint] =
+    Gen.oneOf(ZorroMode.SPECKLE, ZorroMode.WIDE_FIELD).map(m => ZorroBlueprint(m))
+
+  implicit val GenVisitorBlueprint: Gen[VisitorBlueprint] =
+    for {
+      s <- Gen.oneOf(Site.GN, Site.GS)
+      n <- Gen.oneOf(VisitorConfig.All.map(_.name))
+    } yield VisitorBlueprint(s, n)
+
+  implicit val ArbitraryGeminiBlueprint: Arbitrary[GeminiBlueprintBase] =
+    Arbitrary{
+      Gen.oneOf(
+        GenAlopekeBlueprint,
+        GenDssiBlueprint,
+        GenIgrinsBlueprint,
+        GenMaroonXBlueprint,
+        GenZorroBlueprint,
+        GenVisitorBlueprint
+      )
     }
 
   def visitorInstrumentComponents(sp: ISPProgram): List[VisitorInstrument] =
@@ -32,29 +57,29 @@ class VisitorBlueprintSpec extends TemplateSpec("VISITOR_BP.xml") with Specifica
   "Visitor" should {
 
     "include all notes" in {
-      forAll { (b: VisitorBlueprint) =>
+      forAll { (b: GeminiBlueprintBase) =>
         expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
-          val notes = VisitorConfig.findByName(b.customName).toList.flatMap(_.noteTitles)
+          val notes = VisitorConfig.findByInstrument(b.instrument).toList.flatMap(_.noteTitles)
           groups(sp).forall(tg => notes.forall(existsNote(tg, _)))
         }
       }
     }
 
     "set the position angle" in {
-      forAll { (b: VisitorBlueprint) =>
+      forAll { (b: GeminiBlueprintBase) =>
         expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
           visitorInstrumentComponents(sp).forall { vi =>
-            vi.getPosAngleDegrees == VisitorConfig.findByName(b.customName).map(_.positionAngle.toDegrees).getOrElse(0.0)
+            vi.getPosAngleDegrees == VisitorConfig.findByInstrument(b.instrument).map(_.positionAngle.toDegrees).getOrElse(0.0)
           }
         }
       }
     }
 
     "set the wavelength" in {
-      forAll { (b: VisitorBlueprint) =>
+      forAll { (b: GeminiBlueprintBase) =>
         expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
           visitorInstrumentComponents(sp).forall { vi =>
-            vi.getWavelength == VisitorConfig.findByName(b.customName).map(_.wavelength.toMicrons).getOrElse(0.0)
+            vi.getWavelength == VisitorConfig.findByInstrument(b.instrument).map(_.wavelength.toMicrons).getOrElse(0.0)
           }
         }
       }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprint.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprint.java
@@ -27,7 +27,7 @@ public final class SpVisitorBlueprint extends SpBlueprint {
 
     public SpVisitorBlueprint(String name, Option<VisitorConfig> visitorConfig) {
         if (name == null) throw new NullPointerException("'name' parameter cannot be null");
-        if (visitorConfig == null) throw new NullPointerException("'instrumentConfig' parameter cannot be null");
+        if (visitorConfig == null) throw new NullPointerException("'visitorConfig' parameter cannot be null");
 
         this.name          = name;
         this.visitorConfig = visitorConfig;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprint.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprint.java
@@ -2,7 +2,6 @@ package edu.gemini.spModel.gemini.visitor.blueprint;
 
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.ImOption;
-import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.gemini.visitor.VisitorConfig;
 import edu.gemini.spModel.gemini.visitor.VisitorConfig$;
 import edu.gemini.spModel.gemini.visitor.VisitorInstrument;
@@ -19,13 +18,9 @@ public final class SpVisitorBlueprint extends SpBlueprint {
     public static final String CONFIG_PARAM_NAME = "visitorConfig";
 
     public final String name;
-    public final Option<VisitorConfig> visitorConfig;
+    public final VisitorConfig visitorConfig;
 
-    public SpVisitorBlueprint(String name, scala.Option<VisitorConfig> visitorConfig) {
-        this(name, ImOption.fromScalaOpt(visitorConfig));
-    }
-
-    public SpVisitorBlueprint(String name, Option<VisitorConfig> visitorConfig) {
+    public SpVisitorBlueprint(String name, VisitorConfig visitorConfig) {
         if (name == null) throw new NullPointerException("'name' parameter cannot be null");
         if (visitorConfig == null) throw new NullPointerException("'visitorConfig' parameter cannot be null");
 
@@ -36,15 +31,12 @@ public final class SpVisitorBlueprint extends SpBlueprint {
     public SpVisitorBlueprint(ParamSet paramSet) {
         this.name          = Pio.getValue(paramSet, NAME_PARAM_NAME, "Unknown");
         this.visitorConfig = ImOption.apply(Pio.getValue(paramSet, CONFIG_PARAM_NAME))
-                              .flatMap(VisitorConfig$.MODULE$::findByNameJava);
+                              .flatMap(id -> ImOption.fromScalaOpt(VisitorConfig$.MODULE$.findByName(id)))
+                              .getOrElse(VisitorConfig.GenericVisitor$.MODULE$);
     }
 
     public String paramSetName() { return PARAM_SET_NAME; }
     public SPComponentType instrumentType() { return VisitorInstrument.SP_TYPE; }
-
-    public scala.Option<VisitorConfig> scalaVisitorConfig() {
-        return ImOption.toScalaOpt(visitorConfig);
-    }
 
     @Override
     public String toString() {
@@ -54,7 +46,7 @@ public final class SpVisitorBlueprint extends SpBlueprint {
     public ParamSet toParamSet(PioFactory factory) {
         ParamSet paramSet = factory.createParamSet(PARAM_SET_NAME);
         Pio.addParam(factory, paramSet, NAME_PARAM_NAME, name);
-        visitorConfig.foreach(c -> Pio.addParam(factory,paramSet, CONFIG_PARAM_NAME, c.name()));
+        Pio.addParam(factory,paramSet, CONFIG_PARAM_NAME, visitorConfig.name());
 
         return paramSet;
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprint.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprint.java
@@ -1,28 +1,50 @@
 package edu.gemini.spModel.gemini.visitor.blueprint;
 
 import edu.gemini.pot.sp.SPComponentType;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.spModel.gemini.visitor.VisitorConfig;
+import edu.gemini.spModel.gemini.visitor.VisitorConfig$;
 import edu.gemini.spModel.gemini.visitor.VisitorInstrument;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
 import edu.gemini.spModel.template.SpBlueprint;
 
+import java.util.Objects;
+
 public final class SpVisitorBlueprint extends SpBlueprint {
-    public static final String PARAM_SET_NAME  = "visitorBlueprint";
-    public static final String NAME_PARAM_NAME = "name";
+    public static final String PARAM_SET_NAME    = "visitorBlueprint";
+    public static final String NAME_PARAM_NAME   = "name";
+    public static final String CONFIG_PARAM_NAME = "visitorConfig";
 
     public final String name;
+    public final Option<VisitorConfig> visitorConfig;
 
-    public SpVisitorBlueprint(String name) {
-        this.name = name;
+    public SpVisitorBlueprint(String name, scala.Option<VisitorConfig> visitorConfig) {
+        this(name, ImOption.fromScalaOpt(visitorConfig));
+    }
+
+    public SpVisitorBlueprint(String name, Option<VisitorConfig> visitorConfig) {
+        if (name == null) throw new NullPointerException("'name' parameter cannot be null");
+        if (visitorConfig == null) throw new NullPointerException("'instrumentConfig' parameter cannot be null");
+
+        this.name          = name;
+        this.visitorConfig = visitorConfig;
     }
 
     public SpVisitorBlueprint(ParamSet paramSet) {
-        this.name = Pio.getValue(paramSet, NAME_PARAM_NAME, "Unknown");
+        this.name          = Pio.getValue(paramSet, NAME_PARAM_NAME, "Unknown");
+        this.visitorConfig = ImOption.apply(Pio.getValue(paramSet, CONFIG_PARAM_NAME))
+                              .flatMap(VisitorConfig$.MODULE$::findByNameJava);
     }
 
     public String paramSetName() { return PARAM_SET_NAME; }
     public SPComponentType instrumentType() { return VisitorInstrument.SP_TYPE; }
+
+    public scala.Option<VisitorConfig> scalaVisitorConfig() {
+        return ImOption.toScalaOpt(visitorConfig);
+    }
 
     @Override
     public String toString() {
@@ -32,6 +54,8 @@ public final class SpVisitorBlueprint extends SpBlueprint {
     public ParamSet toParamSet(PioFactory factory) {
         ParamSet paramSet = factory.createParamSet(PARAM_SET_NAME);
         Pio.addParam(factory, paramSet, NAME_PARAM_NAME, name);
+        visitorConfig.foreach(c -> Pio.addParam(factory,paramSet, CONFIG_PARAM_NAME, c.name()));
+
         return paramSet;
     }
 
@@ -39,16 +63,12 @@ public final class SpVisitorBlueprint extends SpBlueprint {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        SpVisitorBlueprint that = (SpVisitorBlueprint) o;
-
-        if (!name.equals(that.name)) return false;
-
-        return true;
+        final SpVisitorBlueprint that = (SpVisitorBlueprint) o;
+        return name.equals(that.name) && visitorConfig.equals(that.visitorConfig);
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return Objects.hash(name, visitorConfig);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/visitor/VisitorConfig.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/visitor/VisitorConfig.scala
@@ -3,8 +3,8 @@
 
 package edu.gemini.spModel.gemini.visitor
 
+import edu.gemini.model.p1.immutable.Instrument
 import edu.gemini.spModel.core.{Angle, Wavelength}
-import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.gemini.visitor.VisitorConfig.{DefaultPositionAngle, DefaultWavelength}
 
 import java.time.Duration
@@ -18,7 +18,13 @@ import scalaz._
  */
 sealed trait VisitorConfig extends Product with Serializable {
 
-  def name: String
+  def instrument: Instrument
+
+  def name: String =
+    instrument.display
+
+  def displayValue: String =
+    instrument.display
 
   def wavelength: Wavelength =
     DefaultWavelength
@@ -49,87 +55,97 @@ object VisitorConfig {
     Duration.ofSeconds(0)
 
   val DefaultWavelength: Wavelength =
-    Wavelength.fromNanometers(700L)
+    Wavelength.fromMicrons(0.7)
 
   val DefaultPositionAngle: Angle =
     Angle.zero
 
   case object Alopeke extends VisitorConfig {
 
-    override def name: String = "alopeke"
+    override val instrument: Instrument =
+      Instrument.Alopeke
 
-    override def wavelength: Wavelength =
-      Wavelength.fromNanometers(674)
+    override val wavelength: Wavelength =
+      Wavelength.fromMicrons(0.674)
 
-    override def setupTime: Duration =
+    override val setupTime: Duration =
       Duration.ofMinutes(5L)
 
-    override def readoutTime: Duration =
+    override val readoutTime: Duration =
       Duration.ofSeconds(6L)
 
   }
 
   case object Dssi extends VisitorConfig {
 
-    override def name: String = "dssi"
+    override val instrument: Instrument =
+      Instrument.Dssi
 
-    override def wavelength: Wavelength =
-      Wavelength.fromNanometers(700)
+    override val wavelength: Wavelength =
+      Wavelength.fromMicrons(0.7)
 
   }
 
   case object Igrins extends VisitorConfig {
 
-    override def name: String = "igrins"
+    override val instrument: Instrument =
+      Instrument.Igrins
 
-    override def wavelength: Wavelength =
-      Wavelength.fromNanometers(2100)
+    override val wavelength: Wavelength =
+      Wavelength.fromMicrons(2.1)
 
-    override def positionAngle: Angle =
+    override val positionAngle: Angle =
       Angle.fromDegrees(90.0)
 
-    override def noteTitles: List[String] =
+    override val noteTitles: List[String] =
       List(
         "IGRINS Observing Details",
         "IGRINS Scheduling Details"
       )
 
-    override def setupTime: Duration =
+    override val setupTime: Duration =
       Duration.ofMinutes(8L)
 
-    override def readoutTime: Duration =
+    override val readoutTime: Duration =
       Duration.ofSeconds(28L)
+
+  }
+
+    case object MaroonX extends VisitorConfig {
+
+    override val instrument: Instrument =
+      Instrument.MaroonX
+
+    override val wavelength: Wavelength =
+      Wavelength.fromMicrons(0.7)
+
+    override val setupTime: Duration =
+      Duration.ofMinutes(5L)
+
+    override val readoutTime: Duration =
+      Duration.ofSeconds(100L)
 
   }
 
   case object Zorro extends VisitorConfig {
 
-    override def name: String = "zorro"
+    override val instrument: Instrument =
+      Instrument.Zorro
 
-    override def wavelength: Wavelength =
-      Wavelength.fromNanometers(674)
+    override val wavelength: Wavelength =
+      Wavelength.fromMicrons(0.674)
 
-    override def setupTime: Duration =
+    override val setupTime: Duration =
       Duration.ofMinutes(5L)
 
-    override def readoutTime: Duration =
+    override val readoutTime: Duration =
       Duration.ofSeconds(6L)
 
   }
 
-  case object MaroonX extends VisitorConfig {
-
-    override def name: String = "maroonx"
-
-    override def wavelength: Wavelength =
-      Wavelength.fromNanometers(700)
-
-    override def setupTime: Duration =
-      Duration.ofMinutes(5L)
-
-    override def readoutTime: Duration =
-      Duration.ofSeconds(100L)
-
+  case object GenericVisitor extends VisitorConfig {
+    override val instrument: Instrument =
+      Instrument.Visitor
   }
 
   implicit val EqVisitorInst: Equal[VisitorConfig] =
@@ -140,14 +156,18 @@ object VisitorConfig {
       Alopeke,
       Dssi,
       Igrins,
+      MaroonX,
       Zorro,
-      MaroonX
+      GenericVisitor
     )
+
+  def AllArray: Array[VisitorConfig] =
+    All.toArray
 
   def findByName(name: String): Option[VisitorConfig] =
     All.find(_.name.equalsIgnoreCase(name))
 
-  def findByNameJava(name: String): edu.gemini.shared.util.immutable.Option[VisitorConfig] =
-    findByName(name).asGeminiOpt
+  def findByInstrument(instrument: Instrument): Option[VisitorConfig] =
+    All.find(_.instrument == instrument)
 
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/visitor/VisitorConfig.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/visitor/VisitorConfig.scala
@@ -39,6 +39,9 @@ sealed trait VisitorConfig extends Product with Serializable {
 
 object VisitorConfig {
 
+  val DefaultExposureTime: Duration =
+    Duration.ofSeconds(0L)
+
   val DefaultSetupTime: Duration =
     Duration.ofMinutes(10L)
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/visitor/VisitorConfig.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/visitor/VisitorConfig.scala
@@ -5,6 +5,7 @@ package edu.gemini.spModel.gemini.visitor
 
 import edu.gemini.spModel.core.{Angle, Wavelength}
 import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.spModel.gemini.visitor.VisitorConfig.{DefaultPositionAngle, DefaultWavelength}
 
 import java.time.Duration
 
@@ -20,10 +21,10 @@ sealed trait VisitorConfig extends Product with Serializable {
   def name: String
 
   def wavelength: Wavelength =
-    Wavelength.zero
+    DefaultWavelength
 
   def positionAngle: Angle =
-    Angle.zero
+    DefaultPositionAngle
 
   def noteTitles: List[String] =
     Nil
@@ -38,11 +39,17 @@ sealed trait VisitorConfig extends Product with Serializable {
 
 object VisitorConfig {
 
-  def DefaultSetupTime: Duration =
+  val DefaultSetupTime: Duration =
     Duration.ofMinutes(10L)
 
-  def DefaultReadoutTime: Duration =
+  val DefaultReadoutTime: Duration =
     Duration.ofSeconds(0)
+
+  val DefaultWavelength: Wavelength =
+    Wavelength.fromNanometers(700L)
+
+  val DefaultPositionAngle: Angle =
+    Angle.zero
 
   case object Alopeke extends VisitorConfig {
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/visitor/PlannedTimeTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/visitor/PlannedTimeTest.scala
@@ -4,18 +4,13 @@
 package edu.gemini.spModel.gemini.visitor
 
 import edu.gemini.pot.sp.{ISPObsComponent, SPComponentType}
-import edu.gemini.spModel.data.config.ISysConfig
 import edu.gemini.spModel.gemini.visitor.VisitorConfig.{DefaultReadoutTime, DefaultSetupTime}
-import edu.gemini.spModel.obs.plannedtime.PlannedTime.Category
 import edu.gemini.spModel.obs.plannedtime.PlannedTimeCalculator
 import edu.gemini.spModel.seqcomp.SeqRepeatObserve
-import edu.gemini.spModel.test.{InstrumentSequenceTestBase, SpModelTestBase}
-import org.junit.{Before, Test}
+import edu.gemini.spModel.test.SpModelTestBase
 import org.junit.Assert.assertEquals
 
 import java.time.Duration
-
-import scala.collection.JavaConverters._
 
 
 final class PlannedTimeTest extends SpModelTestBase {

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/visitor/PlannedTimeTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/visitor/PlannedTimeTest.scala
@@ -4,7 +4,7 @@
 package edu.gemini.spModel.gemini.visitor
 
 import edu.gemini.pot.sp.{ISPObsComponent, SPComponentType}
-import edu.gemini.spModel.gemini.visitor.VisitorConfig.{DefaultReadoutTime, DefaultSetupTime}
+import edu.gemini.shared.util.immutable.ImOption
 import edu.gemini.spModel.obs.plannedtime.PlannedTimeCalculator
 import edu.gemini.spModel.seqcomp.SeqRepeatObserve
 import edu.gemini.spModel.test.SpModelTestBase
@@ -34,13 +34,14 @@ final class PlannedTimeTest extends SpModelTestBase {
     Duration.ofMillis(PlannedTimeCalculator.instance.calc(getObs).totalTime)
 
   private def configure(
-    cfg:     Option[VisitorConfig],
+    cfg:     VisitorConfig,
     expTime: Duration,
     count:   Int
   ): Unit = {
 
     dataObj.foreach { d =>
-      d.setName(cfg.map(_.name).getOrElse("Generic"))
+      d.setName(cfg.displayValue)
+      d.setVisitorConfig(cfg)
       d.setExposureTime(expTime.toMillis.toDouble / 1000.0)
       obsComp.foreach(_.setDataObject(d))
     }
@@ -53,31 +54,31 @@ final class PlannedTimeTest extends SpModelTestBase {
   }
 
   private def exec(
-    cfg:     Option[VisitorConfig],
+    cfg:     VisitorConfig,
     expTime: Duration,
     count:   Int
   ): Unit = {
 
     configure(cfg, expTime, count)
 
-    val setup = cfg.map(_.setupTime).getOrElse(DefaultSetupTime)
-    val exp   = expTime.plus(cfg.map(_.readoutTime).getOrElse(DefaultReadoutTime)).multipliedBy(count)
+    val setup = cfg.setupTime
+    val exp   = expTime.plus(cfg.readoutTime).multipliedBy(count)
 
     assertEquals(setup.plus(exp), totalTime)
   }
 
   import VisitorConfig._
 
-  def testNoInstNoSteps(): Unit = {
-    exec(None, Duration.ofSeconds(1), 1)
+  def testGenericNoSteps(): Unit = {
+    exec(GenericVisitor, Duration.ofSeconds(1), 1)
   }
 
   def testAlopekeTwoSteps(): Unit = {
-    exec(Some(Alopeke), Duration.ofSeconds(10), 2)
+    exec(Alopeke, Duration.ofSeconds(10), 2)
   }
 
   def testIgrinsOneStep(): Unit = {
-    exec(Some(Igrins), Duration.ofSeconds(20), 1)
+    exec(Igrins, Duration.ofSeconds(20), 1)
   }
 
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprintTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprintTest.scala
@@ -13,24 +13,25 @@ final class SpVisitorBlueprintTest {
 
   @Test
   def genericSanityTests(): Unit = {
-    val generic = new SpVisitorBlueprint("name", None)
+    val generic = new SpVisitorBlueprint("name", VisitorConfig.GenericVisitor)
     assertEquals("name", generic.name)
-    assertEquals(None, generic.scalaVisitorConfig())
+    assertEquals(VisitorConfig.GenericVisitor, generic.visitorConfig)
 
     val ps = generic.toParamSet(fact)
 
     assertEquals(1, ps.getParams(NAME_PARAM_NAME).size())
     assertEquals("name", ps.getParam(NAME_PARAM_NAME).getValue)
 
-    assertEquals(0, ps.getParams(CONFIG_PARAM_NAME).size())
+    assertEquals(1, ps.getParams(CONFIG_PARAM_NAME).size())
+    assertEquals(VisitorConfig.GenericVisitor.name, ps.getParam(CONFIG_PARAM_NAME).getValue)
 
   }
 
   @Test
   def igrinsSanityTests(): Unit = {
-    val igrins = new SpVisitorBlueprint("igrins", Some(VisitorConfig.Igrins))
+    val igrins = new SpVisitorBlueprint("igrins", VisitorConfig.Igrins)
     assertEquals("igrins", igrins.name)
-    assertEquals(Some(VisitorConfig.Igrins), igrins.scalaVisitorConfig())
+    assertEquals(VisitorConfig.Igrins, igrins.visitorConfig)
 
     val ps = igrins.toParamSet(fact)
 
@@ -43,7 +44,7 @@ final class SpVisitorBlueprintTest {
 
   @Test
   def igrinsRoundtripTest(): Unit = {
-    val igrins = new SpVisitorBlueprint("igrins", Some(VisitorConfig.Igrins))
+    val igrins = new SpVisitorBlueprint("igrins", VisitorConfig.Igrins)
     assertEquals(igrins, new SpVisitorBlueprint(igrins.toParamSet(fact)))
   }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprintTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/visitor/blueprint/SpVisitorBlueprintTest.scala
@@ -1,19 +1,50 @@
 package edu.gemini.spModel.gemini.visitor.blueprint
 
+import edu.gemini.spModel.gemini.visitor.VisitorConfig
 import org.junit.Test
 import org.junit.Assert._
-import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.pio.xml.PioXmlFactory
-import edu.gemini.spModel.gemini.texes.TexesParams
 
-class SpVisitorBlueprintTest {
+import SpVisitorBlueprint.{NAME_PARAM_NAME, CONFIG_PARAM_NAME}
+
+final class SpVisitorBlueprintTest {
+
+  val fact = new PioXmlFactory
+
   @Test
-  def sanityTests() {
-    // Check filters are preserved
-    val blueprint = new SpVisitorBlueprint("name")
-    assertEquals("name", blueprint.name)
+  def genericSanityTests(): Unit = {
+    val generic = new SpVisitorBlueprint("name", None)
+    assertEquals("name", generic.name)
+    assertEquals(None, generic.scalaVisitorConfig())
 
-    // Verify Could be in GN
-    assertEquals(1, blueprint.toParamSet(new PioXmlFactory).getParams(SpVisitorBlueprint.NAME_PARAM_NAME).size())
+    val ps = generic.toParamSet(fact)
+
+    assertEquals(1, ps.getParams(NAME_PARAM_NAME).size())
+    assertEquals("name", ps.getParam(NAME_PARAM_NAME).getValue)
+
+    assertEquals(0, ps.getParams(CONFIG_PARAM_NAME).size())
+
   }
+
+  @Test
+  def igrinsSanityTests(): Unit = {
+    val igrins = new SpVisitorBlueprint("igrins", Some(VisitorConfig.Igrins))
+    assertEquals("igrins", igrins.name)
+    assertEquals(Some(VisitorConfig.Igrins), igrins.scalaVisitorConfig())
+
+    val ps = igrins.toParamSet(fact)
+
+    assertEquals(1, ps.getParams(NAME_PARAM_NAME).size())
+    assertEquals("igrins", ps.getParam(NAME_PARAM_NAME).getValue)
+
+    assertEquals(1, ps.getParams(CONFIG_PARAM_NAME).size())
+    assertEquals(VisitorConfig.Igrins.name, ps.getParam(CONFIG_PARAM_NAME).getValue)
+  }
+
+  @Test
+  def igrinsRoundtripTest(): Unit = {
+    val igrins = new SpVisitorBlueprint("igrins", Some(VisitorConfig.Igrins))
+    assertEquals(igrins, new SpVisitorBlueprint(igrins.toParamSet(fact)))
+  }
+
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/visitor/VisitorEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/visitor/VisitorEditor.java
@@ -3,7 +3,6 @@ package jsky.app.ot.gemini.visitor;
 import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.shared.gui.bean.ComboPropertyCtrl;
 import edu.gemini.shared.gui.bean.TextFieldPropertyCtrl;
-import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.gemini.visitor.VisitorConfig;
 import edu.gemini.spModel.gemini.visitor.VisitorConfig$;
 import edu.gemini.spModel.gemini.visitor.VisitorInstrument;
@@ -13,6 +12,7 @@ import jsky.app.ot.gemini.editor.ComponentEditor;
 import javax.swing.*;
 import java.awt.*;
 import java.beans.PropertyDescriptor;
+import java.util.function.Function;
 
 /**
  * User Interface for visitor instruments.
@@ -49,9 +49,8 @@ public class VisitorEditor extends ComponentEditor<ISPObsComponent, VisitorInstr
 
         // Visitor Config
         final PropertyDescriptor configProp = VisitorInstrument.CONFIG_PROP;
-        configCtrl = new ComboPropertyCtrl<>(configProp, VisitorConfig$.MODULE$.AllArray(), VisitorConfig::displayValue);
-
-//                ComboPropertyCtrl.optionInstance(configProp, VisitorConfig$.MODULE$.AllArray(), v -;
+        final Function<VisitorConfig, String> renderer = v -> (v == VisitorConfig.GenericVisitor$.MODULE$) ? "Other" : v.displayValue();
+        configCtrl = new ComboPropertyCtrl<>(configProp, VisitorConfig$.MODULE$.AllArray(), renderer);
 
         pan.add(new JLabel("Visitor"), propLabelGbc(rightLabelCol, row));
         pan.add(configCtrl.getComponent(), propWidgetGbc(rightWidgetCol, row));

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/visitor/VisitorEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/visitor/VisitorEditor.java
@@ -1,8 +1,13 @@
 package jsky.app.ot.gemini.visitor;
 
 import edu.gemini.pot.sp.ISPObsComponent;
+import edu.gemini.shared.gui.bean.ComboPropertyCtrl;
 import edu.gemini.shared.gui.bean.TextFieldPropertyCtrl;
+import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.spModel.gemini.visitor.VisitorConfig;
+import edu.gemini.spModel.gemini.visitor.VisitorConfig$;
 import edu.gemini.spModel.gemini.visitor.VisitorInstrument;
+import jsky.app.ot.StaffBean;
 import jsky.app.ot.gemini.editor.ComponentEditor;
 
 import javax.swing.*;
@@ -19,7 +24,8 @@ public class VisitorEditor extends ComponentEditor<ISPObsComponent, VisitorInstr
     private final TextFieldPropertyCtrl<VisitorInstrument, Double> posAngleCtrl;
     private final TextFieldPropertyCtrl<VisitorInstrument, String> nameCtrl;
     private final TextFieldPropertyCtrl<VisitorInstrument, Double> wavelengthCtrl;
-    private static final int gapCol        = 1;
+    private final ComboPropertyCtrl<VisitorInstrument, VisitorConfig> configCtrl;
+
     private static final int rightLabelCol = 1;
     private static final int rightWidgetCol= 2;
     private static final int rightUnitsCol = 3;
@@ -38,6 +44,17 @@ public class VisitorEditor extends ComponentEditor<ISPObsComponent, VisitorInstr
         nameCtrl.getTextField().addMouseListener(focusOnCaretPositionListener);
         pan.add(new JLabel(instrumentNameProp.getDisplayName()), propLabelGbc(rightLabelCol, row));
         pan.add(nameCtrl.getComponent(), propWidgetGbc(rightWidgetCol, row, 2, 1));
+
+        ++row;
+
+        // Visitor Config
+        final PropertyDescriptor configProp = VisitorInstrument.CONFIG_PROP;
+        configCtrl = new ComboPropertyCtrl<>(configProp, VisitorConfig$.MODULE$.AllArray(), VisitorConfig::displayValue);
+
+//                ComboPropertyCtrl.optionInstance(configProp, VisitorConfig$.MODULE$.AllArray(), v -;
+
+        pan.add(new JLabel("Visitor"), propLabelGbc(rightLabelCol, row));
+        pan.add(configCtrl.getComponent(), propWidgetGbc(rightWidgetCol, row));
 
         ++row;
 
@@ -73,6 +90,10 @@ public class VisitorEditor extends ComponentEditor<ISPObsComponent, VisitorInstr
 
         // Filler
         pan.add(new JPanel(), pushGbc(colCount, row + 1));
+
+        // When the key changes, enable/disable the visitor instrument selector
+        StaffBean.addPropertyChangeListener(evt -> adjustStaffOnlyFields());
+        adjustStaffOnlyFields();
     }
 
     @Override
@@ -86,6 +107,11 @@ public class VisitorEditor extends ComponentEditor<ISPObsComponent, VisitorInstr
         posAngleCtrl.setBean(inst);
         nameCtrl.setBean(inst);
         wavelengthCtrl.setBean(inst);
+        configCtrl.setBean(inst);
+    }
+
+    private void adjustStaffOnlyFields() {
+        configCtrl.getComponent().setEnabled(StaffBean.isStaff());
     }
 
 }


### PR DESCRIPTION
The PR fixes an issue with visitor instrument configurations.  Heretofore we relied upon the `name` parameter of the visitor instrument in order to lookup the corresponding configuration.  Because that's silly and error-prone, and because we do _have_ the proper visitor instrument identification from the outset at Phase 1, this PR changes `VisitorInstrument` to track the corresponding configuration directly.

There is a matching change to the visitor instrument editor in the OT.  Staff users can select the visitor instrument configuration to apply (for setup and readout time).  PIs can see which one was selected.

![Screen Shot 2021-10-15 at 12 27 26](https://user-images.githubusercontent.com/4906023/137513198-aac9a546-d41d-433e-bf63-e513f6899830.png)

In the screen shot above the "Name" is "Zorro Wide Field" etc. etc.  We could pick out "Zorro" and cross our fingers or we could actually store the `VisitorConfig.Zorro` instead, which is what this PR accomplishes. 

