### PR TITLE
REL-4018: Reinstate missing ITC sky background data file

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -100,6 +100,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2021-Oct-28</footer>
+<footer>Last updated 2021-Nov-14</footer>
 </body>
 </html>


### PR DESCRIPTION
Not sure how we lost it, but I found an old copy of the file from 2014.