### PR TITLE
REL-3987 GMOS skeleton updates (3)

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNImaging.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosNImaging.scala
@@ -10,7 +10,7 @@ import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.spModel.core.SPProgramID
 
 
-case class GmosNImaging(blueprint:SpGmosNBlueprintImaging) extends GmosNBase[SpGmosNBlueprintImaging] {
+case class GmosNImaging(blueprint:SpGmosNBlueprintImaging) extends GmosNBase.WithTargetFolder[SpGmosNBlueprintImaging] {
 
   import blueprint._
 
@@ -20,7 +20,7 @@ case class GmosNImaging(blueprint:SpGmosNBlueprintImaging) extends GmosNBase[SpG
   //          exposure time for each filter from
   //          http://dmt.gemini.edu/docushare/dsweb/Get/Document-333602/GMOS_img_exptimes.xlsx
 
-  val targetGroup = Seq(1)
+  val targetFolder = Seq(1)
   val baselineFolder = Seq.empty
   val notes = Seq.empty
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSImaging.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/gmos/GmosSImaging.scala
@@ -8,7 +8,7 @@ import edu.gemini.pot.sp.{ISPObservation, ISPGroup}
 import edu.gemini.spModel.gemini.gmos.GmosSouthType._
 import edu.gemini.spModel.core.SPProgramID
 
-case class GmosSImaging(blueprint:SpGmosSBlueprintImaging) extends GmosSBase[SpGmosSBlueprintImaging] {
+case class GmosSImaging(blueprint:SpGmosSBlueprintImaging) extends GmosSBase.WithTargetFolder[SpGmosSBlueprintImaging] {
 
   import blueprint._
 
@@ -18,7 +18,7 @@ case class GmosSImaging(blueprint:SpGmosSBlueprintImaging) extends GmosSBase[SpG
   //          exposure time for each filter from
   //          http://dmt.gemini.edu/docushare/dsweb/Get/Document-333602/GMOS_img_exptimes.xlsx
 
-  val targetGroup = Seq(1)
+  val targetFolder = Seq(1)
   val baselineFolder = Seq.empty
   val notes = Seq.empty
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosNorthBlueprintSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosNorthBlueprintSpec.scala
@@ -114,7 +114,7 @@ class GmosNorthBlueprintSpec extends TemplateSpec("GMOS_N_BP.xml") with Specific
       expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) =>
 
         // REL-3987
-        checkSingleTemplateGroupWithType(sp, GroupType.TYPE_SCHEDULING)
+        checkSingleTemplateGroupWithType(sp, GroupType.TYPE_FOLDER)
         groups(sp).flatMap(libs).toSet must_== Set(1)
 
       }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosSouthBlueprintSpec.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GmosSouthBlueprintSpec.scala
@@ -110,7 +110,7 @@ class GmosSouthBlueprintSpec extends TemplateSpec("GMOS_S_BP.xml") with Specific
       expand(proposal(bp, List(1), MagnitudeBand.H)) { (p, sp) =>
 
         // REL-3987
-        checkSingleTemplateGroupWithType(sp, GroupType.TYPE_SCHEDULING)
+        checkSingleTemplateGroupWithType(sp, GroupType.TYPE_FOLDER)
         groups(sp).flatMap(libs).toSet must_== Set(1)
 
       }


### PR DESCRIPTION
The blueprint text updates didn't mention changing the folder type for imaging, so I left it as `TYPE_SHEDULING` and in fact wrote some code to abstract over this difference. But I had interpreted the requiremeents incorrectly and all GMOS templates should in fact expand to `TYPE_FOLDER` instead. So this changes the folder type for imaging templates but leaves the abstraction there, in case they change their mind or we need to use the pattern for other instruments in the future.