### PR TITLE
REL-3997: No such thing as GHOST HRIFU2 or HR w/o sky

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
@@ -29,11 +29,7 @@ public enum AsterismType {
             new Some<>(AsterismConverters.GhostSkyPlusTargetConverter$.MODULE$),
             GhostAsterism$.MODULE$::createEmptySkyPlusTargetAsterism),
 
-    GhostHighResolutionTarget("ghostHRTarget", "HRIFU1 Target",
-            new Some<>(AsterismConverters.GhostHRTargetConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptyHRTargetAsterism),
-
-    GhostHighResolutionTargetPlusSky("ghostHRTargetPlusSky", "HRIFU1 Target, HRIFU2 Sky",
+    GhostHighResolutionTargetPlusSky("ghostHRTargetPlusSky", "HRIFU Target, SRIFU2 Sky",
             new Some<>(AsterismConverters.GhostHRTargetPlusSkyConverter$.MODULE$),
             GhostAsterism$.MODULE$::createEmptyTargetPlusSkyAsterism)
 
@@ -61,18 +57,18 @@ public enum AsterismType {
     // Return the asterism types supported by the different instruments.
     // We need to do this here because we want these statically accessible.
     public static Set<AsterismType> supportedTypesForInstrument(final Instrument instType) {
-        switch (instType) {
-            case Ghost:
-                final Set<AsterismType> s = new TreeSet<>();
-                s.add(GhostSingleTarget);
-                s.add(GhostDualTarget);
-                s.add(GhostTargetPlusSky);
-                s.add(GhostSkyPlusTarget);
-                s.add(GhostHighResolutionTarget);
-                s.add(GhostHighResolutionTargetPlusSky);
-                return Collections.unmodifiableSet(s);
-            default:
-                return Collections.singleton(Single);
+        final Set<AsterismType> result;
+        if (instType == Instrument.Ghost) {
+            final Set<AsterismType> s = new TreeSet<>();
+            s.add(GhostSingleTarget);
+            s.add(GhostDualTarget);
+            s.add(GhostTargetPlusSky);
+            s.add(GhostSkyPlusTarget);
+            s.add(GhostHighResolutionTargetPlusSky);
+            result = Collections.unmodifiableSet(s);
+        } else {
+            result = Collections.singleton(Single);
         }
+        return result;
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/ResolutionMode.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/ResolutionMode.java
@@ -15,12 +15,13 @@ public enum ResolutionMode {
                     AsterismType.GhostSkyPlusTarget)
     ),
     GhostHigh("ghostHigh", "High Resolution",
-            Arrays.asList(
-                    AsterismType.GhostHighResolutionTarget,
+            Collections.singletonList(
                     AsterismType.GhostHighResolutionTargetPlusSky
             )),
     GhostPRV("ghostPRV", "Precision Radial Velocity",
-            Collections.singletonList(AsterismType.GhostHighResolutionTarget));
+            Collections.singletonList(
+                    AsterismType.GhostHighResolutionTargetPlusSky
+            ));
 
     public final String tag;
     public final String name;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
@@ -144,16 +144,6 @@ public final class TargetSelection {
                     res.add(new CoordinatesSelection(idx++, gsta.sky()));
                     res.add(new NormalTargetSelection(idx++, gsta.target().spTarget()));
                     break;
-                case GhostHighResolutionTarget:
-                    final GhostAsterism.HighResolutionTarget ghta = (GhostAsterism.HighResolutionTarget) a;
-                    if (ghta.overriddenBase().isDefined())
-                        res.add(new CoordinatesSelection(idx++, ghta.overriddenBase().get()));
-                    else {
-                        final scala.Option<Coordinates> c = ghta.basePosition(ImOption.scalaNone());
-                        res.add(new CoordinatesSelection(idx++, c.isDefined() ? c.get() : Coordinates.zero()));
-                    }
-                    res.add(new NormalTargetSelection(idx++, ghta.target().spTarget()));
-                    break;
                 case GhostHighResolutionTargetPlusSky:
                     final GhostAsterism.HighResolutionTargetPlusSky ghtsa = (GhostAsterism.HighResolutionTargetPlusSky) a;
                     if (ghtsa.overriddenBase().isDefined())
@@ -208,7 +198,6 @@ public final class TargetSelection {
                     idx = 1;
                     break;
                 case GhostSingleTarget:
-                case GhostHighResolutionTarget:
                     idx = 2;
                     break;
                 case GhostDualTarget:

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismConverters.scala
@@ -1,7 +1,7 @@
 package edu.gemini.spModel.gemini.ghost
 
 import edu.gemini.shared.util.immutable.ImList
-import edu.gemini.spModel.core.{Coordinates, SiderealTarget}
+import edu.gemini.spModel.core.SiderealTarget
 import edu.gemini.spModel.target.{SPCoordinates, SPTarget}
 import edu.gemini.spModel.target.env.{TargetEnvironment, UserTarget}
 
@@ -31,10 +31,10 @@ object AsterismConverters {
             case DualTarget(t1, t2, b)                => creator(env, t1, t2.some,   None, b).some
             case TargetPlusSky(t, s, b)               => creator(env, t,     None, s.some, b).some
             case SkyPlusTarget(s, t, b)               => creator(env, t,     None, s.some, b).some
-            case HighResolutionTarget(t, b)           => creator(env, t,     None,   None, b).some
             case HighResolutionTargetPlusSky(t, s, b) => creator(env, t,     None, s.some, b).some
           }
-        case _                                              => None
+        case _                 =>
+          None
       }
 
     /** This is just a method that takes the targets / coordinates common to all GHOST asterism types so that we can
@@ -78,16 +78,6 @@ object AsterismConverters {
 
     override protected def creator(env: TargetEnvironment, t: GhostTarget, t2: Option[GhostTarget], s: SkyPosition, b: BasePosition): TargetEnvironment = {
       val asterism    = SkyPlusTarget(s.getOrElse(new SPCoordinates), t, b)
-      val userTargets = appendTarget(env.getUserTargets, gT2UT(t2))
-      TargetEnvironment.createWithClonedTargets(asterism, env.getGuideEnvironment, userTargets)
-    }
-  }
-
-  case object GhostHRTargetConverter extends GhostAsterismConverter {
-    override val name: String = "GhostAsterism.HighResolutionTarget"
-
-    override protected def creator(env: TargetEnvironment, t: GhostTarget, t2: Option[GhostTarget], s: SkyPosition, b: BasePosition): TargetEnvironment = {
-      val asterism    = HighResolutionTarget(t, b)
       val userTargets = appendTarget(env.getUserTargets, gT2UT(t2))
       TargetEnvironment.createWithClonedTargets(asterism, env.getGuideEnvironment, userTargets)
     }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
@@ -15,19 +15,19 @@ object AsterismTypeConverters {
    * data is maintained.
    */
   val asterismTypeConverters: ((ResolutionMode, AsterismType, ResolutionMode)) => Option[AsterismType] = Map(
-      (GhostStandard, GhostSingleTarget, GhostHigh)  -> GhostHighResolutionTarget,
-      (GhostStandard, GhostSingleTarget, GhostPRV)   -> GhostHighResolutionTarget,
-      (GhostStandard, GhostDualTarget, GhostHigh)    -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostDualTarget, GhostPRV)     -> GhostHighResolutionTarget,
+      (GhostStandard, GhostSingleTarget,  GhostHigh) -> GhostHighResolutionTargetPlusSky,
+      (GhostStandard, GhostSingleTarget,  GhostPRV)  -> GhostHighResolutionTargetPlusSky,
+      (GhostStandard, GhostDualTarget,    GhostHigh) -> GhostHighResolutionTargetPlusSky,
+      (GhostStandard, GhostDualTarget,    GhostPRV)  -> GhostHighResolutionTargetPlusSky,
       (GhostStandard, GhostTargetPlusSky, GhostHigh) -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostTargetPlusSky, GhostPRV)  -> GhostHighResolutionTarget,
+      (GhostStandard, GhostTargetPlusSky, GhostPRV)  -> GhostHighResolutionTargetPlusSky,
       (GhostStandard, GhostSkyPlusTarget, GhostHigh) -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostSkyPlusTarget, GhostPRV)  -> GhostHighResolutionTarget,
+      (GhostStandard, GhostSkyPlusTarget, GhostPRV)  -> GhostHighResolutionTargetPlusSky,
 
-      (GhostHigh, GhostHighResolutionTarget, GhostStandard) -> GhostSingleTarget,
-      (GhostHigh, GhostHighResolutionTarget, GhostPRV)      -> GhostSingleTarget,
       (GhostHigh, GhostHighResolutionTargetPlusSky, GhostStandard) -> GhostTargetPlusSky,
-      (GhostHigh, GhostHighResolutionTargetPlusSky, GhostPRV) -> GhostHighResolutionTarget,
+      (GhostHigh, GhostHighResolutionTargetPlusSky, GhostPRV)      -> GhostHighResolutionTargetPlusSky,
 
-      (GhostPRV, GhostHighResolutionTarget, GhostStandard) -> GhostSingleTarget).lift
+      (GhostPRV, GhostHighResolutionTargetPlusSky, GhostStandard) -> GhostSingleTarget,
+      (GhostPRV, GhostHighResolutionTargetPlusSky, GhostHigh)     -> GhostHighResolutionTargetPlusSky
+  ).lift
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -203,7 +203,6 @@ object GhostAsterism {
       NonEmptyList(target.spTarget)
 
     override def allSpCoordinates: List[SPCoordinates] = this match {
-      case HighResolutionTarget(_,b)          => b.toList
       case HighResolutionTargetPlusSky(_,s,b) => b.toList :+ s
     }
 
@@ -215,42 +214,29 @@ object GhostAsterism {
       Target.pm.get(target.spTarget.getTarget)
 
     override def copyWithClonedTargets: Asterism = this match {
-      case HighResolutionTarget(t,b) => HighResolutionTarget(t.copyWithClonedTarget, b.map(_.clone))
       case HighResolutionTargetPlusSky(t,s,b) => HighResolutionTargetPlusSky(t.copyWithClonedTarget, s.clone, b.map(_.clone))
     }
 
     override def resolutionMode: ResolutionMode = ResolutionMode.GhostHigh
 
     override def asterismType: AsterismType = this match {
-      case HighResolutionTarget(_,_)          => AsterismType.GhostHighResolutionTarget
       case HighResolutionTargetPlusSky(_,_,_) => AsterismType.GhostHighResolutionTargetPlusSky
     }
 
     def hrifu1: GhostTarget = this match {
-      case HighResolutionTarget(t,_)          => t
       case HighResolutionTargetPlusSky(t,_,_) => t
     }
     def hrifu2: Option[SPCoordinates] = this match {
-      case HighResolutionTarget(_,_)          => None
       case HighResolutionTargetPlusSky(_,s,_) => Some(s)
     }
   }
-
-  final case class HighResolutionTarget(target: GhostTarget,
-                                        override val overriddenBase: Option[SPCoordinates]) extends HighResolution(target)
 
   final case class HighResolutionTargetPlusSky(target: GhostTarget,
                                                sky:    SPCoordinates,
                                                override val overriddenBase: Option[SPCoordinates]) extends HighResolution(target)
 
   object HighResolution {
-    val emptyHRTarget: HighResolutionTarget = HighResolutionTarget(GhostTarget.empty, None)
     val emptyHRTargetPlusSky: HighResolutionTargetPlusSky = HighResolutionTargetPlusSky(GhostTarget.empty, new SPCoordinates, None)
-
-    val HRTargetIFU1: HighResolutionTarget @> GhostTarget =
-      Lens.lensu((a,b) => a.copy(target = b), _.target)
-    val HRTargetOverriddenBase: HighResolutionTarget @> Option[SPCoordinates] =
-      Lens.lensu((a,b) => a.copy(overriddenBase = b), _.overriddenBase)
 
     val HRTargetPlusSkyIFU1: HighResolutionTargetPlusSky @> GhostTarget =
       Lens.lensu((a,b) => a.copy(target = b), _.target)
@@ -278,10 +264,6 @@ object GhostAsterism {
     StandardResolution.emptySkyPlusTarget.copyWithClonedTargets
   }
 
-  def createEmptyHRTargetAsterism: Asterism = {
-    HighResolution.emptyHRTarget.copyWithClonedTargets
-  }
-
   def createEmptyHRTargetPlusSkyAsterism: Asterism = {
     HighResolution.emptyHRTargetPlusSky.copyWithClonedTargets
   }
@@ -289,6 +271,5 @@ object GhostAsterism {
   // Names of the IFUs.
   val SRIFU1: String = "SRIFU1"
   val SRIFU2: String = "SRIFU2"
-  val HRIFU1: String = "HRIFU1"
-  val HRIFU2: String = "HRIFU2"
+  val HRIFU:  String = "HRIFU"
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostParamSetCodecs.scala
@@ -8,12 +8,12 @@ import edu.gemini.spModel.target.TargetParamSetCodecs._
 
 
 object GhostParamSetCodecs {
-  private val IFU1 = "ifu1"
-  private val IFU2 = "ifu2"
-  private val Target = "target"
+  private val IFU1    = "ifu1"
+  private val IFU2    = "ifu2"
+  private val Target  = "target"
   private val GFState = "guideFiberState"
-  private val Base = "base"
-  
+  private val Base    = "base"
+
   implicit val GuideFiberStateParamCodec: ParamCodec[GuideFiberState] =
     ParamCodec[String].xmap(GuideFiberState.unsafeFromString, _.name)
 
@@ -44,12 +44,6 @@ object GhostParamSetCodecs {
       .withParamSet(IFU1, SkyPlusTargetIFU1)
       .withParamSet(IFU2, SkyPlusTargetIFU2)
       .withOptionalParamSet(Base, SkyPlusTargetOverriddenBase)
-
-  implicit val HRTargetParamSetCodec: ParamSetCodec[HighResolutionTarget] =
-    ParamSetCodec.initial(emptyHRTarget)
-      .withParamSet(IFU1, HRTargetIFU1)
-      .withOptionalParamSet(Base, HRTargetOverriddenBase)
-
 
   implicit val HRTargetPlusSkyParamSetCodec: ParamSetCodec[HighResolutionTargetPlusSky] =
     ParamSetCodec.initial(emptyHRTargetPlusSky)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -150,7 +150,6 @@ object Asterism {
           case a: GhostAsterism.DualTarget                  => GhostParamSetCodecs.DualTargetParamSetCodec.encode(key, a)
           case a: GhostAsterism.TargetPlusSky               => GhostParamSetCodecs.TargetPlusSkyParamSetCodec.encode(key, a)
           case a: GhostAsterism.SkyPlusTarget               => GhostParamSetCodecs.SkyPlusTargetParamSetCodec.encode(key, a)
-          case a: GhostAsterism.HighResolutionTarget        => GhostParamSetCodecs.HRTargetParamSetCodec.encode(key, a)
           case a: GhostAsterism.HighResolutionTargetPlusSky => GhostParamSetCodecs.HRTargetPlusSkyParamSetCodec.encode(key, a)
         }
         Pio.addParam(pf, ps, "tag", tag)
@@ -164,7 +163,6 @@ object Asterism {
           case AsterismType.GhostDualTarget.tag                  => GhostParamSetCodecs.DualTargetParamSetCodec.decode(ps)
           case AsterismType.GhostTargetPlusSky.tag               => GhostParamSetCodecs.TargetPlusSkyParamSetCodec.decode(ps)
           case AsterismType.GhostSkyPlusTarget.tag               => GhostParamSetCodecs.SkyPlusTargetParamSetCodec.decode(ps)
-          case AsterismType.GhostHighResolutionTarget.tag        => GhostParamSetCodecs.HRTargetParamSetCodec.decode(ps)
           case AsterismType.GhostHighResolutionTargetPlusSky.tag => GhostParamSetCodecs.HRTargetPlusSkyParamSetCodec.decode(ps)
           case other                                             => UnknownTag(other, "Asterism").left
         }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/ghost/AsterismConvertersSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/ghost/AsterismConvertersSpec.scala
@@ -32,20 +32,8 @@ object AsterismConvertersSpec extends Specification with ScalaCheck with Arbitra
       oneWayTest(genGhostSkyPlusTargetTargetEnvironment, GhostSkyPlusTargetConverter)
     }
 
-    "Convert HighResolutionTarget to itself losslessly" in {
-      oneWayTest(genGhostHighResTargetAsterismTargetEnvironment, GhostHRTargetConverter)
-    }
-
     "Convert HighResolutionTargetPlusSky to itself losslessly" in {
       oneWayTest(genGhostHighResTargetPlusSkyAsterismTargetEnvironment, GhostHRTargetPlusSkyConverter)
-    }
-
-    "Convert between SingleTarget and HighResolutionTarget losslessly" in {
-      twoWayTest(genGhostSingleTargetTargetEnvironment, GhostHRTargetConverter, GhostSingleTargetConverter)
-    }
-
-    "Convert between HighResolutionTarget and SingleTarget losslessly" in {
-      twoWayTest(genGhostHighResTargetAsterismTargetEnvironment, GhostSingleTargetConverter, GhostHRTargetConverter)
     }
 
     "Convert between TargetPlusSky and SkyPlusTarget losslessly" in {
@@ -90,7 +78,6 @@ object AsterismConvertersSpec extends Specification with ScalaCheck with Arbitra
     GhostDualTargetConverter,
     GhostTargetPlusSkyConverter,
     GhostSkyPlusTargetConverter,
-    GhostHRTargetConverter,
     GhostHRTargetPlusSkyConverter
   )
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Almosts.scala
@@ -158,12 +158,6 @@ trait Almosts {
         (a.target ~= b.target) && (a.sky ~= b.sky) && (a.overriddenBase ~= b.overriddenBase)
     }
 
-  implicit val GhostAsterismHighResTargetAlmostEqual: AlmostEqual[GhostAsterism.HighResolutionTarget] =
-    new AlmostEqual[GhostAsterism.HighResolutionTarget] {
-      override def almostEqual(a: GhostAsterism.HighResolutionTarget, b: GhostAsterism.HighResolutionTarget): Boolean =
-        (a.target ~= b.target) && (a.overriddenBase ~= b.overriddenBase)
-    }
-
   implicit val GhostAsterismHighResTargetPlusSkyAlmostEqual: AlmostEqual[GhostAsterism.HighResolutionTargetPlusSky] =
     new AlmostEqual[GhostAsterism.HighResolutionTargetPlusSky] {
       override def almostEqual(a: GhostAsterism.HighResolutionTargetPlusSky, b: GhostAsterism.HighResolutionTargetPlusSky): Boolean =
@@ -179,7 +173,6 @@ trait Almosts {
           case (a: GhostAsterism.DualTarget,                  b: GhostAsterism.DualTarget)                  => a ~= b
           case (a: GhostAsterism.TargetPlusSky,               b: GhostAsterism.TargetPlusSky)               => a ~= b
           case (a: GhostAsterism.SkyPlusTarget,               b: GhostAsterism.SkyPlusTarget)               => a ~= b
-          case (a: GhostAsterism.HighResolutionTarget,        b: GhostAsterism.HighResolutionTarget)        => a ~= b
           case (a: GhostAsterism.HighResolutionTargetPlusSky, b: GhostAsterism.HighResolutionTargetPlusSky) => a ~= b
           case _ => false
         }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
@@ -244,16 +244,6 @@ trait Arbitraries extends edu.gemini.spModel.core.Arbitraries {
         case TargetPlusSky(t, s, Some(bc)) => SkyPlusTarget(s, t, Some(bc))
       }
 
-    // HIGH RESOLUTION TARGET
-    val genHighResTargetNoBase: Gen[HighResolutionTarget] =
-      arbitrary[GhostTarget].map(t => HighResolutionTarget(t, None))
-
-    val genHighResTargetWithBase: Gen[HighResolutionTarget] =
-      for {
-        bc :: tc :: _ <- coordinateGen(2)
-        t <- ghostTargetWithCoords(tc)
-      } yield HighResolutionTarget(t, Some(new SPCoordinates(bc)))
-
     // HIGH RESOLUTION TARGET + SKY
     val genHighResTargetPlusSkyNoBase: Gen[HighResolutionTargetPlusSky] =
       for {
@@ -311,12 +301,6 @@ trait Arbitraries extends edu.gemini.spModel.core.Arbitraries {
       arbitrary[GhostAsterism.SkyPlusTarget]
     ))
 
-  implicit val arbGhostHighResolutionTargetAsterism: Arbitrary[GhostAsterism.HighResolutionTarget] =
-    Arbitrary(Gen.oneOf(
-      GhostGens.genHighResTargetNoBase,
-      GhostGens.genHighResTargetWithBase
-    ))
-
   implicit val arbGhostHighResolutionTargetPlusSkyAsterism: Arbitrary[GhostAsterism.HighResolutionTargetPlusSky] =
     Arbitrary(Gen.oneOf(
       GhostGens.genHighResTargetPlusSkyNoBase,
@@ -325,10 +309,9 @@ trait Arbitraries extends edu.gemini.spModel.core.Arbitraries {
 
 
   implicit val arbGhostHighResolutionAsterism: Arbitrary[GhostAsterism.HighResolution] =
-    Arbitrary(Gen.oneOf(
-      arbitrary[GhostAsterism.HighResolutionTarget],
+    Arbitrary(
       arbitrary[GhostAsterism.HighResolutionTargetPlusSky]
-    ))
+    )
 
   implicit val arbGhostAsterism: Arbitrary[GhostAsterism] =
     Arbitrary(Gen.oneOf(
@@ -352,8 +335,6 @@ trait Arbitraries extends edu.gemini.spModel.core.Arbitraries {
     createTargetEnvironmentGen(arbitrary[GhostAsterism.TargetPlusSky])
   val genGhostSkyPlusTargetTargetEnvironment: Gen[TargetEnvironment] =
     createTargetEnvironmentGen(arbitrary[GhostAsterism.SkyPlusTarget])
-  val genGhostHighResTargetAsterismTargetEnvironment: Gen[TargetEnvironment] =
-    createTargetEnvironmentGen(arbitrary[GhostAsterism.HighResolutionTarget])
   val genGhostHighResTargetPlusSkyAsterismTargetEnvironment: Gen[TargetEnvironment] =
     createTargetEnvironmentGen(arbitrary[GhostAsterism.HighResolutionTargetPlusSky])
   val genGhostAsterismTargetEnvironment: Gen[TargetEnvironment] =

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/AsterismParamSetCodecSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/AsterismParamSetCodecSpec.scala
@@ -29,7 +29,6 @@ object AsterismParamSetCodecSpec extends Specification with ScalaCheck with Arbi
     close[GhostAsterism.DualTarget]
     close[GhostAsterism.TargetPlusSky]
     close[GhostAsterism.SkyPlusTarget]
-    close[GhostAsterism.HighResolutionTarget]
     close[GhostAsterism.HighResolutionTargetPlusSky]
     close[Asterism]
   }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -210,9 +210,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
             case GhostSkyPlusTarget:
                 final GhostAsterism.SkyPlusTarget gsta = (GhostAsterism.SkyPlusTarget) a;
                 return ImOption.fromScalaOpt(gsta.overriddenBase()).toRight(() -> gsta.target().spTarget());
-            case GhostHighResolutionTarget:
-                final GhostAsterism.HighResolutionTarget ghta = (GhostAsterism.HighResolutionTarget) a;
-                return ImOption.fromScalaOpt(ghta.overriddenBase()).toRight(() -> ghta.target().spTarget());
             case GhostHighResolutionTargetPlusSky:
                 final GhostAsterism.HighResolutionTargetPlusSky ghtsa = (GhostAsterism.HighResolutionTargetPlusSky) a;
                 return ImOption.fromScalaOpt(ghtsa.overriddenBase()).toRight(() -> ghtsa.target().spTarget());
@@ -1219,10 +1216,6 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 case GhostSkyPlusTarget:
                     final GhostAsterism.SkyPlusTarget gsta = (GhostAsterism.SkyPlusTarget) oldA;
                     newA = gsta.copy(gsta.sky(), gsta.target(), coords(gsta, linked));
-                    break;
-                case GhostHighResolutionTarget:
-                    final GhostAsterism.HighResolutionTarget ghta = (GhostAsterism.HighResolutionTarget) oldA;
-                    newA = ghta.copy(ghta.target(), coords(ghta, linked));
                     break;
                 case GhostHighResolutionTargetPlusSky:
                     final GhostAsterism.HighResolutionTargetPlusSky ghtsa = (GhostAsterism.HighResolutionTargetPlusSky) oldA;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/TelescopePosTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/TelescopePosTableModel.java
@@ -1,7 +1,6 @@
 package jsky.app.ot.gemini.editor.targetComponent.telescopePosTableModel;
 
 import edu.gemini.ags.api.AgsAnalysis;
-import edu.gemini.ags.api.AgsAnalysis$;
 import edu.gemini.ags.api.AgsGuideQuality;
 import edu.gemini.ags.api.AgsMagnitude;
 import edu.gemini.ags.api.AgsRegistrar;
@@ -47,7 +46,6 @@ final public class TelescopePosTableModel extends AbstractTableModel {
 
             // A base and a target (which can be the same).
             case GhostSingleTarget:
-            case GhostHighResolutionTarget:
                 autoGroupIdx = 2;
                 break;
 
@@ -156,9 +154,6 @@ final public class TelescopePosTableModel extends AbstractTableModel {
                     case GhostSkyPlusTarget:
                         gt = ((GhostAsterism.SkyPlusTarget) a).target();
                         break;
-                    case GhostHighResolutionTarget:
-                        gt = ((GhostAsterism.HighResolutionTarget) a).target();
-                        break;
                     case GhostHighResolutionTargetPlusSky:
                         gt = ((GhostAsterism.HighResolutionTargetPlusSky) a).target();
                         break;
@@ -223,17 +218,6 @@ final public class TelescopePosTableModel extends AbstractTableModel {
         return hdr;
     }
 
-    private List<Row> createGhostHighResolutionTargetAsterismRows() {
-        // Base position, a science target, and possibly a sky position.
-        final List<Row> hdr                        = new ArrayList<>();
-        final GhostAsterism.HighResolutionTarget a = (GhostAsterism.HighResolutionTarget) env.getAsterism();
-        final GhostTarget gt                       = a.target();
-
-        hdr.add(createGhostBaseRow(a));
-        hdr.add(new GhostTargetRow(GhostAsterism$.MODULE$.HRIFU1(), gt, baseCoords, when));
-        return hdr;
-    }
-
     private List<Row> createGhostHighResolutionTargetPlusSkyAsterismRows() {
         // Base position, a science target, and possibly a sky position.
         final List<Row> hdr                               = new ArrayList<>();
@@ -242,8 +226,8 @@ final public class TelescopePosTableModel extends AbstractTableModel {
         final SPCoordinates c                             = a.sky();
 
         hdr.add(createGhostBaseRow(a));
-        hdr.add(new GhostTargetRow(GhostAsterism$.MODULE$.HRIFU1(), gt, baseCoords, when));
-        hdr.add(new GhostSkyRow(GhostAsterism$.MODULE$.HRIFU2(), c, baseCoords));
+        hdr.add(new GhostTargetRow(GhostAsterism$.MODULE$.HRIFU(), gt, baseCoords, when));
+        hdr.add(new GhostSkyRow(GhostAsterism$.MODULE$.SRIFU2(), c, baseCoords));
         return hdr;
     }
 
@@ -272,9 +256,6 @@ final public class TelescopePosTableModel extends AbstractTableModel {
                 break;
             case GhostSkyPlusTarget:
                 asterismRows = createGhostSkyPlusTargetAsterismRows();
-                break;
-            case GhostHighResolutionTarget:
-                asterismRows = createGhostHighResolutionTargetAsterismRows();
                 break;
             case GhostHighResolutionTargetPlusSky:
                 asterismRows = createGhostHighResolutionTargetPlusSkyAsterismRows();

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/Utils.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/Utils.java
@@ -41,7 +41,6 @@ final class Utils {
             case GhostDualTarget:
             case GhostTargetPlusSky:
             case GhostSkyPlusTarget:
-            case GhostHighResolutionTarget:
             case GhostHighResolutionTargetPlusSky:
                 return getCoordinates((GhostAsterism) a, when);
             default:

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -139,7 +139,6 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       GhostDualTarget,
       GhostTargetPlusSky,
       GhostSkyPlusTarget,
-      GhostHighResolutionTarget,
       GhostHighResolutionTargetPlusSky
     )
 
@@ -672,7 +671,6 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
           case a: SingleTarget => toc.setTargetEnvironment(env.setAsterism((SingleTargetIFU1 >=> GhostTarget.guideFiberState).set(a, state)))
           case a: DualTarget => toc.setTargetEnvironment(env.setAsterism((DualTargetIFU1 >=> GhostTarget.guideFiberState).set(a, state)))
           case a: TargetPlusSky => toc.setTargetEnvironment(env.setAsterism((TargetPlusSkyIFU1 >=> GhostTarget.guideFiberState).set(a, state)))
-          case a: HighResolutionTarget => toc.setTargetEnvironment(env.setAsterism((HRTargetIFU1 >=> GhostTarget.guideFiberState).set(a, state)))
           case a: HighResolutionTargetPlusSky => toc.setTargetEnvironment(env.setAsterism((HRTargetPlusSkyIFU1 >=> GhostTarget.guideFiberState).set(a, state)))
         }
         oc.setDataObject(toc)
@@ -737,7 +735,6 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
           case GhostAsterism.DualTarget(gt1, gt2, _)               => (gt1.spTarget.getName, Some(gt2.spTarget.getName))
           case GhostAsterism.TargetPlusSky(gt1, _, _)              => (gt1.spTarget.getName, Some(Sky))
           case GhostAsterism.SkyPlusTarget(_, gt2, _)              => (Sky, Some(gt2.spTarget.getName))
-          case GhostAsterism.HighResolutionTarget(gt, _)           => (gt.spTarget.getName, None)
           case GhostAsterism.HighResolutionTargetPlusSky(gt, _, _) => (gt.spTarget.getName, Some(Sky))
           case _                                                   => sys.error("illegal asterism type")
         }
@@ -752,7 +749,6 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
           case GhostAsterism.DualTarget(gt1, gt2, _)               => (gt1.guideFiberState == Enabled, true, gt2.guideFiberState == Enabled, true)
           case GhostAsterism.TargetPlusSky(gt, _, _)               => (gt.guideFiberState === Enabled, true, false, false)
           case GhostAsterism.SkyPlusTarget(_, gt2, _)              => (false, false, gt2.guideFiberState === Enabled, true)
-          case GhostAsterism.HighResolutionTarget(gt, _)           => (gt.guideFiberState === Enabled, true, false, false)
           case GhostAsterism.HighResolutionTargetPlusSky(gt, _, _) => (gt.guideFiberState === Enabled, true, false, false)
           case _                                                   => sys.error("illegal asterism type")
         }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
@@ -132,11 +132,6 @@ final class TpeGhostIfuFeature extends TpeImageFeature("GHOST", "Show the patrol
               val p2 = pm.getLocationFromTag(t.spTarget)
               drawStandardResolutionIfu(g2d, p2, Ifu2, AsTarget)
 
-            case GhostAsterism.HighResolutionTarget(t, _) =>
-              // IFU1
-              val p1 = pm.getLocationFromTag(t.spTarget)
-              drawHighResolutionIfu(g2d, p1)
-
             case GhostAsterism.HighResolutionTargetPlusSky(t, s, _) =>
               // IFU1
               val p1 = pm.getLocationFromTag(t.spTarget)
@@ -144,7 +139,9 @@ final class TpeGhostIfuFeature extends TpeImageFeature("GHOST", "Show the patrol
 
               // IFU2
               val p2 = pm.getLocationFromTag(s)
-              drawStandardResolutionIfu(g2d, p2, Ifu2, AsSky)
+              // We don't draw the SRIFU2, apparently, even though its position
+              // determines the position of the HR sky fibers
+              // drawStandardResolutionIfu(g2d, p2, Ifu2, AsSky)
               drawHighResolutionSky(g2d, p2)
           }
         }
@@ -310,7 +307,7 @@ final class TpeGhostIfuFeature extends TpeImageFeature("GHOST", "Show the patrol
    */
   private def usingIFU2(env: TargetEnvironment): Boolean = env.getAsterism.asterismType match {
     case AsterismType.GhostDualTarget | AsterismType.GhostTargetPlusSky | AsterismType.GhostSkyPlusTarget | AsterismType.GhostHighResolutionTargetPlusSky => true
-    case AsterismType.GhostSingleTarget | AsterismType.GhostHighResolutionTarget => false
+    case AsterismType.GhostSingleTarget => false
     case AsterismType.Single => sys.error("Invalid asterism type for GHOST")
   }
 


### PR DESCRIPTION
We incorrectly had labeled HRIFU as HRIFU1 and invented an HRIFU2 that doesn't exist.  The only high resolution option, as I understand it, is HRIFU + Sky.  This PR removes the HRIFU1 Target mode and changes HRIFU1 Target + HRIFU2 Sky to just "HRIFU Target, SRIFU2 Sky".  That is, the sky position is at SRIFU2 though it is unused.  Instead the dedicated HR sky fibers just above it are used as shown in the TPE.

In the screenshot below, I added a "User" target where the sky coordinates are.  Ordinarily nothing would show here, but slightly north of it are the HR sky fibers.

<img width="263" alt="Screen Shot 2021-11-17 at 16 26 06" src="https://user-images.githubusercontent.com/4906023/142269163-58845d16-3b03-42df-b8bc-75d6b3333c5e.png">

The requirements are still not clear though so I expect at least one more round of this.