### PR TITLE
REL-3987 GMOS skeleton updates

### DIFF
--- a/bundle/edu.gemini.phase2.core/src/main/java/edu/gemini/phase2/core/model/GroupShell.java
+++ b/bundle/edu.gemini.phase2.core/src/main/java/edu/gemini/phase2/core/model/GroupShell.java
@@ -67,6 +67,7 @@ public final class GroupShell extends BaseGroupShell {
         final TemplateGroup dataObj = new TemplateGroup();
         dataObj.setBlueprintId(blueprintId);
         dataObj.setTitle(group.getTitle());
+        dataObj.setGroupType(group.getGroupType());
         return new TemplateGroupShell(dataObj, argList, obsComponents, observations);
     }
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_N_BP.txt
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_N_BP.txt
@@ -4,6 +4,8 @@ Version : 2013 October 9, Bryan Miller, set MOS slit width
 Version : 2013 October 10, AStephens, add Altair
 Version : 2013 November 10, Bryan Miller, set slit width for MOS acqs
 Version : 2014 May 9, AStephens, set AO imaging Xbin=Ybin=1 and slit spectroscopy Ybin=1
+Version : 2016 September 2, Bryan Miller, rules for MOS mask names
+Version : 2021 September 14, jscharwaechter, change target groups to folders, move science arcs into target folders, updates to xml templates
 
 Target and conditions information from the Phase I observations only
 needs to be entered into the template science observations. Daytime
@@ -31,8 +33,8 @@ INCLUDE BP{1}
 
 IF SPECTROSCOPY MODE == LONGSLIT
         INCLUDE FROM 'LONGSLIT BP' IN
-            Target group: {2} - {3}
-            Baseline folder: {4}-{8}
+            Target folder: {2} - {4}
+            Baseline folder: {5}-{8}
         For spec observations: {3}, {4}, {6}-{8}
             SET DISPERSER FROM PI
             SET FILTER FROM PI
@@ -46,8 +48,8 @@ IF SPECTROSCOPY MODE == LONGSLIT
         
 IF SPECTROSCOPY MODE == LONGSLIT N&S
         INCLUDE FROM 'LONGSLIT N&S BP' IN
-            Target group: {9} - {10}
-            Baseline folder: {11} - {16}
+            Target folder: {9} - {11}
+            Baseline folder: {12} - {16}
         For spec observations: {10}, {11}, {13}-{15}    
             SET DISPERSER FROM PI
             SET FILTER FROM PI
@@ -61,19 +63,27 @@ IF SPECTROSCOPY MODE == LONGSLIT N&S
 
 IF SPECTROSCOPY MODE == MOS
         INCLUDE FROM 'MOS BP' IN
-            Target group:   {20}, {21} - {23}
+            Target folder:   {20}, {21} - {23}
               IF PRE-IMAGING REQ == YES
                 INCLUDE {18}, {17}
               IF PRE-IMAGING REQ == NO
                 INCLUDE {19}
             Baseline folder: {24}-{26}
         For spec observations: {20}, {21}, {23}, {25}, {26}
-                SET DISPERSER FROM PI
-                SET FILTER FROM PI
-                For {20}, {21}
-                    SET MOS "Slit Width" from PI
-                For {25}, {26} 
-                    SET FPU (built-in longslit) using the width specified in PI
+            SET DISPERSER FROM PI
+            SET FILTER FROM PI
+            For {20}, {21}
+                SET MOS "Slit Width" from PI
+            For {25}, {26} 
+                SET FPU (built-in longslit) using the width specified in PI
+        For MOS observations in the target folder (not pre-image): any of {18} - {23}
+            SET "Custom Mask MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN 
+                where: 
+                (N/S) is the site 
+                YYYYS is the semester, e.g. 2015A 
+                (Q/C/DD/SV/LP/FT) is the program type 
+                XXX is the program number, e.g. 001, or 012, or 123 
+                NN should be the string "NN" since the mask number is unknown
         For standard acquisition: {24}
             if FPU!=None in the OT inst. iterators, then SET FPU (built-in longslit) using the width specified in PI
         For acquisitions: {18}, {19}, and mask image {22}
@@ -85,19 +95,27 @@ IF SPECTROSCOPY MODE == MOS
 
 IF SPECTROSCOPY MODE == MOS N&S
         INCLUDE IN
-            Target group: {29}, {22}, {31}, {32}
+            Target folder: {29}, {22}, {31}, {32}
               IF PRE-IMAGING REQ == YES
                 INCLUDE {17}, {27}
               IF PRE-IMAGING REQ == NO
                 INCLUDE {28}
             Baseline folder: {30}, {33}-{35}
-       For spec observations: {29}, {31}, {32}, {34}, {35}
+        For spec observations: {29}, {31}, {32}, {34}, {35}
             SET DISPERSER FROM PI
             SET FILTER FROM PI
             For {29}, {31}
                 SET MOS "Slit Width" from PI
             For {34}, {35} 
                 SET FPU (built-in longslit) using the width specified in PI
+        For MOS observations in the target folder (not pre-image): any of {27} - {32}
+            SET "Custom Mask MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN 
+                where: 
+                (N/S) is the site 
+                YYYYS is the semester, e.g. 2015A 
+                (Q/C/DD/SV/LP/FT) is the program type 
+                XXX is the program number, e.g. 001, or 012, or 123 
+                NN should be the string "NN" since the mask number is unknown
         For standard acquisition: {33}
             if FPU!=None in the OT inst. iterators, then SET FPU (built-in longslit) using the width specified in PI
         For acquisitions {27}, {28}; mask image {22}; and N&S dark {30}
@@ -109,8 +127,8 @@ IF SPECTROSCOPY MODE == MOS N&S
 
 IF SPECTROSCOPY MODE == IFU
         INCLUDE FROM 'IFU BP' IN,
-            Target group: {36}-{37}
-            Baseline folder: {38}-{42}
+            Target folder: {36}-{38}
+            Baseline folder: {39}-{42}
         Where FPU!=None in BP (static and iterator), SET FPU from PI
             IFU acq obs have an iterator titled "Field image" with
                 FPU=None, the FPU must not be set here.

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_N_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_N_BP.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
 
 <document>
-  <container kind="program" type="Program" version="2018A-1" subtype="basic" key="c313a6e9-cf0e-4a98-a2bf-192f3091d541" name="GMOS-N-BP-copy3">
+  <container kind="program" type="Program" version="2020A-1" subtype="basic" key="c313a6e9-cf0e-4a98-a2bf-192f3091d541" name="GMOS-N-BP-copy3">
     <paramset name="Science Program" kind="dataObj">
       <param name="title" value="GMOS-N PHASE I/II MAPPING BPS"/>
       <param name="programMode" value="QUEUE"/>
@@ -48,8 +48,15 @@
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="87e0d018-9254-4c98-aaf3-e57152ba45bd" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
@@ -62,6 +69,8 @@
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0303"/>
@@ -106,18 +115,18 @@
                     <param name="defaultGuideOption" value="on"/>
                   </paramset>
                   <paramset name="Offset0" sequence="1">
-                    <param name="p" value="7.0"/>
-                    <param name="q" value="7.0"/>
+                    <param name="p" value="10.0"/>
+                    <param name="q" value="10.0"/>
                     <param name="defaultGuideOption" value="on"/>
                   </paramset>
                   <paramset name="Offset3" sequence="2">
-                    <param name="p" value="7.0"/>
+                    <param name="p" value="10.0"/>
                     <param name="q" value="0.0"/>
                     <param name="defaultGuideOption" value="on"/>
                   </paramset>
                   <paramset name="Offset2" sequence="3">
                     <param name="p" value="0.0"/>
-                    <param name="q" value="7.0"/>
+                    <param name="q" value="10.0"/>
                     <param name="defaultGuideOption" value="on"/>
                   </paramset>
                 </paramset>
@@ -146,8 +155,15 @@
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="cc4f5d5a-33d4-46f9-abac-946121749b27" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -225,6 +241,8 @@ Details:
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
             <param name="filter" value="r_G0303"/>
@@ -365,8 +383,15 @@ Details:
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="24d865b6-d02f-4d31-be78-bf88f67b4dab" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -550,8 +575,15 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e8540b42-2a0e-4c3b-8b55-c1267d8eebd5" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -693,8 +725,15 @@ time for the given instrument configuration.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5fdd546f-6bfd-41d4-aff7-02210eda5175" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -735,6 +774,8 @@ The FPU should match the one used for the Baseline Standard observation.
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
             <param name="filter" value="g_G0301"/>
@@ -892,8 +933,15 @@ The FPU should match the one used for the Baseline Standard observation.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="b8837917-7c39-4400-b8a1-76bf430cd687" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -1006,8 +1054,15 @@ when conditions are convenient for observing baseline standards.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a111820d-e7d0-4d08-9261-0aae7313a3fe" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -1135,8 +1190,15 @@ time for the given instrument configuration.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="b9b9b1d9-3efc-4266-b643-cd88c45e1db4" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -1270,8 +1332,15 @@ The exposure is taken on the sky so the Translation stage should be
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="e1ba843a-938f-4028-8904-c5fbd45f3887" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -1340,6 +1409,8 @@ Details:
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="NS_3"/>
             <param name="filter" value="r_G0303"/>
@@ -1480,8 +1551,15 @@ Details:
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a4b43a3e-98e1-4313-88f1-f1567c898d85" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -1517,9 +1595,10 @@ The exposures are the follow:
    science  at 770nm, DtaX=-4
    GCALflat at 770nm, DtaX=-4
 
-The DTAX offset dither sequence is recommended to help reduce the effect
-of charge traps in the data; see the N&amp;S web pages.  Here by using four
-GMOS-N Sequences to change central wavelength and dither the DTAX we save 
+DTA-X offsetting was implemented to aid in the suppression of linear charge traps affecting 
+Nod &amp; Shuffle data in the original EEV detectors. With the upgraded GMOS-N and GMOS-S 
+Hamamatsu detectors DTA-X offsetting is no longer as advantageous; see the N&amp;S web pages.  
+Here by using four GMOS-N Sequences to change central wavelength and dither the DTAX we save 
 on overhead with an efficient science-flat-flat-science-science-flat-flat-science 
 arrangement, minimizing the number of calibration congfiguration movements 
 required.
@@ -1552,7 +1631,7 @@ required.
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
+            <param name="nsNumCycles" value="10"/>
             <param name="nsDetectorRows" value="1392"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
@@ -1775,8 +1854,15 @@ required.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="039f6d59-a669-4cc9-be57-40e70cffadec" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -1914,8 +2000,15 @@ time for the given instrument configuration.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="c670d1e5-25de-4df2-a9ec-8ece19f5540e" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -1954,6 +2047,8 @@ Step 4: Copy of the third step and is used only if necessary to further
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="NS_3"/>
             <param name="filter" value="i_G0302"/>
@@ -2111,8 +2206,15 @@ Step 4: Copy of the third step and is used only if necessary to further
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="8a36ea12-177f-48c4-aa3b-933ada992b06" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -2227,8 +2329,15 @@ when conditions are convenient for observing baseline standards.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="551acb3c-4650-44b3-8ff3-6a9e68bea450" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -2358,8 +2467,15 @@ time for the given instrument configuration.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="b4a31bbb-9a35-4faf-acbd-c3b0459a5ee7" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -2484,13 +2600,20 @@ The exposure is taken on the sky so the Translation stage should be
       </container>
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="a1b24a11-b110-4e25-abe9-2366dd5c2da8" name="GMOS-N-BP-copy3-16">
         <paramset name="Observation" kind="dataObj">
-          <param name="title" value="N&amp;S Longslit: Baseline Dark: A=60, 15cy, 2x2, 1392pix"/>
+          <param name="title" value="N&amp;S Longslit: Baseline Dark: A=60, 10cy, 2x1, 1392row"/>
           <param name="libraryId" value="16"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="a6607511-56e7-4d5f-989a-9d1b577e07d7" name="Observing Conditions">
           <paramset name="Observing Conditions" kind="dataObj">
@@ -2548,13 +2671,13 @@ TAKEN from the GMOS-N component.
 
 Offset (shuffle distance) = 1392 rows for N&amp;S LONGSLIT darks.
 
-Number of N&amp;S cycles (same as the science exposure) = 15 in this example.
-Therefore, the total open shutter time is 1800sec per dark exposure in this example.
+Number of N&amp;S cycles (same as the science exposure) = 10 in this example.
+Therefore, the total open shutter time is 1200sec per dark exposure in this example.
 Note that the number of N&amp;S cycles IS taken from the static GMOS-N component.
 For example, setting the Dark to have an Observe 15x will take 15 N&amp;S darks, 
-each having 15 N&amp;S cycles.
+each having 10 N&amp;S cycles.
 
-Detector Binning = 2x2 in this example
+Detector Binning = 2x1 in this example
 
 The guide star has been removed from the target component since the
 telescope will be stationary at zenith for this observation.
@@ -2581,6 +2704,8 @@ Number of N&amp;S observations is 15</value>
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0303"/>
@@ -2592,7 +2717,7 @@ Number of N&amp;S observations is 15</value>
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
+            <param name="nsNumCycles" value="10"/>
             <param name="nsDetectorRows" value="1392"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
@@ -2605,7 +2730,7 @@ Number of N&amp;S observations is 15</value>
               </paramset>
               <paramset name="Offset1" sequence="1">
                 <param name="p" value="0.0"/>
-                <param name="q" value="10.0"/>
+                <param name="q" value="0.0"/>
                 <param name="defaultGuideOption" value="on"/>
                 <param name="GMOS OIWFS" value="park"/>
               </paramset>
@@ -2653,8 +2778,15 @@ Number of N&amp;S observations is 15</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="7b203573-bd09-4fd0-b222-7b9235eb7dae" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -2688,6 +2820,8 @@ can be submitted.</value>
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0303"/>
@@ -2759,8 +2893,15 @@ can be submitted.</value>
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="7bccbfdf-71ca-46cb-803c-e21d0ee4842e" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
@@ -2773,6 +2914,8 @@ can be submitted.</value>
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
@@ -2885,8 +3028,15 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="d5c6b572-3865-4a49-aa52-e21fab4aa4a7" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -2978,6 +3128,8 @@ gacq *filenumber*
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
@@ -3103,8 +3255,15 @@ gacq *filenumber*
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="13c0cfd1-bb01-4b0a-b79b-8a088c2e8183" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -3274,8 +3433,15 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="584a6768-6c9a-40c2-9725-7da8d73d185e" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -3287,7 +3453,7 @@ during the day (class=Daytime Calibration).
 The guide star has been removed from the target component, since the
 telescope will be stationary at zenith for this observation.
 
-The Translation Stage has been set to "Follow in Z Only" since the telescope is stationary
+The Translation Stage has been set to "Do not Follow" since the telescope is stationary
 and the Telescope Control System may not be up when this observation
 is taken.
 
@@ -3422,8 +3588,15 @@ time for the given slit width.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="b481cf7e-4914-4b5d-97af-3c8a06b29e66" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -3496,6 +3669,8 @@ Gemini Staff.
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
@@ -3583,8 +3758,15 @@ Gemini Staff.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="6fe1f4d6-bbda-45f2-b765-22a3dd4be866" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -3724,8 +3906,15 @@ masks for use, with a technical limit of 99 masks).</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="a121cb30-9fe1-4eff-9139-eb253ab9b0a7" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -3768,6 +3957,8 @@ The FPU, binning and exposure time are sequenced.
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
             <param name="filter" value="g_G0301"/>
@@ -3925,8 +4116,15 @@ The FPU, binning and exposure time are sequenced.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="885d67fe-7847-44b8-a5bc-caba170d32dc" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -4084,8 +4282,15 @@ spectrophotometric baseline standards.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="8aa5c8f5-00aa-4b35-b3b3-122295301c3c" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -4230,8 +4435,15 @@ as used for the Baseline Standard observation.
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GMOS" key="b79f6096-b017-4210-886e-bb1385ae8ff7" name="GMOS-N">
           <paramset name="GMOS-N" kind="dataObj">
@@ -4244,6 +4456,8 @@ as used for the Baseline Standard observation.
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
@@ -4356,8 +4570,15 @@ defined until after the mask has been designed and submitted.  The Custom ROI fi
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="29eb8fd2-cc73-4d42-9280-e807fc68d7d0" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -4449,6 +4670,8 @@ gacq *filenumber*
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GNYYYYSQXXX-NN"/>
@@ -4574,8 +4797,15 @@ gacq *filenumber*
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="69ea82c3-9e20-49cc-8603-0ab3a02fea85" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -4599,10 +4829,11 @@ defined with respect to the slit center and should be smaller than the half the
 defined slit length.  The NODs are only in the q direction, along the slit, and not in 
 the p direction which is across the slit.
 
-The sequence dithers the DTAX in order to minimize the effect of "charge trap"
-features which appear in Nod &amp; Shuffled data.  The sequence also dithers the
-grating spectrally by by 10 nm above and below the central wavelength in order to
-fill in the information missing due to the gaps between the detectors.
+DTA-X offsetting was implemented to aid in the suppression of linear charge traps affecting 
+Nod &amp; Shuffle data in the original EEV detectors. With the upgraded GMOS-N and GMOS-S 
+Hamamatsu detectors DTA-X offsetting is no longer as advantageous; see the N&amp;S web pages.
+The sequence also dithers the grating spectrally by by 10 nm above and below the 
+central wavelength in order to fill in the information missing due to the gaps between the detectors.
 
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
@@ -4615,10 +4846,10 @@ and the central wavelength.  By using nested GMOS-N Sequences to dither the DTAX
 central wavelength we save on overhead with an efficient flat-science-science-flat-flat-science 
 arrangement, minimizing the numberof calibration congfiguration movements required.
 
