### PR TITLE
Make the fire test more reliable

### DIFF
--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/session/FireEnvironment.scala
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/session/FireEnvironment.scala
@@ -77,7 +77,7 @@ object FireEnvironment {
     List(Dataset)
 
   val TimeoutSec: Int =
-    1
+    10
 
   def initializeForDatabase(
     db: IDBDatabaseService

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/session/FireTest.scala
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/scala/edu/gemini/wdba/session/FireTest.scala
@@ -87,8 +87,21 @@ class FireTest extends OdbTestBase {
 
     env.foreach { e =>
       test(e)
-      val actual = toJsonString(e.buf.toList.map(FireMessage.uuid.set(Uuid)))
-      assertEquals("FireMessage comparison", expected, actual)
+      val actual  = toJsonString(e.buf.toList.map(FireMessage.uuid.set(Uuid)))
+      val message =
+        s"""
+           |FireMessage comparison failure.
+           |
+           |Expected:
+           |$expected
+           |
+           |--
+           |
+           |Actual:
+           |$actual
+           |
+           |""".stripMargin
+      assertEquals(message, expected, actual)
     }
   }
 


### PR DESCRIPTION
FIRE messages are posted asynchronously after the event that triggered them has been processed. The test case waits up to one second for the event to show up before triggering more events, but when other test cases are running in parallel and the machine is busy that is sometimes not enough.  This PR increases the wait time for an expected FIRE message to 10 seconds.

The PR only changes test code.