### PR TITLE
REL-3965: visitor name + science target fix

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/VISITOR_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/VISITOR_BP.xml
@@ -172,7 +172,7 @@
             <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="6d939e86-a0ac-4040-a70e-12061d38f6e7" name="Observe">
               <paramset name="Observe" kind="dataObj">
                 <param name="repeatCount" value="1"/>
-                <param name="class" value="PARTNER_CAL"/>
+                <param name="class" value="SCIENCE"/>
               </paramset>
             </container>
           </container>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/Visitor.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/visitor/Visitor.scala
@@ -14,7 +14,7 @@ case class Visitor(blueprint: SpVisitorBlueprint) extends VisitorBase {
 
   include(all: _*) in TargetGroup
 
-  forObs(sci: _*)(setName fromPI)
+  forObs(all: _*)(setName fromPI)
   forObs(all: _*)(setVisitorConfig fromPI)
   forObs(all: _*)(setWavelength fromPI)
   forObs(sci: _*)(setPosAngle fromPI)


### PR DESCRIPTION
Two separate fixes in one PR.

1. The blueprint XML had improperly identified the science observation as a partner cal, which meant that upon instantiation it didn't pick up the phase 1 target.
2. I didn't know whether the calibration observation should take the PI-supplied name and made the wrong assumption.