-Each science exposure consists of 15 N&amp;S cycles. The nods are along the 
+Each science exposure consists of 10 N&amp;S cycles. The nods are along the 
 slits, keeping the science targets in the slits at all times. The total on-target
-open shutter time is 1800sec per science exposure in this example,
-4.5hour total for the full observation.
+open shutter time is 1200sec per science exposure in this example,
+3hour total for the full observation.
 
 The other required observations for a MOS N&amp;S program are similar to 
 those for non N&amp;S MOS program.  Only the actual science observation is 
@@ -4681,7 +4912,7 @@ masks for use, with a technical limit of 99 masks).
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
+            <param name="nsNumCycles" value="10"/>
             <param name="nsDetectorRows" value="63"/>
             <param name="useElectronicOffsetting" value="true"/>
             <paramset name="nsShuffleOffset">
@@ -4899,13 +5130,20 @@ masks for use, with a technical limit of 99 masks).
       </container>
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="606a0a71-6557-4620-ab9b-b0c4bfb7ca58" name="GMOS-N-BP-copy3-30">
         <paramset name="Observation" kind="dataObj">
-          <param name="title" value="MOS N&amp;S: Baseline Dark A=60, 15cy, 2x2, 32pix"/>
+          <param name="title" value="MOS N&amp;S: Baseline Dark A=60, 10cy, 2x1, 63row"/>
           <param name="libraryId" value="30"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5d9d7729-7b34-4764-a541-dad7d29209a8" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -4928,12 +5166,12 @@ of *unbinned* pixels no matter what the binning is set to.  For micro-shuffling
 this number must match the slit length in the MOS mask design.  For Band 
 Shuffling this number must match the band size used in the MOS mask design.
 
-Number of N&amp;S Cycles = 15 in this example.  Note that the number 
+Number of N&amp;S Cycles = 10 in this example.  Note that the number 
 of N&amp;S cycles IS taken from the static GMOS-N component (another
 potentially confusing feature).  Setting the Dark to have an Observe 15x 
-will take 15 N&amp;S darks, each having 15 N&amp;S cycles.
+will take 15 N&amp;S darks, each having 10 N&amp;S cycles.
 
-Detector Binning = 2x2 in this example.
+Detector Binning = 2x1 in this example.
 
 These four parameters define a Nod &amp; Shuffle dark.  It is recommended
 that all PIs using Nod &amp; Shuffle define darks to match their science
@@ -4957,6 +5195,8 @@ obtained on a best effort basis.</value>
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0303"/>
@@ -4968,7 +5208,7 @@ obtained on a best effort basis.</value>
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
+            <param name="nsNumCycles" value="10"/>
             <param name="nsDetectorRows" value="63"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
@@ -5059,8 +5299,15 @@ obtained on a best effort basis.</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="4bd30e62-a4be-4a58-8e23-fac4ae1ae354" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -5201,8 +5448,15 @@ time for the given instrument configuration.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="b7c0b88c-2b5b-4f02-b27f-81923fcb710f" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -5343,8 +5597,15 @@ masks for use, with a technical limit of 99 masks).</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="9611ce6d-0502-4914-847d-f491bac0da54" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -5382,6 +5643,8 @@ Step 4: Another image though the slit which is used only if additional centering
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
             <param name="filter" value="i_G0302"/>
@@ -5539,8 +5802,15 @@ Step 4: Another image though the slit which is used only if additional centering
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="5a22caec-63bf-4f60-9755-e894e826a3cc" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -5702,8 +5972,15 @@ time for the given instrument configuration.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="167d4927-425d-4203-beb3-c4c6b6514ec6" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -5847,8 +6124,15 @@ time for the given instrument configuration.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="79e27718-4295-4d21-8ccb-ed8eed5459aa" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -5869,7 +6153,7 @@ recommended for acquisition observations.
 
 For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  
 For more information on blind offsetting, please see 
-http://www.gemini.edu/sciops/telescopes-and-sites/acquisition-hardware-and-techniques/acquisition-techniques.
+https://www.gemini.edu/observing/telescopes-and-sites/telescopes#Acquisition.
 For help setting up the acquistion, see the Description note for the "Longslit Acquisition (Blind Offset)" within the 
 Templates: Spectroscopy Acquisition Observations folder.  If it is not possible to find a nearby reference star with well 
 known coordinates for blind offsetting, make the 2nd step be another imaging exposure, such that the position of the target 
@@ -5891,6 +6175,8 @@ will approximately fall in the IFU field of view.
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
             <param name="filter" value="r_G0303"/>
@@ -5998,8 +6284,15 @@ will approximately fall in the IFU field of view.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="ac78fa02-c2a6-4aee-bb25-263825886137" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -6011,7 +6304,7 @@ The instrument is configured based on the Phase I resource selections.
 It is assumed that GMOS is mounted on the side-looking ISS port.
 
 For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  
-For more information on blind offsetting, please see http://www.gemini.edu/sciops/telescopes-and-sites/acquisition-hardware-and-techniques/acquisition-techniques.
+For more information on blind offsetting, please see https://www.gemini.edu/observing/telescopes-and-sites/telescopes#Acquisition.
 For help setting up the acquistion, see the Description note for the "Longslit Acquisition (Blind Offset)" within the Templates: Spectroscopy Acquisition Observations folder.  
 If it is not possible to find a nearby reference star with well known coordinates for blind offsetting, make the 2nd step be another imaging exposure, such that the position 
 of the target on the CCD in imaging mode can be checked after the initial telescope offset has been determined and applied. The blind offset method is preferred because 
@@ -6178,8 +6471,15 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="8c6bd666-0b7c-460d-9902-2ed3cdb93f21" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -6313,8 +6613,15 @@ time for the given instrument configuration.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="f45645a1-8c52-4703-8967-a62b8b23f45a" name="Targets">
           <paramset name="Targets" kind="dataObj">
@@ -6437,8 +6744,15 @@ easy for the observer to adjust it as needed for the brightness of the sky.</val
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="294bf61b-fd3a-4e3f-a565-bc0ac3289582" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -6450,7 +6764,7 @@ during the day (class=Daytime Calibration) for Baseline Standard.
 - The guide star has been removed from the target component, since the
 telescope will be stationary at zenith for this observation.
 
-- The Translation Stage has been set to "Follow in Z Only" since the telescope is stationary
+- The Translation Stage has been set to "Do not Follow" since the telescope is stationary
 and the Telescope Control System may not be up when this observation
 is taken.
 
@@ -6564,8 +6878,15 @@ time for the given instrument configuration.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="e90d49b7-623c-4829-9af3-f2b8f23dc5a7" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -6601,6 +6922,8 @@ Step 3: Copy of step 2 to further adjust the centering of the target in the IFU.
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
             <param name="filter" value="r_G0303"/>
@@ -6720,8 +7043,15 @@ Step 3: Copy of step 2 to further adjust the centering of the target in the IFU.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
         </paramset>
         <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="e35e9b79-ab14-4f2d-b73f-1f5adeecce66" name="Note">
           <paramset name="Note" kind="dataObj">
@@ -6865,6 +7195,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="606a0a71-6557-4620-ab9b-b0c4bfb7ca58"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="16"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="b42e602a-51fa-4b44-85ae-c4910a679b2b"/>
@@ -6941,6 +7272,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="69ea82c3-9e20-49cc-8603-0ab3a02fea85"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="18"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="31420daa-15eb-4c59-9e2f-d8efb5459989"/>
@@ -7353,10 +7685,12 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="ac78fa02-c2a6-4aee-bb25-263825886137"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="190718b9-50ad-45c9-8274-d2a9c89502c8" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="0d94736c-76b6-421f-9fcc-8744da7f9762"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="12"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="8cccea12-1769-4b4c-9e83-ff70f79f1a75"/>
@@ -7694,6 +8028,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="5d9d7729-7b34-4764-a541-dad7d29209a8"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="6"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="942934eb-409d-4529-baf3-3ccf8d78e2cf"/>
@@ -7838,6 +8173,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="e3cbe75a-8b3c-460f-9959-077abe9cde88"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="f45645a1-8c52-4703-8967-a62b8b23f45a"/>
@@ -8058,6 +8394,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="584a6768-6c9a-40c2-9725-7da8d73d185e"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="300a9db0-5fb5-42fd-ae58-a8bb3167a2b3"/>
@@ -8102,6 +8439,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="294bf61b-fd3a-4e3f-a565-bc0ac3289582"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="9203b1b4-4b50-4a8b-9818-561c478a1b2a"/>
@@ -8218,6 +8556,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="79e27718-4295-4d21-8ccb-ed8eed5459aa"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="190718b9-50ad-45c9-8274-d2a9c89502c8" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="1398f642-a19c-489e-82f6-1bf11a980cf9"/>
@@ -8250,6 +8589,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="a1b24a11-b110-4e25-abe9-2366dd5c2da8"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="14"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="a5613f95-03c2-4673-84bc-27dea85340b9"/>
@@ -8302,6 +8642,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="faf8d275-ccfa-4e22-a670-fd045cc592d4"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="a7502b90-dcdb-4447-9c7a-4b284e9e6329"/>
@@ -8518,6 +8859,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="31a0376c-0718-438e-b3fc-aad2b6e10172"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="8"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="26032384-b381-42c0-9b2b-12321a037d9c"/>
@@ -8646,6 +8988,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="93986720-47e0-426a-b202-21844de0cb15"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="3"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="50c878b3-6180-4be1-b0a5-23d0c8d781b9"/>
@@ -8786,6 +9129,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="a4b43a3e-98e1-4313-88f1-f1567c898d85"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="8"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="d5b33b21-7443-4fba-946f-6e28fa3791d8"/>
@@ -8870,6 +9214,7 @@ time for the given instrument configuration.
     <paramset name="node">
       <param name="key" value="60167289-39c1-4481-8952-8b0b6517484c"/>
       <param name="b8758db1-4326-49cf-a680-cd8b53d2ecf4" value="1"/>
+      <param name="2c5f9d9b-dd36-43a1-985e-40b62f97c03c" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="baadf8bb-7a52-479c-93d0-6640886a0370"/>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_S_BP.txt
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_S_BP.txt
@@ -1,7 +1,7 @@
 Instrument : GMOS-S
 Blueprint templates: GMOS_S_BP.xml
 
-Last update: 2013 November 10, Bryan Miller
+Last update: 2021 September 22, Julia Scharwaechter
 
 Target and conditions information from the Phase I observations only
 needs to be entered into the template science observations. Daytime
@@ -27,8 +27,8 @@ INCLUDE BP{1}
 
 IF SPECTROSCOPY MODE == LONGSLIT
         INCLUDE FROM 'LONGSLIT BP' IN
-            Target Group: {2} - {3}
-            Baseline Folder: {4} - {8}
+            Target Folder: {2} - {4}
+            Baseline Folder: {5} - {8}
         For spec observations: {3}, {4}, {6}-{8}
             SET DISPERSER FROM PI
             SET FILTER FROM PI
@@ -38,8 +38,8 @@ IF SPECTROSCOPY MODE == LONGSLIT
 
 IF SPECTROSCOPY MODE == LONGSLIT N&S
         INCLUDE FROM 'LONGSLIT N&S BP' IN
-            Target group: {9} - {10} 
-            Baseline folder: {11} - {16}
+            Target folder: {9} - {11} 
+            Baseline folder: {12} - {16}
         For spec observations: {10}, {11}, {13}-{15}    
             SET DISPERSER FROM PI
             SET FILTER FROM PI
@@ -49,19 +49,27 @@ IF SPECTROSCOPY MODE == LONGSLIT N&S
         
 IF SPECTROSCOPY MODE == MOS
         INCLUDE FROM 'MOS BP' IN
-            Target group: {20}, {21} - {23}
+            Target folder: {20}, {21} - {23}
               IF PRE-IMAGING REQ == YES
                 INCLUDE {18}, {17}
               IF PRE-IMAGING REQ == NO
                 INCLUDE {19}
             Baseline folder: {24}-{26}
         For spec observations: {20}, {21}, {23}, {25}, {26}
-                SET DISPERSER FROM PI
-                SET FILTER FROM PI
-                For {20}, {21}
-                    SET MOS "Slit Width" from PI
-                For {25}, {26} 
+            SET DISPERSER FROM PI
+            SET FILTER FROM PI
+            For {20}, {21}
+                 SET MOS "Slit Width" from PI
+            For {25}, {26} 
                     SET FPU (built-in longslit) using the width specified in PI
+        For MOS observations in the target folder (not pre-image): any of {18} - {23}
+            SET "Custom Mask MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN 
+                where: 
+                (N/S) is the site 
+                YYYYS is the semester, e.g. 2015A 
+                (Q/C/DD/SV/LP/FT) is the program type 
+                XXX is the program number, e.g. 001, or 012, or 123 
+                NN should be the string "NN" since the mask number is unknown
         For standard acquisition: {24}
             if FPU!=None in the OT inst. iterators, then SET FPU (built-in longslit) using the width specified in PI
         For acquisitions: {18}, {19} and mask image {22}
@@ -69,7 +77,7 @@ IF SPECTROSCOPY MODE == MOS
 
 IF SPECTROSCOPY MODE == MOS N&S
         INCLUDE IN
-            Target group: {29}, {22}, {31}, {32}
+            Target folder: {29}, {22}, {31}, {32}
               IF PRE-IMAGING REQ == YES
                 INCLUDE {17}, {27}
               IF PRE-IMAGING REQ == NO
@@ -82,6 +90,14 @@ IF SPECTROSCOPY MODE == MOS N&S
                 SET MOS "Slit Width" from PI
             For {34}, {35} 
                 SET FPU (built-in longslit) using the width specified in PI
+       For MOS observations in the target folder (not pre-image): any of {27} - {32}
+            SET "Custom Mask MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN 
+                where: 
+                (N/S) is the site 
+                YYYYS is the semester, e.g. 2015A 
+                (Q/C/DD/SV/LP/FT) is the program type 
+                XXX is the program number, e.g. 001, or 012, or 123 
+                NN should be the string "NN" since the mask number is unknown
         For standard acquisition: {33}
             if FPU!=None in the OT inst. iterators, then SET FPU (built-in longslit) using the width specified in PI
         For acquisitions: {27}, {28}; mask image {22}; and N&S dark {30}
@@ -89,8 +105,8 @@ IF SPECTROSCOPY MODE == MOS N&S
 
 IF SPECTROSCOPY MODE == IFU
         INCLUDE FROM 'IFU BP' IN,
-            Target group: {36}-{37}
-            Baseline folder: {38}-{42}
+            Target folder: {36}-{38}
+            Baseline folder: {39}-{42}
         Where FPU!=None in BP (static and iterator), SET FPU from PI
             IFU acq obs have an iterator titled "Field image" with
                 FPU=None, the FPU must not be set here.
@@ -104,15 +120,15 @@ IF SPECTROSCOPY MODE == IFU
            else SET FILTER=r (as in BP)
         else SET FILTER FROM PI
             IF FPU = "IFU 2 slits" in PI:
-	        IF FILTER=None, SET FILTER=r_G0326
+            IF FILTER=None, SET FILTER=r_G0326
                 SET CENTRAL WAVELENGTHS TO THE FILTER EFF WAVELENGTH
                  AND EFF WAVELENGTH + 5nm (if iteration over wavelength)
                 See http://www.gemini.edu/node/10637
 
 IF SPECTROSCOPY MODE == IFU N&S
         INCLUDE FROM 'IFU N&S BP' IN, 
-            Target group: {43}-{44}
-            Baseline folder: {45}-{50}
+            Target folder: {43}-{45}
+            Baseline folder: {46}-{50}
         Where FPU!=None in BP (static and iterator), SET FPU from PI
             IFU acq obs have an iterator titled "Field image" with
                 FPU=None, the FPU must not be set here.
@@ -126,7 +142,7 @@ IF SPECTROSCOPY MODE == IFU N&S
            else SET FILTER=r (as in BP)
         else SET FILTER FROM PI
             IF FPU = 'IFU 2 slits' in PI (IFU or IFU N&S mode):
-	        IF FILTER=None, SET FILTER=r_G0326
+            IF FILTER=None, SET FILTER=r_G0326
                 SET CENTRAL WAVELENGTHS TO THE FILTER EFF WAVELENGTH
                  AND EFF WAVELENGTH + 5nm (if iteration over wavelength)
                 See http://www.gemini.edu/node/10637

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_S_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GMOS_S_BP.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
 
 <document>
-  <container kind="program" type="Program" version="2018A-1" subtype="basic" key="d4ad9f8d-e5d1-4e36-a7c0-189f1d62531d" name="GMOS-S-BP">
+  <container kind="program" type="Program" version="2020A-1" subtype="basic" key="d4ad9f8d-e5d1-4e36-a7c0-189f1d62531d" name="GMOS-S-BP">
     <paramset name="Science Program" kind="dataObj">
       <param name="title" value="GMOS-S PHASE I/II MAPPING BPS"/>
       <param name="programMode" value="QUEUE"/>
@@ -43,6 +43,12 @@
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -58,6 +64,8 @@
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0326"/>
@@ -142,6 +150,12 @@
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -184,6 +198,8 @@ the slit image (second step) should be left as defined at 20 seconds.
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
             <param name="filter" value="r_G0326"/>
@@ -354,6 +370,12 @@ Details:
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -522,6 +544,12 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -660,6 +688,12 @@ between the CCDs and get full wavelength coverage.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -710,6 +744,8 @@ the slit image (second step) should be left as defined at 20 seconds.
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
             <param name="filter" value="g_G0325"/>
