### PR TITLE
REL-4005-B: Correct GHOST Readout Cost

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
@@ -109,7 +109,7 @@ public class OverheadTablePrinter {
 
             if (cts != null) {
                 for (PlannedTime.CategorizedTime lct : cts) {
-                    if (lct.detail.equals("LGS Reacquisition")) {
+                    if (lct.detail.contains("LGS Reacquisition")) {
                         gsaoiLgsReacqNum++;
                     }
                 }
@@ -160,7 +160,7 @@ public class OverheadTablePrinter {
             if (cts != null) {
                 for (PlannedTime.CategorizedTime lct : cts) {
                     Double time = lct.time / 1000.0;
-                    if (lct.detail.equals(OffsetOverheadCalculator.DETAIL) && lct.time != 0) {
+                    if (lct.detail.contains(OffsetOverheadCalculator.DETAIL) && lct.time != 0) {
                         offsetsByOverhead.put(time, offsetsByOverhead.getOrDefault(time, 0) + 1);
                     }
                 }
@@ -245,7 +245,7 @@ public class OverheadTablePrinter {
             if (cts == null) continue;
             PlannedTime.CategorizedTime ct = cts.max(Comparator.naturalOrder());
             int coadds = p.observation().calculationMethod().coaddsOrElse(1);
-            String category = (ct.detail == null) ? ct.category.display : ct.detail;
+            String category = ct.detail.getOrElse(ct.category.display);
 
             buf.append("<tr>");
             buf.append("<td>").append(category).append("</td>");

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
@@ -698,7 +698,7 @@ public final class Gsaoi extends SPInstObsComp
 
         // Predicate that leaves all CategorizedTime except for the offset overhead.
     private static final PredicateOp<CategorizedTime> RM_OFFSET_OVERHEAD = ct -> !((ct.category == Category.CONFIG_CHANGE) &&
-             (ct.detail.equals(OffsetOverheadCalculator.DETAIL)));
+             ct.detail.contains(OffsetOverheadCalculator.DETAIL));
 
     private static double getOffsetArcsec(Config c, ItemKey k) {
         final String d;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/InstNICI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/InstNICI.java
@@ -255,7 +255,7 @@ public final class InstNICI extends SPInstObsComp implements PropertyProvider, G
 
     // Predicate that leaves all CategorizedTime except for the offset overhead.
     private static final PredicateOp<CategorizedTime> RM_OFFSET_OVERHEAD = ct -> !((ct.category == Category.CONFIG_CHANGE) &&
-             OffsetOverheadCalculator.DETAIL.equals(ct.detail));
+             ct.detail.contains(OffsetOverheadCalculator.DETAIL));
 
     // Get correct offset overhead in the common group.  If a small offset,
     // we remove the offset overhead put there by the common step calculator

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/plannedtime/PlannedTime.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/plannedtime/PlannedTime.java
@@ -66,7 +66,7 @@ public final class PlannedTime implements Serializable {
             this.display = display;
         }
 
-        public final CategorizedTime ZERO = new CategorizedTime(this, 0);
+        public final CategorizedTime ZERO = new CategorizedTime(this, 0, ImOption.empty());
 
     }
 
@@ -77,10 +77,6 @@ public final class PlannedTime implements Serializable {
         public final long time;
 
         public final Option<String> detail;
-
-        private CategorizedTime(Category cat, long time) {
-            this(cat, time, ImOption.empty());
-        }
 
         private CategorizedTime(Category cat, long time, Option<String> detail) {
             if (cat == null) throw new IllegalArgumentException("Category is null");
@@ -125,7 +121,7 @@ public final class PlannedTime implements Serializable {
          */
         public static CategorizedTime fromSeconds(Category cat, double sec) {
             long time = toMillsec(sec);
-            return (time == 0) ? cat.ZERO : new CategorizedTime(cat, time);
+            return (time == 0) ? cat.ZERO : new CategorizedTime(cat, time, ImOption.empty());
         }
 
         public static CategorizedTime fromSeconds(Category cat, double sec, String detail) {
@@ -133,11 +129,11 @@ public final class PlannedTime implements Serializable {
         }
 
         public static CategorizedTime apply(Category cat, long time) {
-            return (time == 0) ? cat.ZERO : new CategorizedTime(cat, time);
+            return (time == 0) ? cat.ZERO : new CategorizedTime(cat, time, ImOption.empty());
         }
 
         public static CategorizedTime apply(Category cat, long time, String detail) {
-            return (detail == null) ? apply(cat, time) : new CategorizedTime(cat, time, ImOption.apply(detail));
+            return new CategorizedTime(cat, time, ImOption.apply(detail));
         }
 
         @Override public int compareTo(CategorizedTime that) {

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -347,7 +347,13 @@ final class Ghost
     val times: java.util.Collection[CategorizedTime] = new java.util.ArrayList[CategorizedTime]()
 
     // TODO-GHOST: Default values
-    times.add(CategorizedTime.fromSeconds(Category.READOUT, 60))
+
+    val red   = cur.getItemValue(Ghost.RED_EXPOSURE_COUNT_KEY).asInstanceOf[Int]
+    val blue  = cur.getItemValue(Ghost.BLUE_EXPOSURE_COUNT_KEY).asInstanceOf[Int]
+    val count = Math.max(red, blue)
+    val label = if (red === blue) "" else if (red > blue) " red" else " blue"
+
+    times.add(CategorizedTime.fromSeconds(Category.READOUT, 60 * count, s"60s x $count$label"))
 
     times.add(CategorizedTime.fromSeconds(Category.EXPOSURE, ExposureCalculator.instance.exposureTimeSec(cur)));
     CommonStepCalculator.instance.calc(cur, prev).addAll(times)

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/ObserveTimeLineNode.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/seq/ObserveTimeLineNode.java
@@ -104,6 +104,15 @@ public class ObserveTimeLineNode extends DefaultTimeLineNode {
                 buf.append("<td align=\"right\"> ").append(secStr).append("</td>");
                 buf.append("</tr>");
 
+                if (ct.category != Category.CONFIG_CHANGE) {
+                    ct.detail.foreach(d -> {
+                        buf.append("<tr>");
+                        buf.append("<td></td>");
+                        buf.append("<td>").append(d).append("</td>");
+                        buf.append("</tr>");
+                    });
+                }
+
                 // Only Config changes have separate actions running in parallel.
                 if (ct.category == Category.CONFIG_CHANGE) {
                     buf.append("<tr>");
@@ -138,7 +147,7 @@ public class ObserveTimeLineNode extends DefaultTimeLineNode {
     }
 
     private static String formatCategory(CategorizedTime ct) {
-        return (ct.detail == null) ? ct.category.display : ct.detail;
+        return ct.detail.getOrElse(ct.category.display);
     }
 
     private static String formatSec(long time) {


### PR DESCRIPTION
There should be a readout cost per exposure, not one for the entire step.  So 4x100 Red + 1x400 Blue actually has a readout cost of 4x60 (not just 60) and exposure + readout is 400 + 240 = 640.

![Screen Shot 2021-11-16 at 18 13 10](https://user-images.githubusercontent.com/4906023/142066690-4c422984-7614-4fe8-adc3-056e46e39d02.png)

Updates the planned time category so that `detail` is no longer nullable but rather an `Option`.  Adds the exposure count and label ("blue" or "red") that dominates the readout overhead in the `detail` message.


