### PR TITLE
REL-4005: exposure time again

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/seqcomp/GhostSeqRepeatExpCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/seqcomp/GhostSeqRepeatExpCB.java
@@ -10,6 +10,8 @@ import edu.gemini.spModel.gemini.ghost.GhostCameras$;
 import edu.gemini.spModel.gemini.ghost.GhostExposureTimeProvider;
 import edu.gemini.spModel.obscomp.InstConstants;
 
+import edu.gemini.spModel.syntax.JavaDurationOps;
+
 import java.util.Map;
 
 /**
@@ -67,7 +69,7 @@ final public class GhostSeqRepeatExpCB extends AbstractSeqComponentCB {
         config.putParameter(SYSTEM_NAME,
             DefaultParameter.getInstance(
                 InstConstants.EXPOSURE_TIME_PROP,
-                GhostCameras$.MODULE$.fromGhostComponent(c).totalSeconds()
+                new JavaDurationOps(GhostCameras$.MODULE$.fromGhostComponent(c).exposure()).fractionalSeconds()
             )
         );
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -346,7 +346,7 @@ final class Ghost
     val gc = GhostCameras.fromConfig(cur)
 
     def label(sec: Double): String =
-      s"${sec}s x ${gc.dominant.getOrElse(gc.red).count}${gc.dominant.map(d => s" ${d.label}").getOrElse("")}"
+      s"${gc.dominant.getOrElse(gc.red).count} x ${sec}s${gc.dominant.map(d => s" ${d.label}").getOrElse("")}"
 
     times.add(CategorizedTime.fromSeconds(
       Category.EXPOSURE,

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/syntax/JavaDuration.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/syntax/JavaDuration.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.spModel.syntax
+
+import java.time.Duration
+
+final class JavaDurationOps(self: Duration) {
+
+  /**
+   * Converts a duration to fractional seconds, which for some reason was the
+   * "standard" we used for time in the early days and which is now firmly
+   * entrenched in the sequence model.
+   */
+  def fractionalSeconds: Double =
+    self.toMillis.toDouble / 1000.0
+
+}
+
+trait ToJavaDurationOps {
+  implicit def ToJavaDurationOps(d: Duration): JavaDurationOps =
+    new JavaDurationOps(d)
+}
+
+object duration extends ToJavaDurationOps


### PR DESCRIPTION
Fixes a bug with GHOST planned time calculation.  I was treating the exposure and readout times independently so a case such as 

```
Red.: 1 x 500s
Blue: 3 x 100s
```

would pick up 500s exposure from the red camera and 180s readout (3 x 60s) from the blue for a total of 680s (500 + 180).  Instead the red camera should "dominate" the calculation because 1 x (500 + 60) > 3 x (100 + 60) and we should have a total time of 560s instead of 680s.