@@ -862,6 +898,12 @@ the slit image (second step) should be left as defined at 20 seconds.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -975,6 +1017,12 @@ when conditions are convenient for observing baseline standards.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -1100,6 +1148,12 @@ is taken.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -1239,6 +1293,12 @@ The exposure is taken on the sky so the Translation stage should be
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -1282,6 +1342,8 @@ the slit image (second step) should be left as defined at 20 seconds.
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="NS_3"/>
             <param name="filter" value="i_G0327"/>
@@ -1452,6 +1514,12 @@ Details:
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -1480,8 +1548,8 @@ Details:
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
-            <param name="nsDetectorRows" value="1536"/>
+            <param name="nsNumCycles" value="10"/>
+            <param name="nsDetectorRows" value="1392"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
               <param name="advancedGuiding" value="GMOS OIWFS"/>
@@ -1508,7 +1576,7 @@ Details:
               <value>This is a N&amp;S longslit science observation of a faint target with GCAL flats
 mixed in. 
 
-Nod offset is +-5arcsec, use the standard shuffling (1536 rows and a binning
+Nod offset is +-5arcsec, use the standard shuffling (1392 rows and a binning
 of X=2, Y=1. It is assumed that GMOS is mounted on the side-looking ISS port.
 
 The observation contain 1 science exposure and 1 GCALflat at each
@@ -1536,12 +1604,10 @@ The exposures are the follow:
    science  at 770nm, DtaX=2
    GCALflat at 770nm, DtaX=2
 
-The DTAX offset dither sequence is recommended to help reduce the effect
-of charge traps in the data; see the N&amp;S web pages.  Here by using four
-GMOS-N Sequences to change central wavelength and dither the DTAX we save 
-on overhead with an efficient science-flat-flat-science-science-flat-flat-science 
-arrangement, minimizing the number of calibration congfiguration movements 
-required.
+DTA-X offsetting was implemented to aid in the suppression of linear charge traps affecting Nod &amp; Shuffle data in the original EEV detectors. With the upgraded GMOS-N and GMOS-S Hamamatsu detectors DTA-X offsetting is no longer as advantageous; see the N&amp;S web pages.  
+Here by using four GMOS-N Sequences to change central wavelength and dither the
+DTAX we save on overhead with an efficient science-flat-flat-science-science-flat-flat-science 
+arrangement, minimizing the number of calibration congfiguration movements required.
 </value>
             </param>
           </paramset>
@@ -1762,6 +1828,12 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -1903,6 +1975,12 @@ wavelength coverage.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -1956,6 +2034,8 @@ closest to  the central wavelength used for the spectroscopy</value>
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="NS_3"/>
             <param name="filter" value="i_G0327"/>
@@ -2108,6 +2188,12 @@ closest to  the central wavelength used for the spectroscopy</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -2223,6 +2309,12 @@ when conditions are convenient for observing baseline standards.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -2355,6 +2447,12 @@ is taken.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -2485,11 +2583,17 @@ The exposure is taken on the sky so the Translation stage should be
       </container>
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="b368b51c-2224-4dcb-ae21-96a5f600ea3d" name="GMOS-S-BP-16">
         <paramset name="Observation" kind="dataObj">
-          <param name="title" value="N&amp;S Longslit Baseline: Dark: A=60, 15cy, 2x2, 1536pix"/>
+          <param name="title" value="N&amp;S Longslit Baseline: Dark: A=60, 10cy, 2x1, 1392row"/>
           <param name="libraryId" value="16"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -2548,15 +2652,15 @@ Exposure time A=60sec. Note that the 60sec exposure time in A (in this example)
 MUST BE SET in the DARK component exposure time. The exposure time is NOT 
 TAKEN from the GMOS-S component. 
 
-Offset (shuffle distance) = 1536 rows for N&amp;S LONGSLIT darks.
+Offset (shuffle distance) = 1392 rows for N&amp;S LONGSLIT darks.
 
-Number of N&amp;S cycles (same as the science exposure) = 15 in this example.
-Therefore, The total open shutter time is 1800sec per dark exposure in this example.
+Number of N&amp;S cycles (same as the science exposure) = 10 in this example.
+Therefore, The total open shutter time is 1200sec per dark exposure in this example.
 Note that the number of N&amp;S cycles IS taken from the static GMOS-S component.
 For example, setting the Dark to have an Observe 15x will take 15 N&amp;S darks, 
-each having 15 N&amp;S cycles.
+each having 10 N&amp;S cycles.
 
-Detector Binning = 2x2 in this example
+Detector Binning = 2x1 in this example
 
 The guide star has been removed from the target component since the
 telescope will be stationary at zenith for this observation.
@@ -2583,6 +2687,8 @@ Number of N&amp;S observations is 15</value>
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0326"/>
@@ -2594,8 +2700,8 @@ Number of N&amp;S observations is 15</value>
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
-            <param name="nsDetectorRows" value="1536"/>
+            <param name="nsNumCycles" value="10"/>
+            <param name="nsDetectorRows" value="1392"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
               <param name="advancedGuiding" value="GMOS OIWFS"/>
@@ -2655,6 +2761,12 @@ Number of N&amp;S observations is 15</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -2691,6 +2803,8 @@ can be submitted.</value>
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0326"/>
@@ -2762,6 +2876,12 @@ can be submitted.</value>
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -2826,6 +2946,8 @@ masks for use, with a technical limit of 99 masks).</value>
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GSYYYYSQXXX-NN"/>
@@ -2884,6 +3006,12 @@ masks for use, with a technical limit of 99 masks).</value>
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -2967,6 +3095,8 @@ gacq *filenumber*
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GSYYYYSQXXX-NN"/>
@@ -3086,6 +3216,12 @@ gacq *filenumber*
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -3257,6 +3393,12 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -3403,6 +3545,12 @@ wavelength coverage.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -3478,6 +3626,8 @@ Gemini Staff.</value>
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GSYYYYSQXXX-NN"/>
@@ -3544,6 +3694,12 @@ Gemini Staff.</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -3680,6 +3836,12 @@ The exposure is taken on the sky so the Translation stage should be
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -3728,6 +3890,8 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
             <param name="filter" value="g_G0325"/>
@@ -3885,6 +4049,12 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -4049,6 +4219,12 @@ it possible to order the exposures as follows:
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -4199,6 +4375,12 @@ is taken.
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -4214,6 +4396,8 @@ is taken.
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="CUSTOM_MASK"/>
             <param name="fpu" value="CUSTOM_MASK"/>
             <param name="fpuCustomMask" value="GSYYYYSQXXX-NN"/>
@@ -4321,6 +4505,12 @@ masks for use, with a technical limit of 99 masks).</value>
           <param name="priority" value="HIGH"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -4336,6 +4526,8 @@ masks for use, with a technical limit of 99 masks).</value>
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0326"/>
@@ -4511,6 +4703,12 @@ gacq *filenumber*
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -4540,8 +4738,7 @@ defined with respect to the slit center and should be smaller than the half the
 defined slit length.  The NODs are only in the q direction, along the slit, and not in 
 the p direction which is across the slit.
 
-The sequence dithers the DTAX in order to minimize the effect of "charge trap"
-features which appear in Nod &amp; Shuffled data.  The sequence also dithers the
+DTA-X offsetting was implemented to aid in the suppression of linear charge traps affecting Nod &amp; Shuffle data in the original EEV detectors. With the upgraded GMOS-N and GMOS-S Hamamatsu detectors DTA-X offsetting is no longer as advantageous. The sequence also dithers the
 grating spectrally by by 10 nm above and below the central wavelength in order to
 fill in the information missing due to the gaps between the detectors.
 
@@ -4556,10 +4753,10 @@ and the central wavelength.  By using nested GMOS-S Sequences to dither the DTAX
 central wavelength we save on overhead with an efficient flat-science-science-flat-flat-science 
 arrangement, minimizing the numberof calibration congfiguration movements required.
 
-Each science exposure consists of 15 N&amp;S cycles. The nods are along the 
+Each science exposure consists of 10 N&amp;S cycles. The nods are along the 
 slits, keeping the science targets in the slits at all times. The total on-target
-open shutter time is 1800sec per science exposure in this example,
-4.5hour total for the full observation.
+open shutter time is 1200sec per science exposure in this example,
+3hour total for the full observation.
 
 The other required observations for a MOS N&amp;S program are similar to 
 those for non N&amp;S MOS program.  Only the actual science observation is 
@@ -4642,7 +4839,7 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
+            <param name="nsNumCycles" value="10"/>
             <param name="nsDetectorRows" value="32"/>
             <param name="useElectronicOffsetting" value="true"/>
             <paramset name="nsShuffleOffset">
@@ -4860,11 +5057,17 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
       </container>
       <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="da3816e7-b2c2-493b-a8b3-e65c92f16012" name="GMOS-S-BP-30">
         <paramset name="Observation" kind="dataObj">
-          <param name="title" value="MOS N&amp;S :Baseline Dark: A=60, 15cy, 2x2, 32pix"/>
+          <param name="title" value="MOS N&amp;S :Baseline Dark: A=60, 10cy, 2x1, 32row"/>
           <param name="libraryId" value="30"/>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -4915,13 +5118,13 @@ TAKEN from the GMOS-S component.
 Offset (shuffle distance) = 32 rows in this example. This is in unit of "unbinned"
 pixels. 
 
-Number of N&amp;S cycles (same as the science exposure) = 15 in this example.
-Therefore, The total open shutter time is 1800sec per dark exposure in this example.
+Number of N&amp;S cycles (same as the science exposure) = 10 in this example.
+Therefore, The total open shutter time is 1200sec per dark exposure in this example.
 Note that the number of N&amp;S cycles IS taken from the static GMOS-S component.
 For example, setting the Dark to have an Observe 15x will take 15 N&amp;S darks, 
-each having 15 N&amp;S cycles.
+each having 10 N&amp;S cycles.
 
-Detector Binning = 2x2 in this example
+Detector Binning = 2x1 in this example
 
 
 The guide star has been removed from the target component since the
@@ -4947,6 +5150,8 @@ closed for bad weather.</value>
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0326"/>
@@ -4958,7 +5163,7 @@ closed for bad weather.</value>
             <param name="dtaXOffset" value="SIX"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
+            <param name="nsNumCycles" value="10"/>
             <param name="nsDetectorRows" value="32"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
@@ -5024,6 +5229,12 @@ closed for bad weather.</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -5107,7 +5318,7 @@ wavelength coverage.
             <param name="customSlitWidth" value="CUSTOM_WIDTH_1_00"/>
             <param name="filter" value="OG515_G0330"/>
             <param name="ccdXBinning" value="TWO"/>
-            <param name="ccdYBinning" value="TWO"/>
+            <param name="ccdYBinning" value="ONE"/>
             <param name="issPort" value="SIDE_LOOKING"/>
             <param name="posAngleConstraint" value="FIXED"/>
             <param name="stageMode" value="FOLLOW_Z_ONLY"/>
@@ -5171,6 +5382,12 @@ wavelength coverage.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -5249,7 +5466,7 @@ The exposure is taken on the sky so the Translation stage should be
             <param name="customSlitWidth" value="OTHER"/>
             <param name="filter" value="OG515_G0330"/>
             <param name="ccdXBinning" value="TWO"/>
-            <param name="ccdYBinning" value="TWO"/>
+            <param name="ccdYBinning" value="ONE"/>
             <param name="issPort" value="SIDE_LOOKING"/>
             <param name="posAngleConstraint" value="FIXED"/>
             <param name="stageMode" value="FOLLOW_XYZ"/>
@@ -5307,6 +5524,12 @@ The exposure is taken on the sky so the Translation stage should be
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -5354,6 +5577,8 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="LONGSLIT_4"/>
             <param name="filter" value="r_G0326"/>
@@ -5511,6 +5736,12 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -5673,6 +5904,12 @@ it possible to order the exposures as follows:
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -5822,6 +6059,12 @@ is taken.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -5844,7 +6087,7 @@ target. Use the ITC to find the exposure time needed. A S/N&gt;=10 is
 recommended for acquisition observations. 
 
 
-For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  For more information on blind offsetting, please see http://www.gemini.edu/sciops/telescopes-and-sites/acquisition-hardware-and-techniques/acquisition-techniques.
+For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  For more information on blind offsetting, please see https://www.gemini.edu/observing/telescopes-and-sites/telescopes#Acquisition.
 For help setting up the acquistion, see the Description note for the "Longslit Acquisition (Blind Offset)" within the Templates: Spectroscopy Acquisition Observations folder.  If it is not possible to find a nearby reference star with well known coordinates for blind offsetting, make the 2nd step be another imaging exposure, such that the position of the target on the CCD in imaging mode can be checked after the initial telescope offset has been determined and applied.   The blind offset method is preferred because the user can  directly measure from the acquisition image where the science target will approximately fall in the IFU field of view. </value>
             </param>
           </paramset>
@@ -5860,6 +6103,8 @@ For help setting up the acquistion, see the Description note for the "Longslit A
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
             <param name="filter" value="r_G0326"/>
@@ -5966,6 +6211,12 @@ For help setting up the acquistion, see the Description note for the "Longslit A
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -6008,7 +6259,7 @@ It is assumed that GMOS is mounted on the side-looking ISS port.
 
 Two offset positions are used to fill in dead fibers.
 
-For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  For more information on blind offsetting, please see http://www.gemini.edu/sciops/telescopes-and-sites/acquisition-hardware-and-techniques/acquisition-techniques.
+For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  For more information on blind offsetting, please see https://www.gemini.edu/observing/telescopes-and-sites/telescopes#Acquisition.
 For help setting up the acquistion, see the Description note for the "Longslit Acquisition (Blind Offset)" within the Templates: Spectroscopy Acquisition Observations folder.  If it is not possible to find a nearby reference star with well known coordinates for blind offsetting, make the 2nd step be another imaging exposure, such that the position of the target on the CCD in imaging mode can be checked after the initial telescope offset has been determined and applied.   The blind offset method is preferred because the user can  directly measure from the acquisition image where the science target will approximately fall in the IFU field of view. </value>
             </param>
           </paramset>
@@ -6146,6 +6397,12 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -6278,6 +6535,12 @@ The readout is "fast" in order to save time.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -6407,6 +6670,12 @@ The exposure is taken on the sky so the Translation stage should be
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -6537,6 +6806,12 @@ on the side-looking ISS port.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -6576,6 +6851,8 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_1"/>
             <param name="filter" value="r_G0326"/>
@@ -6694,6 +6971,12 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -6813,6 +7096,12 @@ it possible to order the exposures as follows:
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -6834,7 +7123,7 @@ The user will need to adjust the exposure time to be appropriate for a given
 target. Use the ITC to find the exposure time needed. A S/N&gt;=10 is 
 recommended for acquisition observations. 
 
-For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  For more information on blind offsetting, please see http://www.gemini.edu/sciops/telescopes-and-sites/acquisition-hardware-and-techniques/acquisition-techniques.
+For targets fainter than R~18mag, imaging through the IFU will take too long.  Instead a blind offset acquisition should be used.  For more information on blind offsetting, please see https://www.gemini.edu/observing/telescopes-and-sites/telescopes#Acquisition.
 For help setting up the acquistion, see the Description note for the "Longslit Acquisition (Blind Offset)" within the Templates: Spectroscopy Acquisition Observations folder.  If it is not possible to find a nearby reference star with well known coordinates for blind offsetting, make the 2nd step be another imaging exposure, such that the position of the target on the CCD in imaging mode can be checked after the initial telescope offset has been determined and applied.   The blind offset method is preferred because the user can  directly measure from the acquisition image where the science target will approximately fall in the IFU field of view. 
 
 </value>
@@ -6852,6 +7141,8 @@ For help setting up the acquistion, see the Description note for the "Longslit A
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_N"/>
             <param name="filter" value="i_G0327"/>
@@ -6958,6 +7249,12 @@ For help setting up the acquistion, see the Description note for the "Longslit A
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -7026,7 +7323,7 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
+            <param name="nsNumCycles" value="10"/>
             <param name="nsDetectorRows" value="285"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
@@ -7108,6 +7405,12 @@ Daytime baseline arc lamp exposures will be provided for all spectroscopic obser
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -7240,6 +7543,12 @@ The readout is "fast" in order to save time.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -7279,8 +7588,8 @@ The readout is "fast" in order to save time.
 The instrument is configured as following: disperser mirror,
 no FPU.
 
-Each dark exposure consists of 15 N&amp;S cycles (same as the science exposure). 
-The total open shutter time is 1800sec per dark exposure in this example.
+Each dark exposure consists of 10 N&amp;S cycles (same as the science exposure). 
+The total open shutter time is 1200sec per dark exposure in this example.
 
 The guide star has been removed from the target component since the
 telescope will be stationary at zenith for this observation.
@@ -7307,6 +7616,8 @@ Number of Nod &amp; Shuffle observations is set to 15.</value>
             <param name="ampReadMode" value="SLOW"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="FPU_NONE"/>
             <param name="filter" value="r_G0326"/>
@@ -7318,7 +7629,7 @@ Number of Nod &amp; Shuffle observations is set to 15.</value>
             <param name="dtaXOffset" value="ZERO"/>
             <param name="builtinROI" value="FULL_FRAME"/>
             <param name="useNS" value="TRUE"/>
-            <param name="nsNumCycles" value="15"/>
+            <param name="nsNumCycles" value="10"/>
             <param name="nsDetectorRows" value="285"/>
             <param name="useElectronicOffsetting" value="false"/>
             <paramset name="nsShuffleOffset">
