### PR TITLE
REL-4080: allow PIs to change visitor instrument

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/visitor/VisitorEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/visitor/VisitorEditor.java
@@ -110,7 +110,7 @@ public class VisitorEditor extends ComponentEditor<ISPObsComponent, VisitorInstr
     }
 
     private void adjustStaffOnlyFields() {
-        configCtrl.getComponent().setEnabled(StaffBean.isStaff());
+        // Do nothing for now.
     }
 
 }


### PR DESCRIPTION
Currently only staff members can change the selected visitor instrument configuration.  This PR removes that restriction so that PIs can do so as well.