@@ -7384,6 +7695,12 @@ Number of Nod &amp; Shuffle observations is set to 15.</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -7516,6 +7833,12 @@ The exposure is taken on the sky so the Translation stage should be
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -7647,6 +7970,12 @@ the CCDs and get full  wavelength coverage.
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -7699,6 +8028,8 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
             <param name="ampReadMode" value="FAST"/>
             <param name="detectorManufacturer" value="HAMAMATSU"/>
             <param name="disperser" value="MIRROR"/>
+            <param name="disperserLambda" value="550.0"/>
+            <param name="disperserOrder" value="ONE"/>
             <param name="fpuMode" value="BUILTIN"/>
             <param name="fpu" value="IFU_N"/>
             <param name="filter" value="i_G0327"/>
@@ -7805,6 +8136,12 @@ the slit image (second step) should be left as defined at 10 seconds.</value>
           <param name="priority" value="LOW"/>
           <param name="tooOverrideRapid" value="false"/>
           <param name="phase2Status" value="INACTIVE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1635701400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
           <param name="qaState" value="UNDEFINED"/>
           <param name="overrideQaState" value="false"/>
           <param name="setupTimeType" value="FULL"/>
@@ -8069,6 +8406,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="4deb15c2-2204-4b1f-af2c-5021dea48b5e"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="0db81411-cfc5-4af5-8fce-08f74178753d"/>
@@ -8125,6 +8463,8 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="9d89d4b4-9846-494c-9aee-36d7383a7eca"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="2"/>
+      <param name="c6f062cb-7969-4906-9f6d-7a21fc214ec3" value="6"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="5f4eaaf4-d3d0-4f3e-9e43-90e8db8a74b5"/>
@@ -8247,6 +8587,8 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="2eb7b4ce-c95a-4853-a1b1-08d095d6b009"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="2"/>
+      <param name="c6f062cb-7969-4906-9f6d-7a21fc214ec3" value="6"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="04256082-0932-4bbe-8fad-a0c1d6fd4cb4"/>
@@ -8353,6 +8695,8 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="749cc530-ef81-48c9-a35e-af2d58f221dc"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="10"/>
+      <param name="c6f062cb-7969-4906-9f6d-7a21fc214ec3" value="7"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="d0929d2b-59c9-4471-97c2-2d26b594bec6"/>
@@ -8373,6 +8717,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="da3816e7-b2c2-493b-a8b3-e65c92f16012"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="10"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="3679a733-827e-4e8e-a32f-1880a5b81fd3"/>
@@ -8485,6 +8830,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="4a26df76-8293-4121-9f55-903e799804f5"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="4"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="f18ff8b2-e9be-478e-82a4-a66a572c3b0c"/>
@@ -8525,6 +8871,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="8f3a4e4b-59b7-4b01-b819-2825c894fb0b"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="e27f91ae-ac41-4124-9a37-71d1feef408f"/>
@@ -8625,6 +8972,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="297ebe90-dc9f-4b18-b1c6-8d1eb7f5ce14"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="8"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="5345435f-3ef8-43d7-bdfa-8db120027c85"/>
@@ -8654,6 +9002,8 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="82b6c061-f3fe-40e6-872f-32dfd36a7678"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="8"/>
+      <param name="c6f062cb-7969-4906-9f6d-7a21fc214ec3" value="6"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="0f0a63e9-797f-4dbd-9eba-a1182f5bb00e"/>
@@ -8723,6 +9073,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="fae66661-dd6d-403f-81c7-8d49f5dc2a5b"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="c6f062cb-7969-4906-9f6d-7a21fc214ec3" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="d0643b87-2b19-4267-9306-763dbe6de393"/>
@@ -8759,6 +9110,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="ab5358a7-ecf1-4ac3-a63a-be36ce7d9347"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="15"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="e277c004-fefc-4824-8487-869a55d617fd"/>
@@ -9227,6 +9579,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="aa60a1a4-a8b7-43af-bc51-bc51a2dc62d8"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="c88250ed-93e7-4f60-ab7b-835a2467a261"/>
@@ -9272,6 +9625,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="e03fda15-154f-4e88-b1d7-ed7f0b93a93b"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="e18efc99-0943-4cf3-a92a-6cc07e230f8d"/>
@@ -9316,6 +9670,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="60e72d50-c5ae-4a79-8985-1345932d1d9b"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="106d3dc4-8cf2-4cb2-8078-58267629a5c9"/>
@@ -9372,6 +9727,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="9142172a-543e-454e-9ee5-74cf8b64e732"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="c6f062cb-7969-4906-9f6d-7a21fc214ec3" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="2332f019-1670-4074-8a92-dca565752685"/>
@@ -9950,6 +10306,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="dd886620-d892-4b78-b5b6-16e89544ad20"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="1ecff6b3-9141-4d10-9b06-b30866a9213a"/>
@@ -10003,6 +10360,7 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="0df01626-a118-4e59-b8c0-b4958866ebd7"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="c6f062cb-7969-4906-9f6d-7a21fc214ec3" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="b5430b7f-8010-4968-b3bb-0d1b13008ac4"/>
@@ -10122,6 +10480,8 @@ it possible to order the exposures as follows:
     <paramset name="node">
       <param name="key" value="b368b51c-2224-4dcb-ae21-96a5f600ea3d"/>
       <param name="b2c7a5b2-7f0b-4df4-9d0c-5a3355e0a904" value="1"/>
+      <param name="cc09d464-f464-46e7-b92a-9c32d00ad528" value="10"/>
+      <param name="c6f062cb-7969-4906-9f6d-7a21fc214ec3" value="6"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="322f5cf4-4a8c-49da-a6cb-e20ce77f1fe1"/>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/servlet/SkeletonResetServlet.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/servlet/SkeletonResetServlet.scala
@@ -20,6 +20,7 @@ import javax.servlet.http.{HttpServletResponse, HttpServletRequest, HttpServlet}
 import scala.collection.JavaConverters._
 import scala.xml.{XML, Elem}
 import java.security.Principal
+import edu.gemini.spModel.core.SPProgramID
 
 
 object SkeletonResetServlet {
@@ -71,14 +72,14 @@ final class SkeletonResetServlet(odb: IDBDatabaseService, templateFactory: Templ
     try {
       for {
         folderShell <- Option(prog.getTemplateFolder).toRight(Failure.badRequest("Program doesn't have a template folder")).right
-        expansion   <- expandTemplates(Phase1Folder.extract(folderShell)).right
+        expansion   <- expandTemplates(Phase1Folder.extract(folderShell), prog.getProgramID()).right
       } yield expansion
     } catch {
       case ex: Exception => Left(Failure.error(ex))
     }
 
-  private def expandTemplates(folder: Phase1Folder): Either[Failure, TemplateFolderExpansion] =
-    TemplateFolderExpansionFactory.expand(folder, templateFactory, false).left map {
+  private def expandTemplates(folder: Phase1Folder, pid: SPProgramID): Either[Failure, TemplateFolderExpansion] =
+    TemplateFolderExpansionFactory.expand(folder, templateFactory, false, pid).left map {
       msg => Failure.badRequest(msg)
     }
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/servlet/SkeletonServlet.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/servlet/SkeletonServlet.scala
@@ -90,7 +90,7 @@ final class SkeletonServlet(odb: IDBDatabaseService, templateFactory: TemplateFa
       p       <- proposal(x, convert).right
       i       <- programId(l, p).right
       s       <- makeSkeleton(i, p).right
-      t       <- expandTemplates(s.folder).right
+      t       <- expandTemplates(s.folder, i.toSp).right
       a       <- pdfAttachment(l).right
     } yield SkeletonRequest(i, p, a, s, t)
 
@@ -194,8 +194,8 @@ final class SkeletonServlet(odb: IDBDatabaseService, templateFactory: TemplateFa
       f <- Phase1FolderFactory.create(s, p).right
     } yield new SkeletonShell(id.toSp, SpProgramFactory.create(p), f)).left map { Failure.badRequest }
 
-  private def expandTemplates(folder: Phase1Folder): Either[Failure, TemplateFolderExpansion] =
-    TemplateFolderExpansionFactory.expand(folder, templateFactory, false).left map { msg =>
+  private def expandTemplates(folder: Phase1Folder, pid: SPProgramID): Either[Failure, TemplateFolderExpansion] =
+    TemplateFolderExpansionFactory.expand(folder, templateFactory, false, pid).left map { msg =>
       Failure.badRequest(msg)
     }
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/api/TemplateFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/api/TemplateFactory.scala
@@ -1,6 +1,7 @@
 package edu.gemini.phase2.template.factory.api
 
 import edu.gemini.spModel.template.{Phase1Group, SpBlueprint}
+import edu.gemini.spModel.core.SPProgramID
 
 /**
  * Provides the API for a service that creates template groups.
@@ -13,6 +14,6 @@ trait TemplateFactory {
    * erased from the generated program; if true they will be preserved, which can be helpful for
    * testing.
    */
-  def expand(blueprint: SpBlueprint, pig: Phase1Group, preserveLibraryIds: Boolean): Either[String, BlueprintExpansion]
+  def expand(blueprint: SpBlueprint, pig: Phase1Group, preserveLibraryIds: Boolean, pid: SPProgramID): Either[String, BlueprintExpansion]
 
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/api/TemplateFolderExpansionFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/api/TemplateFolderExpansionFactory.scala
@@ -4,19 +4,20 @@ import edu.gemini.phase2.core.model.TemplateFolderExpansion
 import edu.gemini.spModel.template.Phase1Folder
 
 import scala.collection.JavaConverters._
+import edu.gemini.spModel.core.SPProgramID
 
 object TemplateFolderExpansionFactory {
 
-  def expand(folder: Phase1Folder, fact: TemplateFactory, preserveLibraryIds: Boolean): Either[String, TemplateFolderExpansion] =
+  def expand(folder: Phase1Folder, fact: TemplateFactory, preserveLibraryIds: Boolean, pid: SPProgramID): Either[String, TemplateFolderExpansion] =
     for {
-      be <- blueprintExpansions(folder, fact, preserveLibraryIds).right
+      be <- blueprintExpansions(folder, fact, preserveLibraryIds, pid).right
     } yield BlueprintExpansion.toTemplateFolderExpansion(be)
 
-  private def blueprintExpansions(folder: Phase1Folder, fact: TemplateFactory, preserveLibraryIds: Boolean): Either[String, List[BlueprintExpansion]] = {
+  private def blueprintExpansions(folder: Phase1Folder, fact: TemplateFactory, preserveLibraryIds: Boolean, pid: SPProgramID): Either[String, List[BlueprintExpansion]] = {
     val empty: Either[String, List[BlueprintExpansion]] = Right(Nil)
     (empty/:folder.groups.asScala) {
       case (e, pig) => e.right flatMap { lst =>
-        fact.expand(folder.blueprintMap.get(pig.blueprintId), pig, preserveLibraryIds).right map { exp =>
+        fact.expand(folder.blueprintMap.get(pig.blueprintId), pig, preserveLibraryIds, pid).right map { exp =>
           exp :: lst
         }
       }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/GroupInitializer.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/GroupInitializer.scala
@@ -5,6 +5,7 @@ import edu.gemini.spModel.template.SpBlueprint
 import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.spModel.obscomp.SPGroup.GroupType
 import edu.gemini.spModel.obscomp.SPGroup
+import edu.gemini.spModel.core.SPProgramID
 
 /**
  * Trait for a class which knows how to find and setup an ISPGroup for a
@@ -20,10 +21,10 @@ trait GroupInitializer[B <: SpBlueprint] {
   def groupType: GroupType = GroupType.TYPE_SCHEDULING
   def instrumentType:SPComponentType = blueprint.instrumentType
 
-  def initialize(db:TemplateDb):Maybe[ISPGroup] =
+  def initialize(db:TemplateDb, pid: SPProgramID):Maybe[ISPGroup] =
     for {
       grp <- db.groups(program, (targetGroup ++ baselineFolder).map(_.toString), notes).right
-      _ <- initialize(grp, db).right
+      _ <- initialize(grp, db, pid).right
     } yield {
       grp.getDataObject() match {
         case g: SPGroup => g.setGroupType(groupType); grp.setDataObject(g)
@@ -32,7 +33,7 @@ trait GroupInitializer[B <: SpBlueprint] {
       grp
     }
 
-  def initialize(group:ISPGroup, db:TemplateDb):Maybe[Unit]
+  def initialize(group:ISPGroup, db:TemplateDb, pid: SPProgramID):Maybe[Unit]
 
   protected def forObservations(group:ISPGroup, idList:Seq[Int], ini:ISPObservation => Maybe[Unit]):Maybe[Unit] =
     for {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateDsl.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateDsl.scala
@@ -3,6 +3,7 @@ package edu.gemini.phase2.template.factory.impl
 import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.spModel.seqcomp.SeqConfigComp
 import edu.gemini.pot.sp.{SPComponentType, ISPSeqComponent, ISPGroup, ISPObservation}
+import edu.gemini.spModel.core.SPProgramID
 
 trait TemplateDsl {gi:GroupInitializer[_] =>
 
@@ -32,7 +33,7 @@ trait TemplateDsl {gi:GroupInitializer[_] =>
   def targetGroup: Seq[Int] =
     includes.getOrElse(TargetGroup, Nil)
 
-  def initialize(g:ISPGroup, db:TemplateDb):Maybe[Unit] =
+  def initialize(g:ISPGroup, db:TemplateDb, pid: SPProgramID):Maybe[Unit] =
     mutators.mapM_((mutate(g) _).tupled)
 
   private def mutate(g:ISPGroup)(e:Either[Seq[Int], ObsLocation], f:Mutator):Maybe[Unit] =

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateDsl2.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateDsl2.scala
@@ -10,6 +10,7 @@ import edu.gemini.spModel.gemini.altair.InstAltair
 import edu.gemini.spModel.gemini.seqcomp.SeqRepeatOffset
 import scala.collection.JavaConverters._
 import scala.collection.{mutable => m}
+import edu.gemini.spModel.core.SPProgramID
 
 trait TemplateDsl2[I <: SPInstObsComp] { gi:GroupInitializer[_] =>
 
@@ -44,7 +45,7 @@ trait TemplateDsl2[I <: SPInstObsComp] { gi:GroupInitializer[_] =>
   def baselineFolder = includes.get(BaseCal).getOrElse(Nil)
   def targetGroup = includes.get(TargetGroup).getOrElse(Nil)
 
-  def initialize(g:ISPGroup, db:TemplateDb):Maybe[Unit] = mutators.mapM_((mutate(g) _).tupled)
+  def initialize(g:ISPGroup, db:TemplateDb, pid: SPProgramID):Maybe[Unit] = mutators.mapM_((mutate(g) _).tupled)
 
   private def mutate(g:ISPGroup)(e:Either[Seq[Int], ObsLocation], f:Mutator):Maybe[Unit] = e match {
     case Left(ns) => mutate(g, ns, f)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateFactoryImpl.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateFactoryImpl.scala
@@ -37,12 +37,13 @@ import edu.gemini.spModel.gemini.gpi.blueprint.SpGpiBlueprint
 import edu.gemini.phase2.template.factory.impl.gpi.Gpi
 import edu.gemini.spModel.gemini.graces.blueprint.SpGracesBlueprint
 import edu.gemini.phase2.template.factory.impl.graces.Graces
+import edu.gemini.spModel.core.SPProgramID
 
 case class TemplateFactoryImpl(db: TemplateDb) extends TemplateFactory {
 
   type TargetId = String
 
-  def expand(blueprint: SpBlueprint, pig: Phase1Group, preserveLibraryIds: Boolean): Either[String, BlueprintExpansion] = {
+  def expand(blueprint: SpBlueprint, pig: Phase1Group, preserveLibraryIds: Boolean, pid: SPProgramID): Either[String, BlueprintExpansion] = {
     // template groups are editable and all arguments can be removed so there
     // may not be an example target
     def sampleTarget: Option[SPTarget] =
@@ -51,7 +52,7 @@ case class TemplateFactoryImpl(db: TemplateDb) extends TemplateFactory {
 
     for {
       ini <- initializer(blueprint, sampleTarget).right
-      grp <- ini.initialize(db).right
+      grp <- ini.initialize(db, pid).right
     } yield convert(blueprint, pig, grp, ini, preserveLibraryIds)
   }
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Imaging.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Imaging.scala
@@ -6,6 +6,7 @@ import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import edu.gemini.spModel.gemini.flamingos2.blueprint.SpFlamingos2BlueprintImaging
 
 import scala.collection.JavaConverters._
+import edu.gemini.spModel.core.SPProgramID
 
 case class Flamingos2Imaging(blueprint:SpFlamingos2BlueprintImaging) extends Flamingos2Base[SpFlamingos2BlueprintImaging] {
 
@@ -50,7 +51,7 @@ case class Flamingos2Imaging(blueprint:SpFlamingos2BlueprintImaging) extends Fla
     }
   }
 
-  def initialize(grp:ISPGroup, db:TemplateDb): Maybe[Unit] = for {
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID): Maybe[Unit] = for {
     _ <- forObservations(grp, science, forScience).right
     _ <- forObservations(grp, cal,     forCalibrations(db)).right
   } yield ()

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Longslit.scala
@@ -8,6 +8,7 @@ import edu.gemini.spModel.core.MagnitudeBand.H
 
 import scala.collection.JavaConverters._
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
+import edu.gemini.spModel.core.SPProgramID
 
 case class Flamingos2Longslit(blueprint:SpFlamingos2BlueprintLongslit, exampleTarget: Option[SPTarget]) extends Flamingos2Base[SpFlamingos2BlueprintLongslit] {
 
@@ -53,7 +54,7 @@ case class Flamingos2Longslit(blueprint:SpFlamingos2BlueprintLongslit, exampleTa
 
   val scienceAndTellurics = Seq(12,15,16,18)
 
-  def initialize(grp:ISPGroup, db:TemplateDb): Either[String, Unit] = for {
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID): Either[String, Unit] = for {
       _ <- forObservations(grp, forAll).right
       _ <- forObservations(grp, scienceAndTellurics, forScienceAndTellurics).right
     } yield ()

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Mos.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/flamingos2/Flamingos2Mos.scala
@@ -5,6 +5,7 @@ import edu.gemini.pot.sp.{ISPObservation, ISPGroup}
 import edu.gemini.spModel.gemini.flamingos2.blueprint.SpFlamingos2BlueprintMos
 
 import scala.collection.JavaConverters._
+import edu.gemini.spModel.core.SPProgramID
 
 
 final case class Flamingos2Mos(blueprint:SpFlamingos2BlueprintMos) extends Flamingos2Base[SpFlamingos2BlueprintMos] {
@@ -56,7 +57,7 @@ final case class Flamingos2Mos(blueprint:SpFlamingos2BlueprintMos) extends Flami
   val scienceAndTellurics: Seq[Int] =
     Seq(34,36,37,39)
 
-  override def initialize(grp:ISPGroup, db:TemplateDb): Maybe[Unit] =
+  override def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID): Maybe[Unit] =
     forObservations(grp, scienceAndTellurics, forScienceAndTellurics)
 
   def forScienceAndTellurics(obs:ISPObservation): Maybe[Unit] =

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosBase.scala
@@ -3,12 +3,25 @@ package edu.gemini.phase2.template.factory.impl.gmos
 import edu.gemini.spModel.template.SpBlueprint
 import edu.gemini.phase2.template.factory.impl.GroupInitializer
 import edu.gemini.spModel.gemini.gmos.GmosCommonType
+import edu.gemini.pot.sp.ISPNode
 
 trait GmosBase[B <: SpBlueprint] extends GroupInitializer[B] {
 
   /** Select the filter with wavelength closest to specified lambda. */
   def closestFilter[A <: GmosCommonType.Filter](f: A, fs:A*)(lambda:Double) = {
     (f :: fs.toList).map(f => (f, Math.abs(f.getWavelength.toDouble - lambda))).sortBy(_._2).map(_._1).head
+  }
+
+  // SET "Custom Mask MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN
+  //     where:
+  //     (N/S) is the site
+  //     YYYYS is the semester, e.g. 2015A
+  //     (Q/C/DD/SV/LP/FT) is the program type
+  //     XXX is the program number, e.g. 001, or 012, or 123
+  //     NN should be the string "NN" since the mask number is unknown
+  def defaultCustomMaskName(n: ISPNode): String = {
+    // or, in programmer-speak, delete the hyphens and add -NN
+    n.getProgramID.toString.filterNot(_ == '-') + "-NN"
   }
 
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosBase.scala
@@ -4,6 +4,7 @@ import edu.gemini.spModel.template.SpBlueprint
 import edu.gemini.phase2.template.factory.impl.GroupInitializer
 import edu.gemini.spModel.gemini.gmos.GmosCommonType
 import edu.gemini.pot.sp.ISPNode
+import edu.gemini.spModel.core.SPProgramID
 
 trait GmosBase[B <: SpBlueprint] extends GroupInitializer[B] {
 
@@ -19,9 +20,9 @@ trait GmosBase[B <: SpBlueprint] extends GroupInitializer[B] {
   //     (Q/C/DD/SV/LP/FT) is the program type
   //     XXX is the program number, e.g. 001, or 012, or 123
   //     NN should be the string "NN" since the mask number is unknown
-  def defaultCustomMaskName(n: ISPNode): String = {
+  def defaultCustomMaskName(pid: SPProgramID): String = {
     // or, in programmer-speak, delete the hyphens and add -NN
-    n.getProgramID.toString.filterNot(_ == '-') + "-NN"
+    pid.toString.filterNot(_ == '-') + "-NN"
   }
 
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNBase.scala
@@ -12,6 +12,7 @@ import edu.gemini.spModel.obsclass.ObsClass
 import edu.gemini.spModel.obscomp.InstConstants
 import edu.gemini.spModel.gemini.altair.AltairParams.Mode
 import edu.gemini.spModel.rich.pot.sp.obsWrapper
+import edu.gemini.spModel.core.SPProgramID
 
 trait GmosNBase[B <: SpGmosNBlueprintBase] extends GmosBase[B] {
 
@@ -45,8 +46,8 @@ trait GmosNBase[B <: SpGmosNBlueprintBase] extends GmosBase[B] {
     def setFpu(fpu:GmosNorthType.FPUnitNorth):Either[String, Unit] =
       ed.updateInstrument(_.setFPUnit(fpu))
 
-    def setDefaultCustomMaskName: Either[String, Unit] =
-      ed.updateInstrument(_.setFPUnitCustomMask(defaultCustomMaskName(obs)))
+    def setDefaultCustomMaskName(pid: SPProgramID): Either[String, Unit] =
+      ed.updateInstrument(_.setFPUnitCustomMask(defaultCustomMaskName(pid)))
 
     def getFpu:Either[String, GmosNorthType.FPUnitNorth] = for {
       i <- ed.instrumentDataObject.right

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNBase.scala
@@ -45,6 +45,9 @@ trait GmosNBase[B <: SpGmosNBlueprintBase] extends GmosBase[B] {
     def setFpu(fpu:GmosNorthType.FPUnitNorth):Either[String, Unit] =
       ed.updateInstrument(_.setFPUnit(fpu))
 
+    def setDefaultCustomMaskName: Either[String, Unit] =
+      ed.updateInstrument(_.setFPUnitCustomMask(defaultCustomMaskName(obs)))
+
     def getFpu:Either[String, GmosNorthType.FPUnitNorth] = for {
       i <- ed.instrumentDataObject.right
     } yield i.getFPUnit
@@ -143,4 +146,8 @@ trait GmosNBase[B <: SpGmosNBlueprintBase] extends GmosBase[B] {
         _ <- addAo(o).right
       } yield ()
   }
+}
+
+object GmosNBase {
+  trait WithTargetFolder[B <: SpGmosNBlueprintBase] extends GmosNBase[B] with TargetFolder[B]
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNIfu.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNIfu.scala
@@ -9,32 +9,35 @@ import GmosNorthType.FPUnitNorth._
 import GmosNorthType.FilterNorth._
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FilterNorth
 
-case class GmosNIfu(blueprint:SpGmosNBlueprintIfu) extends GmosNBase[SpGmosNBlueprintIfu] {
+case class GmosNIfu(blueprint:SpGmosNBlueprintIfu) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintIfu] {
 
-//  IF SPECTROSCOPY MODE == IFU
-//          INCLUDE FROM 'IFU BP' IN,
-//              Target group: {36}-{37}
-//              Baseline folder: {38}-{42}
-//          Where FPU!=None in BP (static and iterator), SET FPU from PI
-//              IFU acq obs have an iterator titled "Field image" with
-//                  FPU=None, the FPU must not be set here.
-//              IF FPU = 'IFU 1 SLIT' in PI then FPU='IFU Right Slit (red)'  in OT
-//          If not acq SET DISPERSER FROM PI
-//          For filter changes below, do not adjust exposure times.
-//          If acq ({36}, {41})
-//             If filter from PI != None, SET FILTER in static component
-//               to griz filter closest in central
-//               wavelength to the filter from PI
-//             else SET FILTER=r (as in BP)
-//          else SET FILTER FROM PI:
-//              IF FPU = "IFU 2 slits" in PI (IFU mode):
-//  	        IF FILTER=None, SET FILTER=r_G0303
-//                  SET CENTRAL WAVELENGTHS TO THE FILTER EFF WAVELENGTH
-//                   AND EFF WAVELENGTH +/- 10 nm (in GMOS iterators)
-//                  See http://www.gemini.edu/node/10637
+  // IF SPECTROSCOPY MODE == IFU
+  //         INCLUDE FROM 'IFU BP' IN,
+  //             Target folder: {36}-{38}
+  //             Baseline folder: {39}-{42}
+  //         Where FPU!=None in BP (static and iterator), SET FPU from PI
+  //             IFU acq obs have an iterator titled "Field image" with
+  //                 FPU=None, the FPU must not be set here.
+  //             IF FPU = 'IFU 1 SLIT' in PI then FPU='IFU Right Slit (red)'  in OT
+  //         If not acq SET DISPERSER FROM PI
+  //         For filter changes below, do not adjust exposure times.
+  //         If acq ({36}, {41})
+  //            If filter from PI != None, SET FILTER in static component
+  //              to griz filter closest in central
+  //              wavelength to the filter from PI
+  //            else SET FILTER=r (as in BP)
+  //         else SET FILTER FROM PI:
+  //             IF FPU = "IFU 2 slits" in PI (IFU mode):
+  // 	        IF FILTER=None, SET FILTER=r_G0303
+  //                 SET CENTRAL WAVELENGTHS TO THE FILTER EFF WAVELENGTH
+  //                  AND EFF WAVELENGTH +/- 10 nm (in GMOS iterators)
+  //                 See http://www.gemini.edu/node/10637
 
-  val targetGroup = 36 to 37
-  val baselineFolder = 38 to 42
+  //         IF AO in PI != None  # XBIN=YBIN=1 for AO imaging
+  //             For acquisition {36}, {41} SET XBIN=YBIN=1
+
+  val targetFolder = 36 to 38
+  val baselineFolder = 39 to 42
   val notes = Seq.empty
 
   val acq = Seq(36, 41)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNIfu.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNIfu.scala
@@ -8,6 +8,7 @@ import edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning.ONE
 import GmosNorthType.FPUnitNorth._
 import GmosNorthType.FilterNorth._
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FilterNorth
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosNIfu(blueprint:SpGmosNBlueprintIfu) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintIfu] {
 
@@ -42,7 +43,7 @@ case class GmosNIfu(blueprint:SpGmosNBlueprintIfu) extends GmosNBase.WithTargetF
 
   val acq = Seq(36, 41)
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = forObservations(grp, withAoUpdate(db)(forAll))
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = forObservations(grp, withAoUpdate(db)(forAll))
 
   def piFpu                    = if (blueprint.fpu == IFU_2) IFU_3 else blueprint.fpu
   def noneOrPiFpu(libFpu: Any) = if (libFpu == FPU_NONE) FPU_NONE else piFpu

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNImaging.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNImaging.scala
@@ -7,6 +7,7 @@ import edu.gemini.pot.sp.{ISPObservation, ISPGroup}
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning.ONE
 import edu.gemini.spModel.gemini.gmos.GmosNorthType._
 import edu.gemini.phase2.template.factory.impl.TemplateDb
+import edu.gemini.spModel.core.SPProgramID
 
 
 case class GmosNImaging(blueprint:SpGmosNBlueprintImaging) extends GmosNBase[SpGmosNBlueprintImaging] {
@@ -23,7 +24,7 @@ case class GmosNImaging(blueprint:SpGmosNBlueprintImaging) extends GmosNBase[SpG
   val baselineFolder = Seq.empty
   val notes = Seq.empty
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = {
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = {
 
     def forAll(obs:ISPObservation):Either[String, Unit] = for {
       _ <- obs.setFilters(filters.asScala).right

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNLongslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNLongslit.scala
@@ -7,6 +7,7 @@ import edu.gemini.spModel.gemini.gmos.{GmosNorthType, InstGmosNorth}
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning.ONE
 import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.phase2.template.factory.impl.TargetFolder
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosNLongslit(blueprint: SpGmosNBlueprintLongslit) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintLongslit] {
 
@@ -25,7 +26,7 @@ case class GmosNLongslit(blueprint: SpGmosNBlueprintLongslit) extends GmosNBase.
   val baselineFolder = 5 to 8
   val notes = Seq.empty
 
-  def initialize(grp: ISPGroup, db: TemplateDb): Either[String, Unit] = {
+  def initialize(grp: ISPGroup, db: TemplateDb, pid: SPProgramID): Either[String, Unit] = {
     val iniAo = withAoUpdate(db) _
 
     def forSpecObservation(o: ISPObservation): Either[String, Unit] = for {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNLongslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNLongslit.scala
@@ -6,13 +6,14 @@ import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.{GmosNorthType, InstGmosNorth}
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning.ONE
 import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.phase2.template.factory.impl.TargetFolder
 
-case class GmosNLongslit(blueprint: SpGmosNBlueprintLongslit) extends GmosNBase[SpGmosNBlueprintLongslit] {
+case class GmosNLongslit(blueprint: SpGmosNBlueprintLongslit) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintLongslit] {
 
   // IF SPECTROSCOPY MODE == LONGSLIT
   //         INCLUDE FROM 'LONGSLIT BP' IN
-  //             Target group: {2} - {3}
-  //             Baseline folder: {4}-{8}
+  //             Target folder: {2} - {4}
+  //             Baseline folder: {5}-{8}
   //         For spec observations: {3}, {4}, {6}-{8}
   //             SET DISPERSER FROM PI
   //             SET FILTER FROM PI
@@ -20,8 +21,8 @@ case class GmosNLongslit(blueprint: SpGmosNBlueprintLongslit) extends GmosNBase[
   //         For acquisitions: {2}, {5}
   //             if FPU!=None in the OT inst. iterators, then SET FPU FROM PI
 
-  val targetGroup = 2 to 3
-  val baselineFolder = 4 to 8
+  val targetFolder = 2 to 4
+  val baselineFolder = 5 to 8
   val notes = Seq.empty
 
   def initialize(grp: ISPGroup, db: TemplateDb): Either[String, Unit] = {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNLongslitNs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNLongslitNs.scala
@@ -6,12 +6,12 @@ import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.{GmosNorthType, InstGmosNorth}
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning.ONE
 
-case class GmosNLongslitNs(blueprint:SpGmosNBlueprintLongslitNs) extends GmosNBase[SpGmosNBlueprintLongslitNs] {
+case class GmosNLongslitNs(blueprint:SpGmosNBlueprintLongslitNs) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintLongslitNs] {
 
   // IF SPECTROSCOPY MODE == LONGSLIT N&S
   //         INCLUDE FROM 'LONGSLIT N&S BP' IN
-  //             Target group: {9} - {10}
-  //             Baseline folder: {11} - {16}
+  //             Target folder: {9} - {11}
+  //             Baseline folder: {12} - {16}
   //         For spec observations: {10}, {11}, {13}-{15}
   //             SET DISPERSER FROM PI
   //             SET FILTER FROM PI
@@ -19,8 +19,8 @@ case class GmosNLongslitNs(blueprint:SpGmosNBlueprintLongslitNs) extends GmosNBa
   //         For acquisitions: {9}, {12}
   //             if FPU!=None in the OT inst. iterators, then SET FPU FROM PI
 
-  val targetGroup = 9 to 10
-  val baselineFolder = 11 to 16
+  val targetFolder = 9 to 11
+  val baselineFolder = 12 to 16
   val notes = Seq.empty
 
   def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNLongslitNs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNLongslitNs.scala
@@ -5,6 +5,7 @@ import edu.gemini.spModel.gemini.gmos.blueprint.SpGmosNBlueprintLongslitNs
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.{GmosNorthType, InstGmosNorth}
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning.ONE
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosNLongslitNs(blueprint:SpGmosNBlueprintLongslitNs) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintLongslitNs] {
 
@@ -23,7 +24,7 @@ case class GmosNLongslitNs(blueprint:SpGmosNBlueprintLongslitNs) extends GmosNBa
   val baselineFolder = 12 to 16
   val notes = Seq.empty
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = {
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = {
     val iniAo = withAoUpdate(db) _
 
     def forSpecObservations(o:ISPObservation):Either[String, Unit] = for {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNMos.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNMos.scala
@@ -6,6 +6,7 @@ import edu.gemini.spModel.gemini.gmos.InstGmosCommon
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning.ONE
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosNMos(blueprint:SpGmosNBlueprintMos) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintMos] {
 
@@ -60,13 +61,13 @@ case class GmosNMos(blueprint:SpGmosNBlueprintMos) extends GmosNBase.WithTargetF
 
   val notes = Seq.empty
 
-  def initialize(group:ISPGroup, db:TemplateDb):Either[String, Unit] = {
+  def initialize(group:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = {
     val iniAo = withAoUpdate(db) _
     for {
       _ <- forObservations(group, spec, iniAo(forSpecObservation)).right
       _ <- forObservations(group, Seq(20, 21), _.setCustomSlitWidth(blueprint.fpu)).right
       _ <- forObservations(group, Seq(25, 26), iniAo(_.setFpu(blueprint.fpu))).right
-      _ <- forObservations(group, (18 to 23).filter(targetFolder.contains), _.setDefaultCustomMaskName).right
+      _ <- forObservations(group, (18 to 23).filter(targetFolder.contains), _.setDefaultCustomMaskName(pid)).right
       _ <- forObservations(group, Seq(24), iniAo(forStandardAcq)).right
       _ <- forObservations(group, Seq(17, 18, 19, 24).filter(all.contains), _.ifAo(_.setXyBin(ONE, ONE))).right
       _ <- forObservations(group, spec, _.ifAo(_.setYbin(ONE))).right

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNMosNs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNMosNs.scala
@@ -6,6 +6,7 @@ import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning.ONE
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosNMosNs(blueprint:SpGmosNBlueprintMos) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintMos] {
 
@@ -24,7 +25,7 @@ case class GmosNMosNs(blueprint:SpGmosNBlueprintMos) extends GmosNBase.WithTarge
   //                 SET MOS "Slit Width" from PI
   //             For {34}, {35}
   //                 SET FPU (built-in longslit) using the width specified in PI
-  //         For MOS observations in the target folder (not pre-image): any of {27} - {32}
+  //         For MOS observations in the target folder (not pre-image): any of {27} - {32} ******** ALSO ADDED 22 HERE, IS THIS RIGHT?
   //             SET "Custom Mask MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN
   //                 where:
   //                 (N/S) is the site
@@ -60,13 +61,13 @@ case class GmosNMosNs(blueprint:SpGmosNBlueprintMos) extends GmosNBase.WithTarge
 
   val notes = Seq.empty
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = {
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = {
     val iniAo = withAoUpdate(db) _
     for {
       _ <- forObservations(grp, spec, iniAo(forSpecObservation)).right
       _ <- forObservations(grp, Seq(29, 31), _.setCustomSlitWidth(blueprint.fpu)).right
       _ <- forObservations(grp, Seq(34, 35), iniAo(_.setCustomSlitWidth(blueprint.fpu))).right
-      _ <- forObservations(grp, (27 to 23).filter(targetFolder.contains), _.setDefaultCustomMaskName).right
+      _ <- forObservations(grp, (List(22) ++ (27 to 32)).filter(targetFolder.contains), _.setDefaultCustomMaskName(pid)).right
       _ <- forObservations(grp, Seq(33), iniAo(forStandardAcq)).right
       _ <- forObservations(grp, Seq(17, 27, 28, 33).filter(all.contains), _.ifAo(_.setXyBin(ONE, ONE))).right
       _ <- forObservations(grp, Seq(29, 30, 31, 32, 34, 35), _.ifAo(_.setYbin(ONE))).right

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNMosNs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNMosNs.scala
@@ -7,29 +7,41 @@ import edu.gemini.spModel.gemini.gmos.GmosNorthType.FPUnitNorth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.Binning.ONE
 
-case class GmosNMosNs(blueprint:SpGmosNBlueprintMos) extends GmosNBase[SpGmosNBlueprintMos] {
+case class GmosNMosNs(blueprint:SpGmosNBlueprintMos) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintMos] {
 
   // IF SPECTROSCOPY MODE == MOS N&S
   //         INCLUDE IN
-  //             Target group: {29}, {22}, {31}, {32}
+  //             Target folder: {29}, {22}, {31}, {32}
   //               IF PRE-IMAGING REQ == YES
   //                 INCLUDE {17}, {27}
   //               IF PRE-IMAGING REQ == NO
   //                 INCLUDE {28}
   //             Baseline folder: {30}, {33}-{35}
-  //        For spec observations: {29}, {31}, {32}, {34}, {35}
+  //         For spec observations: {29}, {31}, {32}, {34}, {35}
   //             SET DISPERSER FROM PI
   //             SET FILTER FROM PI
   //             For {29}, {31}
   //                 SET MOS "Slit Width" from PI
   //             For {34}, {35}
   //                 SET FPU (built-in longslit) using the width specified in PI
-  //        For standard acquisition: {33}
+  //         For MOS observations in the target folder (not pre-image): any of {27} - {32}
+  //             SET "Custom Mask MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN
+  //                 where:
+  //                 (N/S) is the site
+  //                 YYYYS is the semester, e.g. 2015A
+  //                 (Q/C/DD/SV/LP/FT) is the program type
+  //                 XXX is the program number, e.g. 001, or 012, or 123
+  //                 NN should be the string "NN" since the mask number is unknown
+  //         For standard acquisition: {33}
   //             if FPU!=None in the OT inst. iterators, then SET FPU (built-in longslit) using the width specified in PI
-  //         For acquisitions {27}, {28}}; mask image {22}; and N&S dark {30}
+  //         For acquisitions {27}, {28}; mask image {22}; and N&S dark {30}
   //             No actions needed
 
-  val targetGroup = Seq(29, 22, 31, 32) ++ (if (blueprint.preImaging) Seq(17, 27) else Seq(28))
+  //         IF AO in PI != None  # XBIN=YBIN=1 for AO imaging and YBIN=1 for AO spectroscopy
+  //             For pre-imaging and acquisitions {17}, {27}, {28}, {33} SET XBIN=YBIN=1
+  //             For spec observations {29}-{32}, {34}, {35} SET YBIN=1
+
+  val targetFolder = Seq(29, 22, 31, 32) ++ (if (blueprint.preImaging) Seq(17, 27) else Seq(28))
   val baselineFolder = Seq(30, 33, 34, 35)
   val all = targetGroup ++ baselineFolder
   val spec = Seq(29, 31, 32, 34, 35).filter(all.contains)
@@ -54,6 +66,7 @@ case class GmosNMosNs(blueprint:SpGmosNBlueprintMos) extends GmosNBase[SpGmosNBl
       _ <- forObservations(grp, spec, iniAo(forSpecObservation)).right
       _ <- forObservations(grp, Seq(29, 31), _.setCustomSlitWidth(blueprint.fpu)).right
       _ <- forObservations(grp, Seq(34, 35), iniAo(_.setCustomSlitWidth(blueprint.fpu))).right
+      _ <- forObservations(grp, (27 to 23).filter(targetFolder.contains), _.setDefaultCustomMaskName).right
       _ <- forObservations(grp, Seq(33), iniAo(forStandardAcq)).right
       _ <- forObservations(grp, Seq(17, 27, 28, 33).filter(all.contains), _.ifAo(_.setXyBin(ONE, ONE))).right
       _ <- forObservations(grp, Seq(29, 30, 31, 32, 34, 35), _.ifAo(_.setYbin(ONE))).right

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSBase.scala
@@ -6,6 +6,7 @@ import edu.gemini.phase2.template.factory.impl.ObservationEditor
 import edu.gemini.spModel.gemini.gmos.{SeqConfigGmosSouth, GmosSouthType, InstGmosSouth}
 import edu.gemini.spModel.obscomp.InstConstants
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.CustomSlitWidth
+import edu.gemini.phase2.template.factory.impl.TargetFolder
 
 
 trait GmosSBase[B <: SpBlueprint] extends GmosBase[B] {
@@ -43,6 +44,9 @@ trait GmosSBase[B <: SpBlueprint] extends GmosBase[B] {
     def setFpu(fpu:GmosSouthType.FPUnitSouth):Either[String, Unit] =
       ed.updateInstrument(_.setFPUnit(fpu))
 
+    def setDefaultCustomMaskName: Either[String, Unit] =
+      ed.updateInstrument(_.setFPUnitCustomMask(defaultCustomMaskName(obs)))
+
     def getFpu:Either[String, GmosSouthType.FPUnitSouth] = for {
       i <- ed.instrumentDataObject.right
     } yield i.getFPUnit
@@ -67,4 +71,8 @@ trait GmosSBase[B <: SpBlueprint] extends GmosBase[B] {
 
   val program = "GMOS-S PHASE I/II MAPPING BPS"
 
+}
+
+object GmosSBase {
+  trait WithTargetFolder[B <: SpBlueprint] extends GmosSBase[B] with TargetFolder[B]
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSBase.scala
@@ -7,6 +7,7 @@ import edu.gemini.spModel.gemini.gmos.{SeqConfigGmosSouth, GmosSouthType, InstGm
 import edu.gemini.spModel.obscomp.InstConstants
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.CustomSlitWidth
 import edu.gemini.phase2.template.factory.impl.TargetFolder
+import edu.gemini.spModel.core.SPProgramID
 
 
 trait GmosSBase[B <: SpBlueprint] extends GmosBase[B] {
@@ -44,8 +45,8 @@ trait GmosSBase[B <: SpBlueprint] extends GmosBase[B] {
     def setFpu(fpu:GmosSouthType.FPUnitSouth):Either[String, Unit] =
       ed.updateInstrument(_.setFPUnit(fpu))
 
-    def setDefaultCustomMaskName: Either[String, Unit] =
-      ed.updateInstrument(_.setFPUnitCustomMask(defaultCustomMaskName(obs)))
+    def setDefaultCustomMaskName(pid: SPProgramID): Either[String, Unit] =
+      ed.updateInstrument(_.setFPUnitCustomMask(defaultCustomMaskName(pid)))
 
     def getFpu:Either[String, GmosSouthType.FPUnitSouth] = for {
       i <- ed.instrumentDataObject.right

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSIfu.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSIfu.scala
@@ -9,32 +9,32 @@ import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FilterSouth
 
-case class GmosSIfu(blueprint:SpGmosSBlueprintIfu) extends GmosSBase[SpGmosSBlueprintIfu] {
+case class GmosSIfu(blueprint:SpGmosSBlueprintIfu) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintIfu] {
 
-//  IF SPECTROSCOPY MODE == IFU
-//          INCLUDE FROM 'IFU BP' IN,
-//              Target group: {36}-{37}
-//              Baseline folder: {38}-{42}
-//          Where FPU!=None in BP (static and iterator), SET FPU from PI
-//              IFU acq obs have an iterator titled "Field image" with
-//                  FPU=None, the FPU must not be set here.
-//              IF FPU = 'IFU 1 SLIT' in PI then SET FPU='IFU Right Slit (red)' in OT
-//          If not acq SET DISPERSER FROM PI
-//          For filter changes below, do not adjust exposure times.
-//          If acq ({36}, {41})
-//             If filter from PI != None, SET FILTER in static component
-//               to ugriz filter closest in central
-//               wavelength to the filter from PI
-//             else SET FILTER=r (as in BP)
-//          else SET FILTER FROM PI
-//              IF FPU = "IFU 2 slits" in PI:
-//  	        IF FILTER=None, SET FILTER=r_G0326
-//                  SET CENTRAL WAVELENGTHS TO THE FILTER EFF WAVELENGTH
-//                   AND EFF WAVELENGTH + 5nm (if iteration over wavelength)
-//                  See http://www.gemini.edu/node/10637
+  // IF SPECTROSCOPY MODE == IFU
+  //         INCLUDE FROM 'IFU BP' IN,
+  //             Target folder: {36}-{38}
+  //             Baseline folder: {39}-{42}
+  //         Where FPU!=None in BP (static and iterator), SET FPU from PI
+  //             IFU acq obs have an iterator titled "Field image" with
+  //                 FPU=None, the FPU must not be set here.
+  //             IF FPU = 'IFU 1 SLIT' in PI then SET FPU='IFU Right Slit (red)' in OT
+  //         If not acq SET DISPERSER FROM PI
+  //         For filter changes below, do not adjust exposure times.
+  //         If acq ({36}, {41})
+  //            If filter from PI != None, SET FILTER in static component
+  //              to ugriz filter closest in central
+  //              wavelength to the filter from PI
+  //            else SET FILTER=r (as in BP)
+  //         else SET FILTER FROM PI
+  //             IF FPU = "IFU 2 slits" in PI:
+  //             IF FILTER=None, SET FILTER=r_G0326
+  //                 SET CENTRAL WAVELENGTHS TO THE FILTER EFF WAVELENGTH
+  //                  AND EFF WAVELENGTH + 5nm (if iteration over wavelength)
+  //                 See http://www.gemini.edu/node/10637
 
-  val targetGroup = 36 to 37
-  val baselineFolder = 38 to 42
+  val targetFolder = 36 to 39
+  val baselineFolder = 39 to 42
   val notes = Seq.empty
 
   val acq = Seq(36, 41)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSIfu.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSIfu.scala
@@ -8,6 +8,7 @@ import GmosSouthType.FilterSouth._
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FilterSouth
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosSIfu(blueprint:SpGmosSBlueprintIfu) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintIfu] {
 
@@ -33,13 +34,13 @@ case class GmosSIfu(blueprint:SpGmosSBlueprintIfu) extends GmosSBase.WithTargetF
   //                  AND EFF WAVELENGTH + 5nm (if iteration over wavelength)
   //                 See http://www.gemini.edu/node/10637
 
-  val targetFolder = 36 to 39
+  val targetFolder = 36 to 38
   val baselineFolder = 39 to 42
   val notes = Seq.empty
 
   val acq = Seq(36, 41)
 
-  def initialize(group:ISPGroup, db:TemplateDb):Either[String, Unit] = forObservations(group, forAll)
+  def initialize(group:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = forObservations(group, forAll)
 
   def piFpu                    = if (blueprint.fpu == IFU_2) IFU_3 else blueprint.fpu
   def noneOrPiFpu(libFpu: Any) = if (libFpu == FPU_NONE) FPU_NONE else piFpu

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSIfuNs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSIfuNs.scala
@@ -8,32 +8,32 @@ import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FilterSouth
 
-case class GmosSIfuNs(blueprint:SpGmosSBlueprintIfuNs) extends GmosSBase[SpGmosSBlueprintIfuNs] {
+case class GmosSIfuNs(blueprint:SpGmosSBlueprintIfuNs) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintIfuNs] {
 
-//  IF SPECTROSCOPY MODE == IFU N&S
-//          INCLUDE FROM 'IFU N&S BP' IN,
-//              Target group: {43}-{44}
-//              Baseline folder: {45}-{50}
-//          Where FPU!=None in BP (static and iterator), SET FPU from PI
-//              IFU acq obs have an iterator titled "Field image" with
-//                  FPU=None, the FPU must not be set here.
-//              IF FPU = 'IFU 1 SLIT' in PI then SET FPU='IFU N & S Right Slit (red)' in OT
-//          If not acq SET DISPERSER FROM PI
-//          For filter changes below, do not adjust exposure times.
-//          If acq ({43}, {49})
-//             If filter from PI != None, SET FILTER in static component
-//               to ugriz filter closest in central wavelength to the filter
-//               from PI
-//             else SET FILTER=r (as in BP)
-//          else SET FILTER FROM PI
-//              IF FPU = 'IFU 2 slits' in PI (IFU or IFU N&S mode):
-//  	        IF FILTER=None, SET FILTER=r_G0326
-//                  SET CENTRAL WAVELENGTHS TO THE FILTER EFF WAVELENGTH
-//                   AND EFF WAVELENGTH + 5nm (if iteration over wavelength)
-//                  See http://www.gemini.edu/node/10637
+  // IF SPECTROSCOPY MODE == IFU N&S
+  //         INCLUDE FROM 'IFU N&S BP' IN,
+  //             Target folder: {43}-{45}
+  //             Baseline folder: {46}-{50}
+  //         Where FPU!=None in BP (static and iterator), SET FPU from PI
+  //             IFU acq obs have an iterator titled "Field image" with
+  //                 FPU=None, the FPU must not be set here.
+  //             IF FPU = 'IFU 1 SLIT' in PI then SET FPU='IFU N & S Right Slit (red)' in OT
+  //         If not acq SET DISPERSER FROM PI
+  //         For filter changes below, do not adjust exposure times.
+  //         If acq ({43}, {49})
+  //            If filter from PI != None, SET FILTER in static component
+  //              to ugriz filter closest in central wavelength to the filter
+  //              from PI
+  //            else SET FILTER=r (as in BP)
+  //         else SET FILTER FROM PI
+  //             IF FPU = 'IFU 2 slits' in PI (IFU or IFU N&S mode):
+  //             IF FILTER=None, SET FILTER=r_G0326
+  //                 SET CENTRAL WAVELENGTHS TO THE FILTER EFF WAVELENGTH
+  //                  AND EFF WAVELENGTH + 5nm (if iteration over wavelength)
+  //                 See http://www.gemini.edu/node/10637
 
-  val targetGroup = 43 to 44
-  val baselineFolder = 45 to 50
+  val targetFolder = 43 to 45
+  val baselineFolder = 46 to 50
   val notes = Seq.empty
 
   val acq = Seq(43, 49)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSIfuNs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSIfuNs.scala
@@ -7,6 +7,7 @@ import edu.gemini.spModel.gemini.gmos.GmosSouthType.FilterSouth._
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FilterSouth
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosSIfuNs(blueprint:SpGmosSBlueprintIfuNs) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintIfuNs] {
 
@@ -38,7 +39,7 @@ case class GmosSIfuNs(blueprint:SpGmosSBlueprintIfuNs) extends GmosSBase.WithTar
 
   val acq = Seq(43, 49)
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = forObservations(grp, forAll)
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = forObservations(grp, forAll)
 
   def piFpu                    = if (blueprint.fpu == IFU_2) IFU_3 else blueprint.fpu
   def noneOrPiFpu(libFpu: Any) = if (libFpu == FPU_NONE) FPU_NONE else piFpu

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSImaging.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSImaging.scala
@@ -6,6 +6,7 @@ import edu.gemini.spModel.gemini.gmos.blueprint.SpGmosSBlueprintImaging
 import scala.collection.JavaConverters._
 import edu.gemini.pot.sp.{ISPObservation, ISPGroup}
 import edu.gemini.spModel.gemini.gmos.GmosSouthType._
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosSImaging(blueprint:SpGmosSBlueprintImaging) extends GmosSBase[SpGmosSBlueprintImaging] {
 
@@ -21,7 +22,7 @@ case class GmosSImaging(blueprint:SpGmosSBlueprintImaging) extends GmosSBase[SpG
   val baselineFolder = Seq.empty
   val notes = Seq.empty
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = {
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = {
 
     def forAll(obs:ISPObservation):Either[String, Unit] = for {
       _ <- obs.setFilters(filters.asScala).right

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSLongslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSLongslit.scala
@@ -5,12 +5,12 @@ import edu.gemini.spModel.gemini.gmos.blueprint.SpGmosSBlueprintLongslit
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.{GmosSouthType, InstGmosSouth}
 
-case class GmosSLongslit(blueprint:SpGmosSBlueprintLongslit) extends GmosSBase[SpGmosSBlueprintLongslit] {
+case class GmosSLongslit(blueprint:SpGmosSBlueprintLongslit) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintLongslit] {
 
   // IF SPECTROSCOPY MODE == LONGSLIT
   //         INCLUDE FROM 'LONGSLIT BP' IN
-  //             Target Group: {2} - {3}
-  //             Baseline Folder: {4} - {8}
+  //             Target Folder: {2} - {4}
+  //             Baseline Folder: {5} - {8}
   //         For spec observations: {3}, {4}, {6}-{8}
   //             SET DISPERSER FROM PI
   //             SET FILTER FROM PI
@@ -18,8 +18,8 @@ case class GmosSLongslit(blueprint:SpGmosSBlueprintLongslit) extends GmosSBase[S
   //         For acquisitions: {2}, {5}
   //             if FPU!=None in the OT inst. iterators, then SET FPU FROM PI
 
-  val targetGroup = 2 to 3
-  val baselineFolder = 4 to 8
+  val targetFolder = 2 to 4
+  val baselineFolder = 5 to 8
   val notes = Seq.empty
 
   def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSLongslit.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSLongslit.scala
@@ -4,6 +4,7 @@ import edu.gemini.pot.sp.{ISPObservation, ISPGroup}
 import edu.gemini.spModel.gemini.gmos.blueprint.SpGmosSBlueprintLongslit
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.{GmosSouthType, InstGmosSouth}
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosSLongslit(blueprint:SpGmosSBlueprintLongslit) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintLongslit] {
 
@@ -22,7 +23,7 @@ case class GmosSLongslit(blueprint:SpGmosSBlueprintLongslit) extends GmosSBase.W
   val baselineFolder = 5 to 8
   val notes = Seq.empty
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = {
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = {
 
     def forSpecObservation(o:ISPObservation):Either[String, Unit] = for {
       _ <- o.setDisperser(blueprint.disperser).right

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSLongslitNs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSLongslitNs.scala
@@ -4,6 +4,7 @@ import edu.gemini.pot.sp.{ISPObservation, ISPGroup}
 import edu.gemini.spModel.gemini.gmos.blueprint.SpGmosSBlueprintLongslitNs
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.{GmosSouthType, InstGmosSouth}
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosSLongslitNs(blueprint:SpGmosSBlueprintLongslitNs) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintLongslitNs] {
 
@@ -22,7 +23,7 @@ case class GmosSLongslitNs(blueprint:SpGmosSBlueprintLongslitNs) extends GmosSBa
   val baselineFolder = 12 to 16
   val notes = Seq.empty
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = {
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] = {
 
     def forSpecObservations(o:ISPObservation):Either[String, Unit] = for {
       _ <- o.setDisperser(blueprint.disperser).right

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSLongslitNs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSLongslitNs.scala
@@ -5,12 +5,12 @@ import edu.gemini.spModel.gemini.gmos.blueprint.SpGmosSBlueprintLongslitNs
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.{GmosSouthType, InstGmosSouth}
 
-case class GmosSLongslitNs(blueprint:SpGmosSBlueprintLongslitNs) extends GmosSBase[SpGmosSBlueprintLongslitNs] {
+case class GmosSLongslitNs(blueprint:SpGmosSBlueprintLongslitNs) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintLongslitNs] {
 
   // IF SPECTROSCOPY MODE == LONGSLIT N&S
   //         INCLUDE FROM 'LONGSLIT N&S BP' IN
-  //             Target group: {9} - {10}
-  //             Baseline folder: {11} - {16}
+  //             Target folder: {9} - {11}
+  //             Baseline folder: {12} - {16}
   //         For spec observations: {10}, {11}, {13}-{15}
   //             SET DISPERSER FROM PI
   //             SET FILTER FROM PI
@@ -18,8 +18,8 @@ case class GmosSLongslitNs(blueprint:SpGmosSBlueprintLongslitNs) extends GmosSBa
   //         For acquisitions: {9}, {12}
   //             if FPU!=None in the OT inst. iterators, then SET FPU FROM PI
 
-  val targetGroup = 9 to 10
-  val baselineFolder = 11 to 16
+  val targetFolder = 9 to 11
+  val baselineFolder = 12 to 16
   val notes = Seq.empty
 
   def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] = {

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSMos.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSMos.scala
@@ -6,30 +6,37 @@ import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon
 
-case class GmosSMos(blueprint:SpGmosSBlueprintMos) extends GmosSBase[SpGmosSBlueprintMos] {
-
+case class GmosSMos(blueprint:SpGmosSBlueprintMos) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintMos] {
 
   // IF SPECTROSCOPY MODE == MOS
   //         INCLUDE FROM 'MOS BP' IN
-  //             Target group: {20}, {21} - {23}
+  //             Target folder: {20}, {21} - {23}
   //               IF PRE-IMAGING REQ == YES
   //                 INCLUDE {18}, {17}
   //               IF PRE-IMAGING REQ == NO
   //                 INCLUDE {19}
   //             Baseline folder: {24}-{26}
   //         For spec observations: {20}, {21}, {23}, {25}, {26}
-  //                 SET DISPERSER FROM PI
-  //                 SET FILTER FROM PI
-  //                 For {20}, {21}
-  //                     SET MOS "Slit Width" from PI
-  //                 For {25}, {26}
-  //                    SET FPU (built-in longslit) using the width specified in PI
+  //             SET DISPERSER FROM PI
+  //             SET FILTER FROM PI
+  //             For {20}, {21}
+  //                  SET MOS "Slit Width" from PI
+  //             For {25}, {26}
+  //                     SET FPU (built-in longslit) using the width specified in PI
+  //         For MOS observations in the target folder (not pre-image): any of {18} - {23}
+  //             SET "Custom Mask MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN
+  //                 where:
+  //                 (N/S) is the site
+  //                 YYYYS is the semester, e.g. 2015A
+  //                 (Q/C/DD/SV/LP/FT) is the program type
+  //                 XXX is the program number, e.g. 001, or 012, or 123
+  //                 NN should be the string "NN" since the mask number is unknown
   //         For standard acquisition: {24}
   //             if FPU!=None in the OT inst. iterators, then SET FPU (built-in longslit) using the width specified in PI
   //         For acquisitions: {18}, {19} and mask image {22}
   //             No actions needed
 
-  val targetGroup = Seq(20, 21, 22, 23) ++ (if (blueprint.preImaging) Seq(18, 17) else Seq(19))
+  val targetFolder = Seq(20, 21, 22, 23) ++ (if (blueprint.preImaging) Seq(18, 17) else Seq(19))
   val baselineFolder = 24 to 26
   val all = targetGroup ++ baselineFolder
   val spec = Seq(20, 21, 23, 25, 26).filter(all.contains)
@@ -53,6 +60,7 @@ case class GmosSMos(blueprint:SpGmosSBlueprintMos) extends GmosSBase[SpGmosSBlue
       _ <- forObservations(group, spec, forSpecObservation).right
       _ <- forObservations(group, Seq(20, 21), _.setCustomSlitWidth(blueprint.fpu)).right
       _ <- forObservations(group, Seq(25, 26), _.setFpu(blueprint.fpu)).right
+      _ <- forObservations(group, (18 to 23).filter(targetFolder.contains), _.setDefaultCustomMaskName).right
       _ <- forObservations(group, Seq(24), forStandardAcq).right
     } yield ()
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSMos.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSMos.scala
@@ -5,6 +5,7 @@ import edu.gemini.spModel.gemini.gmos.blueprint.SpGmosSBlueprintMos
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosSMos(blueprint:SpGmosSBlueprintMos) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintMos] {
 
@@ -55,12 +56,12 @@ case class GmosSMos(blueprint:SpGmosSBlueprintMos) extends GmosSBase.WithTargetF
 
   val notes = Seq.empty
 
-  def initialize(group:ISPGroup, db:TemplateDb):Either[String, Unit] =
+  def initialize(group:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] =
     for {
       _ <- forObservations(group, spec, forSpecObservation).right
       _ <- forObservations(group, Seq(20, 21), _.setCustomSlitWidth(blueprint.fpu)).right
       _ <- forObservations(group, Seq(25, 26), _.setFpu(blueprint.fpu)).right
-      _ <- forObservations(group, (18 to 23).filter(targetFolder.contains), _.setDefaultCustomMaskName).right
+      _ <- forObservations(group, (18 to 23).filter(targetFolder.contains), _.setDefaultCustomMaskName(pid)).right
       _ <- forObservations(group, Seq(24), forStandardAcq).right
     } yield ()
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSMosNs.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSMosNs.scala
@@ -5,6 +5,7 @@ import edu.gemini.spModel.gemini.gmos.blueprint.SpGmosSBlueprintMos
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.gemini.gmos.GmosSouthType.FPUnitSouth._
 import edu.gemini.spModel.gemini.gmos.InstGmosCommon
+import edu.gemini.spModel.core.SPProgramID
 
 case class GmosSMosNs(blueprint:SpGmosSBlueprintMos) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintMos] {
 
@@ -23,7 +24,7 @@ case class GmosSMosNs(blueprint:SpGmosSBlueprintMos) extends GmosSBase.WithTarge
   //                 SET MOS "Slit Width" from PI
   //             For {34}, {35}
   //                 SET FPU (built-in longslit) using the width specified in PI
-  //        For MOS observations in the target folder (not pre-image): any of {27} - {32}
+  //        For MOS observations in the target folder (not pre-image): any of {27} - {32} // ALSO ADDED 22
   //             SET "Custom Mask MDF" = G(N/S)YYYYS(Q/C/DD/SV/LP/FT)XXX-NN
   //                 where:
   //                 (N/S) is the site
@@ -55,12 +56,12 @@ case class GmosSMosNs(blueprint:SpGmosSBlueprintMos) extends GmosSBase.WithTarge
 
   val notes = Seq.empty
 
-  def initialize(grp:ISPGroup, db:TemplateDb):Either[String, Unit] =
+  def initialize(grp:ISPGroup, db:TemplateDb, pid: SPProgramID):Either[String, Unit] =
     for {
       _ <- forObservations(grp, spec, forSpecObservation).right
       _ <- forObservations(grp, Seq(29, 31), _.setCustomSlitWidth(blueprint.fpu)).right
       _ <- forObservations(grp, Seq(34, 35), _.setFpu(blueprint.fpu)).right
-      _ <- forObservations(grp, (27 to 32).filter(targetFolder.contains), _.setDefaultCustomMaskName).right
+      _ <- forObservations(grp, (List(22) ++ (27 to 32)).filter(targetFolder.contains), _.setDefaultCustomMaskName(pid)).right
       _ <- forObservations(grp, Seq(33), forStandardAcq).right
     } yield ()
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gnirs/GnirsBase.scala
@@ -6,6 +6,7 @@ import edu.gemini.phase2.template.factory.impl._
 import edu.gemini.pot.sp.{ISPGroup, ISPObservation}
 import edu.gemini.spModel.gemini.gnirs.GNIRSParams._
 import edu.gemini.spModel.telescope.PosAngleConstraint
+import edu.gemini.spModel.core.SPProgramID
 
 trait GnirsBase[B <: SpGnirsBlueprintBase] extends GroupInitializer[B] with TemplateDsl2[InstGNIRS] {
 
@@ -44,10 +45,10 @@ trait GnirsBase[B <: SpGnirsBlueprintBase] extends GroupInitializer[B] with Temp
 
   // HACK: override superclass initialize to hang onto db reference
   var db:Option[TemplateDb] = None
-  override def initialize(db:TemplateDb):Maybe[ISPGroup] =
+  override def initialize(db:TemplateDb, pid: SPProgramID):Maybe[ISPGroup] =
     try {
       this.db = Some(db)
-      super.initialize(db)
+      super.initialize(db, pid)
     } finally {
       this.db = None
     }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/graces/Graces.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/graces/Graces.scala
@@ -9,6 +9,7 @@ import edu.gemini.spModel.target.SPTarget
 
 import SpGracesBlueprint.ReadMode._
 import SpGracesBlueprint.FiberMode._
+import edu.gemini.spModel.core.SPProgramID
 
 case class Graces(blueprint: SpGracesBlueprint, exampleTarget: Option[SPTarget]) extends GroupInitializer[SpGracesBlueprint] with TemplateDsl2[VisitorInstrument] {
   val program = "GRACES PHASE I/II MAPPING BPS"
@@ -21,10 +22,10 @@ case class Graces(blueprint: SpGracesBlueprint, exampleTarget: Option[SPTarget])
 
   // This seems to be necessary, sorry.
   var db:Option[TemplateDb] = None
-  override def initialize(db:TemplateDb):Maybe[ISPGroup] =
+  override def initialize(db:TemplateDb, pid: SPProgramID):Maybe[ISPGroup] =
     try {
       this.db = Some(db)
-      super.initialize(db)
+      super.initialize(db, pid)
     } finally {
       this.db = None
     }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gsaoi/GsaoiBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gsaoi/GsaoiBase.scala
@@ -6,6 +6,7 @@ import scala.collection.JavaConverters._
 import edu.gemini.spModel.gemini.gsaoi.blueprint.SpGsaoiBlueprint
 import edu.gemini.spModel.gemini.gsaoi.GsaoiSeqConfig
 import edu.gemini.spModel.gemini.gsaoi.Gsaoi.Filter
+import edu.gemini.spModel.core.SPProgramID
 
 trait GsaoiBase extends GroupInitializer[SpGsaoiBlueprint] with TemplateDsl {
 
@@ -34,10 +35,10 @@ trait GsaoiBase extends GroupInitializer[SpGsaoiBlueprint] with TemplateDsl {
   // HACK: override superclass initialize to hang onto db reference
   var db: Option[TemplateDb] = None
 
-  override def initialize(db: TemplateDb): Maybe[ISPGroup] =
+  override def initialize(db: TemplateDb, pid: SPProgramID): Maybe[ISPGroup] =
     try {
       this.db = Some(db)
-      super.initialize(db)
+      super.initialize(db, pid)
     } finally {
       this.db = None
     }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/NifsBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/nifs/NifsBase.scala
@@ -6,6 +6,7 @@ import edu.gemini.spModel.gemini.nifs.blueprint.SpNifsBlueprintBase
 import edu.gemini.phase2.template.factory.impl._
 import edu.gemini.pot.sp.ISPGroup
 import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.spModel.core.SPProgramID
 
 trait NifsBase[B <: SpNifsBlueprintBase] extends GroupInitializer[B] with TemplateDsl2[InstNIFS] {
 
@@ -19,10 +20,10 @@ trait NifsBase[B <: SpNifsBlueprintBase] extends GroupInitializer[B] with Templa
 
   // HACK: override superclass initialize to hang onto db reference.
   var db:Option[TemplateDb] = None
-  override def initialize(db:TemplateDb):Maybe[ISPGroup] =
+  override def initialize(db:TemplateDb, pid: SPProgramID):Maybe[ISPGroup] =
     try {
       this.db = Some(db)
-      super.initialize(db)
+      super.initialize(db, pid)
     } finally {
       this.db = None
     }
@@ -44,7 +45,7 @@ trait NifsBase[B <: SpNifsBlueprintBase] extends GroupInitializer[B] with Templa
   def setExposure = mutateStatic[Double](_.setExposureTime(_))
 
   // When we set the disperser, we also set the wavelength
-  def setDisperser = mutateStatic[Disperser] { (o, d) => 
+  def setDisperser = mutateStatic[Disperser] { (o, d) =>
     o.setDisperser(d)
     o.setCentralWavelength(d.getWavelength)
   }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/niri/NiriBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/niri/NiriBase.scala
@@ -8,6 +8,7 @@ import edu.gemini.pot.sp.{ISPGroup, ISPObservation}
 import scala.collection.JavaConverters._
 import InstNIRI.{READ_MODE_PROP, FILTER_PROP, EXPOSURE_TIME_PROP, COADDS_PROP}
 import edu.gemini.spModel.seqcomp.{SeqRepeatDarkObs, SeqConfigComp}
+import edu.gemini.spModel.core.SPProgramID
 
 trait NiriBase extends GroupInitializer[SpNiriBlueprint] with TemplateDsl with AltairSupport {
 
@@ -43,10 +44,10 @@ trait NiriBase extends GroupInitializer[SpNiriBlueprint] with TemplateDsl with A
 
   // HACK: override superclass initialize to hang onto db reference
   var db:Option[TemplateDb] = None
-  override def initialize(db:TemplateDb):Maybe[ISPGroup] =
+  override def initialize(db:TemplateDb, pid: SPProgramID):Maybe[ISPGroup] =
     try {
       this.db = Some(db)
-      super.initialize(db)
+      super.initialize(db, pid)
     } finally {
       this.db = None
     }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/texes/TexesBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/texes/TexesBase.scala
@@ -5,6 +5,7 @@ import edu.gemini.spModel.gemini.texes.blueprint.SpTexesBlueprint
 import edu.gemini.spModel.gemini.texes.{TexesParams, InstTexes}
 import scala.Some
 import edu.gemini.pot.sp.{ISPObservation, ISPGroup}
+import edu.gemini.spModel.core.SPProgramID
 
 trait TexesBase extends GroupInitializer[SpTexesBlueprint] with TemplateDsl {
   val program = "TEXES PHASE I/II MAPPING BPS"
@@ -21,10 +22,10 @@ trait TexesBase extends GroupInitializer[SpTexesBlueprint] with TemplateDsl {
   // HACK: override superclass initialize to hang onto db reference
   var db: Option[TemplateDb] = None
 
-  override def initialize(db: TemplateDb): Maybe[ISPGroup] =
+  override def initialize(db: TemplateDb, pid: SPProgramID): Maybe[ISPGroup] =
     try {
       this.db = Some(db)
-      super.initialize(db)
+      super.initialize(db, pid)
     } finally {
       this.db = None
     }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/VisitorBase.scala
@@ -4,6 +4,7 @@ import edu.gemini.phase2.template.factory.impl._
 import edu.gemini.spModel.gemini.visitor.blueprint.SpVisitorBlueprint
 import edu.gemini.spModel.gemini.visitor.{VisitorConfig, VisitorInstrument}
 import edu.gemini.pot.sp.{ISPGroup, ISPObservation, SPComponentType}
+import edu.gemini.spModel.core.SPProgramID
 
 //noinspection MutatorLikeMethodIsParameterless
 trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl {
@@ -36,10 +37,10 @@ trait VisitorBase extends GroupInitializer[SpVisitorBlueprint] with TemplateDsl 
   // HACK: override superclass initialize to hang onto db reference
   var db: Option[TemplateDb] = None
 
-  override def initialize(db: TemplateDb): Maybe[ISPGroup] =
+  override def initialize(db: TemplateDb, pid: SPProgramID): Maybe[ISPGroup] =
     try {
       this.db = Some(db)
-      super.initialize(db)
+      super.initialize(db, pid)
     } finally {
       this.db = None
     }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosNorthBlueprintSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosNorthBlueprintSpec.scala
@@ -20,8 +20,14 @@ import edu.gemini.model.p1.immutable.Altair
 import edu.gemini.model.p1.immutable.AltairNone
 import edu.gemini.model.p1.immutable.AltairNGS
 import edu.gemini.model.p1.immutable.AltairLGS
+import edu.gemini.spModel.obscomp.SPGroup.GroupType
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.phase2.template.factory.impl.ObservationEditor
+import edu.gemini.spModel.gemini.gmos.InstGmosNorth
+import edu.gemini.spModel.gemini.gmos.SeqConfigGmosNorth
+import edu.gemini.spModel.obs.SPObservation
 
-class GmosNouthBlueprintSpec extends TemplateSpec("GMOS_N_BP.xml") with SpecificationLike with ScalaCheck {
+class GmosNorthBlueprintSpec extends TemplateSpec("GMOS_N_BP.xml") with SpecificationLike with ScalaCheck {
 
   implicit val ArbitraryFilter: Arbitrary[GmosNFilter] =
     Arbitrary(Gen.oneOf(GmosNFilter.values))
@@ -102,26 +108,68 @@ class GmosNouthBlueprintSpec extends TemplateSpec("GMOS_N_BP.xml") with Specific
   // This is just a sanity check to ensure that expansion works and that referenced library
   // observations exist. It doesn't test the specifics of the blueprint logic.
 
-  "GMOS North Sanity Check" >> {
+  "GMOS North Check" >> {
 
     "Imaging Blueprint Expansion" ! forAll { (bp: GmosNBlueprintImaging) =>
-      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) =>
+
+        // REL-3987
+        checkSingleTemplateGroupWithType(sp, GroupType.TYPE_SCHEDULING)
+        groups(sp).flatMap(libs).toSet must_== Set(1)
+
+      }
     }
 
     "IFU Expansion" ! forAll { (bp: GmosNBlueprintIfu) =>
-      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) =>
+
+        // REL-3987
+        checkSingleTemplateGroupWithType(sp, GroupType.TYPE_FOLDER)
+        groups(sp).flatMap(libs).toSet must_== Set(36,37,38)
+
+      }
     }
 
     "Longslit Expansion" ! forAll { (bp: GmosNBlueprintLongslit) =>
-      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) =>
+
+        // REL-3987
+        checkSingleTemplateGroupWithType(sp, GroupType.TYPE_FOLDER)
+        groups(sp).flatMap(libs).toSet must_== Set(2,3,4)
+
+      }
     }
 
     "Longslit (N&S) Expansion" ! forAll { (bp: GmosNBlueprintLongslitNs) =>
-      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) =>
+
+        // REL-3987
+        checkSingleTemplateGroupWithType(sp, GroupType.TYPE_FOLDER)
+        groups(sp).flatMap(libs).toSet must_== Set(9,10,11)
+
+      }
     }
 
     "MOS Expansion" ! forAll { (bp: GmosNBlueprintMos) =>
-      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) =>
+
+        // REL-3987
+        checkSingleTemplateGroupWithType(sp, GroupType.TYPE_FOLDER)
+        groups(sp).flatMap(libs).toSet must_== {
+          if (bp.nodAndShuffle) Set(29, 22, 31, 32) ++ (if (bp.preImaging) Set(17, 27) else Set(28))
+          else                  Set(20, 21, 22, 23) ++ (if (bp.preImaging) Set(18, 17) else Set(19))
+        }
+        templateObservations(sp).filter { o =>
+          val ed = ObservationEditor[InstGmosNorth](o, InstGmosNorth.SP_TYPE, SeqConfigGmosNorth.SP_TYPE)
+          val om = ed.instrumentDataObject.right.toOption.map(_.getFPUnitCustomMask())
+          val exp = o.getProgramID().toString().filterNot(_ == '-') + "-NN"
+          om == Some(exp)
+        } .map(_.getDataObject.asInstanceOf[SPObservation].getLibraryId.toInt).toSet must_== {
+          if (bp.nodAndShuffle) Set(29, 22, 31, 32) ++ (if (bp.preImaging) Set(27) else Set(28))
+          else                  Set(20, 21, 22, 23) ++ (if (bp.preImaging) Set(18) else Set(19))
+        }
+
+      }
     }
 
   }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosNorthBlueprintSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosNorthBlueprintSpec.scala
@@ -1,0 +1,130 @@
+package edu.gemini.phase2.skeleton.factory
+
+import edu.gemini.model.p1.immutable.{
+  GmosNBlueprintImaging,
+  GmosNBlueprintIfu,
+  GmosNBlueprintLongslit,
+  GmosNBlueprintLongslitNs,
+  GmosNBlueprintMos
+}
+import edu.gemini.model.p1.mutable.{GmosNMOSFpu, GmosNFpuNs, GmosNFpu, GmosNDisperser, GmosNFilter, GmosNFpuIfu}
+
+import edu.gemini.spModel.core.MagnitudeBand
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop.forAll
+import org.specs2.ScalaCheck
+import org.specs2.mutable.SpecificationLike
+import edu.gemini.model.p1.immutable.Altair
+import edu.gemini.model.p1.immutable.AltairNone
+import edu.gemini.model.p1.immutable.AltairNGS
+import edu.gemini.model.p1.immutable.AltairLGS
+
+class GmosNouthBlueprintSpec extends TemplateSpec("GMOS_N_BP.xml") with SpecificationLike with ScalaCheck {
+
+  implicit val ArbitraryFilter: Arbitrary[GmosNFilter] =
+    Arbitrary(Gen.oneOf(GmosNFilter.values))
+
+  implicit val ArbitraryDisperser: Arbitrary[GmosNDisperser] =
+    Arbitrary(Gen.oneOf(GmosNDisperser.values))
+
+  implicit val ArbitraryIfu: Arbitrary[GmosNFpuIfu] =
+    Arbitrary(Gen.oneOf(GmosNFpuIfu.values))
+
+  implicit val ArbitraryFPu: Arbitrary[GmosNFpu] =
+    Arbitrary(Gen.oneOf(GmosNFpu.values))
+
+  implicit val ArbitraryFPuNs: Arbitrary[GmosNFpuNs] =
+    Arbitrary(Gen.oneOf(GmosNFpuNs.values))
+
+  implicit val ArbitraryMosFPu: Arbitrary[GmosNMOSFpu] =
+    Arbitrary(Gen.oneOf(GmosNMOSFpu.values))
+
+  implicit val ArbitraryAltair: Arbitrary[Altair] =
+    Arbitrary(Gen.oneOf(
+      Gen.const(AltairNone),
+      arbitrary[Boolean].map(fieldLens => AltairNGS(fieldLens)),
+      Gen.choose(0,3).map(c => AltairLGS(c == 1, c == 2, c == 3))
+    ))
+
+  implicit val ArbitraryBlueprintImaging: Arbitrary[GmosNBlueprintImaging] =
+    Arbitrary {
+      for {
+        a  <- arbitrary[Altair]
+        f  <- arbitrary[GmosNFilter]
+        fs <- arbitrary[Set[GmosNFilter]]
+      } yield GmosNBlueprintImaging(a, (fs + f).toList)
+    }
+
+  implicit val ArbitraryBlueprintIfu: Arbitrary[GmosNBlueprintIfu] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Altair]
+        d <- arbitrary[GmosNDisperser]
+        f <- arbitrary[GmosNFilter]
+        i <- arbitrary[GmosNFpuIfu]
+      } yield GmosNBlueprintIfu(a, d, f, i)
+    }
+
+  implicit val ArbitraryBlueprintLongslit: Arbitrary[GmosNBlueprintLongslit] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Altair]
+        d <- arbitrary[GmosNDisperser]
+        f <- arbitrary[GmosNFilter]
+        i <- arbitrary[GmosNFpu]
+      } yield GmosNBlueprintLongslit(a, d, f, i)
+    }
+
+  implicit val ArbitraryBlueprintLongslitNs: Arbitrary[GmosNBlueprintLongslitNs] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Altair]
+        d <- arbitrary[GmosNDisperser]
+        f <- arbitrary[GmosNFilter]
+        i <- arbitrary[GmosNFpuNs]
+      } yield GmosNBlueprintLongslitNs(a, d, f, i)
+    }
+
+  implicit val ArbitraryBlueprintMos: Arbitrary[GmosNBlueprintMos] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Altair]
+        d <- arbitrary[GmosNDisperser]
+        f <- arbitrary[GmosNFilter]
+        i <- arbitrary[GmosNMOSFpu]
+        n <- arbitrary[Boolean]
+        p <- arbitrary[Boolean]
+      } yield GmosNBlueprintMos(a, d, f, i, n, p)
+    }
+
+  // This is just a sanity check to ensure that expansion works and that referenced library
+  // observations exist. It doesn't test the specifics of the blueprint logic.
+
+  "GMOS North Sanity Check" >> {
+
+    "Imaging Blueprint Expansion" ! forAll { (bp: GmosNBlueprintImaging) =>
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+    }
+
+    "IFU Expansion" ! forAll { (bp: GmosNBlueprintIfu) =>
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+    }
+
+    "Longslit Expansion" ! forAll { (bp: GmosNBlueprintLongslit) =>
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+    }
+
+    "Longslit (N&S) Expansion" ! forAll { (bp: GmosNBlueprintLongslitNs) =>
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+    }
+
+    "MOS Expansion" ! forAll { (bp: GmosNBlueprintMos) =>
+      expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
+    }
+
+  }
+
+
+}

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosSouthBlueprintSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosSouthBlueprintSpec.scala
@@ -109,7 +109,7 @@ class GmosSouthBlueprintSpec extends TemplateSpec("GMOS_S_BP.xml") with Specific
       expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
     }
 
-    "IFU (N&S) Expansion" ! forAll { (bp: GmosSBlueprintIfu) =>
+    "IFU (N&S) Expansion" ! forAll { (bp: GmosSBlueprintIfuNs) =>
       expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) => true }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
@@ -143,7 +143,7 @@ public class InstantiationFunctor extends DBAbstractFunctor {
         final ISPGroup group = fact.createGroup(prog, null);
         final SPGroup groupData = (SPGroup) group.getDataObject();
         groupData.setTitle(createGroupTitle(templateGroupData, targetData));
-        groupData.setGroupType(SPGroup.GroupType.TYPE_SCHEDULING);
+        groupData.setGroupType(templateGroupData.getGroupType());
         group.setDataObject(groupData);
         return group;
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
@@ -5,6 +5,7 @@ import edu.gemini.pot.sp.ISPNodeInitializer;
 import edu.gemini.pot.sp.ISPTemplateGroup;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gemini.init.SimpleNodeInitializer;
+import edu.gemini.spModel.obscomp.SPGroup.GroupType;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
@@ -14,7 +15,7 @@ import edu.gemini.spModel.util.VersionToken;
 
 public final class TemplateGroup extends AbstractDataObject {
 
-    public static final String VERSION = "2015A-1";
+    public static final String VERSION = "2021A-1";
     public static final SPComponentType SP_TYPE = SPComponentType.TEMPLATE_GROUP;
 
     public static final ISPNodeInitializer<ISPTemplateGroup, TemplateGroup> NI =
@@ -25,10 +26,12 @@ public final class TemplateGroup extends AbstractDataObject {
     private static final String PARAM_STATUS = "status";
     private static final String PARAM_VERSION_TOKEN = "versionToken";
     private static final String PARAM_VERSION_TOKEN_NEXT = "versionTokenNext";
+    private static final String PARAM_GROUP_TYPE = "groupType";
 
     // Public property identifiers (for truly mutable stuff only)
     public static final String PROP_STATUS = PARAM_STATUS;
     public static final String PROP_SPLIT_TOKEN = PARAM_VERSION_TOKEN;
+    public static final String PROP_GROUP_TYPE = PARAM_GROUP_TYPE;
 
     /**
      * Observation status values.
@@ -72,6 +75,7 @@ public final class TemplateGroup extends AbstractDataObject {
     private String blueprintId;
     private Status status = Status.DEFAULT;
     private VersionToken versionToken = new VersionToken(1);
+    private GroupType groupType = GroupType.DEFAULT;
 
     public TemplateGroup() {
         setTitle("Untitled");
@@ -87,6 +91,16 @@ public final class TemplateGroup extends AbstractDataObject {
         if (blueprintId == null)
             throw new IllegalArgumentException("blueprintId cannot be null.");
         this.blueprintId = blueprintId;
+    }
+
+    public GroupType getGroupType() {
+        return groupType;
+    }
+
+    public void setGroupType(GroupType groupType) {
+        if (groupType == null)
+            throw new IllegalArgumentException("groupType cannot be null");
+        this.groupType = groupType;
     }
 
     public Status getStatus() {
@@ -120,6 +134,7 @@ public final class TemplateGroup extends AbstractDataObject {
         Pio.addParam(factory, ps, PARAM_STATUS, status.name());
         Pio.addParam(factory, ps, PARAM_VERSION_TOKEN, versionToken.toString());
         Pio.addIntParam(factory, ps, PARAM_VERSION_TOKEN_NEXT, versionToken.nextSegment());
+        Pio.addEnumParam(factory, ps, PARAM_GROUP_TYPE, groupType);
         return ps;
     }
 
@@ -128,7 +143,7 @@ public final class TemplateGroup extends AbstractDataObject {
         super.setParamSet(paramSet);
         blueprintId = Pio.getValue(paramSet, PARAM_BLUEPRINT);
         status = Status.valueOf(Pio.getValue(paramSet, PARAM_STATUS));
-
+        groupType = Pio.getEnumValue(paramSet, PROP_GROUP_TYPE, GroupType.DEFAULT);
         int[] segments = VersionToken.segments(Pio.getValue(paramSet, PARAM_VERSION_TOKEN, versionToken.toString()));
         int next = Pio.getIntValue(paramSet, PARAM_VERSION_TOKEN_NEXT, 1);
         versionToken = VersionToken.apply(segments, next);

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/RegenerationClient.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/RegenerationClient.java
@@ -2,6 +2,7 @@ package jsky.app.ot.editor.template;
 
 import edu.gemini.phase2.core.model.TemplateFolderExpansion;
 import edu.gemini.spModel.core.Peer;
+import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioNode;
 import edu.gemini.spModel.pio.xml.PioXmlException;
@@ -96,10 +97,11 @@ public final class RegenerationClient {
         }
     }
 
-    public static Result expand(Phase1Folder folder, Peer peer, int timeoutMs) {
+    public static Result expand(Phase1Folder folder, SPProgramID pid, Peer peer, int timeoutMs) {
         // Setup to post the template folder XML.
         MultipartPostMethod post;
         post = new MultipartPostMethod(getUrl(peer));
+        post.addParameter("pid", pid.toString());
         post.addPart(makeFilePart(folder));
         post.setRequestHeader( "Accept-Encoding", ENC);
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/RegenerationDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/RegenerationDialog.java
@@ -266,7 +266,7 @@ public final class RegenerationDialog extends JDialog {
                 publish("Could not find a peer to contact for template observation expansion.");
                 return false;
             }
-            Result res = RegenerationClient.expand(folder, p, 10000);
+            Result res = RegenerationClient.expand(folder, program.getProgramID(), p, 10000);
             if (res.isFailure()) {
                 publish(res.failure.code.message + " " + res.failure.detail);
                 return false;


### PR DESCRIPTION
It is with great sadness that I announce this PR is ready for review. It updates the templates for GMOS and in so doing required adding two new features.

- Templates can now expand into organizational folders (in addition to scheduling groups, the default) as specified by the `GroupInitializer`. In order to make this work I had to add a `groupType` member to `TemplateFolder` that is consulted by the `InsantiationFunctor` at "runtime".
- For MOS observations the default MDF mask name is now set to match the program ID (without dashes, and with `-NN` at the end). In order to do this I needed to pass the `SPProgramID` down from the top to make it available in the `GroupInitializer`, which involved (among other things) turning it into a request parameter for the template reset web service.

There are tests that the proper observations make it into the template folder, that the folder type is properly recorded, and that the mask name is correctly set.

There are _not_ tests for runtime template expansion (to verify that the group type ends up correct) or for the template reset service. These will need to be monkey-tested.