### PR TITLE
REL-4059: Support multiple attachment parameters

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/skeleton.sh
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/skeleton.sh
@@ -6,27 +6,29 @@ HOST=localhost
 #
 # USAGE
 #
-# skeleton myproposal.xml [myproposal.pdf] [program id]
+# skeleton myproposal.xml [myproposal.pdf] [myproposal2.pdf] ... [program id]
 #
 #
 # DESCRIPTION
-# 
+#
 # Use this script to post a proposal XML to the ODB, creating a corresponding
 # skeleton.
 #
-# Text Attachment PDF
+# Text Attachment PDF(s)
 #
-# The proposal text attachment must be specified unless it is in the same
-# directory as the XML file and has the same file name (except with a .pdf
-# extension).  For example, if the proposal is "myproposal.xml" and its text
-# attachment is "myproposal.pdf" in the same directory there's no need to
-# specify it.  Regardless, the attachment PDF must have a .pdf extension.
+# Any number of proposal attachments may be included.  At least one must be
+# specified unless there is a single proposal attachment with the same name
+# as the proposal file, changing the `.xml` extension for `.pdf`.
+#
+# For example, if the proposal is "myproposal.xml" and its text attachment is
+# "myproposal.pdf" in the same directory there's no need to specify it.
+# Regardless, the attachment PDF(s) must have a .pdf extension.
 #
 # Program Ids
 #
 # Every proposal document either has to contain a Gemini program ID (as
 # assigned by the ITAC software) or else you must specify the program ID on
-# the command line.  Program ids are checked for validity so 'normal' ids 
+# the command line.  Program ids are checked for validity so 'normal' ids
 # like GS-2012B-Q-1 will work but random strings or exotic program types like
 # GS-2012B-TEST-1 will not.
 #
@@ -47,35 +49,38 @@ HOST=localhost
 #
 #	skeleton myproposal.xml
 #
-# Post a proposal for which the text attachment has a different name and no
+# Post a proposal for which the PDF attachment has a different name and no
 # proposal id has been assigned by ITAC software.
 #
 #	skeleton myproposal.xml mytextpart.pdf GS-2012B-Q-2
 #
+# Post a proposal with two PDF attachments and no proposal ID.
+#
+#	skeleton myproposal.xml myattachment1.pdf myattachment2.dpf GS-2022B-Q-1
 #
 
 CMD=$0
 
 fail() {
     echo "$1"
-    echo "Usage: $CMD proposal.xml [proposal.pdf] [programid]" 1>&2
+    echo "Usage: $CMD proposal.xml [attachment1.pdf] [attachment2.pdf] ... [programid]" 1>&2
     exit 1
 }
 
 verifyId() {
     echo "$1" | grep -q "^G[NS]-[0-9][0-9][0-9][0-9][AB]-[A-Z]*-[0-9]*$" || fail "$1 doesn't appear to be a Gemini program ID"
 }
- 
+
 XML=
-PDF=
+PDFS=()
 ID=
 
 # Process the command line args to find the proposal XML, attachment PDF and
 # program id if specified.
 while [ $# -gt 0 ]; do
     case "$1" in
-        *".xml" ) XML=$1 ;;  
-        *".pdf" ) PDF=$1 ;;
+        *".xml" ) XML=$1 ;;
+        *".pdf" ) PDFS+=("$1") ;;
         *) ID=$1
            verifyId $ID
            ;;
@@ -87,20 +92,43 @@ done
 [ -n "$XML" ] || fail "Missing program.xml argument."
 [ -f "$XML" ] || fail "Proposal file $XML does not exist."
 
-# If the pdf file is not explicitly specified, try the same prefix as the
+# If a pdf file is not explicitly specified, try the same prefix as the
 # proposal file but with a ".pdf" extension.
-ORIG_PDF=$PDF
-if [ -z "$PDF" ]; then
-   PDF=`echo "$XML" | sed -e 's/\.xml$/\.pdf/'`
-fi
-if [ ! -f "$PDF" ]; then
-   [ -n "$ORIG_PDF" ] || fail "Proposal attachment not specified and default $PDF doesn't exist."
-   fail "Proposal attachment $PDF does not exist."
+if [ ${#PDFS[@]} -eq 0 ]; then
+    DEF_PDF=`echo "$XML" | sed -e 's/\.xml$/\.pdf/'`
+    PDFS+=("$DEF_PDF")
 fi
 
-if [ -z "$ID" ]; then
-    curl -F "proposal=@$XML;type=text/xml" -F "attachment=@$PDF;type=application/pdf" http://${HOST}:8442/skeleton?convert=true
+# Validate that all PDFS exist.
+for p in "${PDFS[@]}"; do
+    if [ ! -f "$p" ]; then
+        fail "Proposal attachment $p does not exist."
+    fi
+done
+
+# Build the curl command to execute.
+CURL="curl -F \"proposal=@$XML;type=text/xml\""
+
+# If there is just one PDF, send with the "attachment" id.
+# Otherwise, add each one with its (1-based) "attachment" index.
+if [ ${#PDFS[@]} -eq 1 ]; then
+    PDF=${PDFS[0]}
+    CURL+=" -F \"attachment=@$PDF;type=application/pdf\""
 else
-    curl -F "proposal=@$XML;type=text/xml" -F "attachment=@$PDF;type=application/pdf" -F "id=$ID" http://${HOST}:8442/skeleton?convert=true
+    for (( i=0; i<${#PDFS[@]}; i++ )); do
+        PDF=${PDFS[$i]}
+        IDX=`expr $i + 1`
+        CURL+=" -F \"attachment$IDX=@$PDF;type=application/pdf\""
+    done
 fi
+
+# Add the program ID if specified.
+if [ -n "$ID" ]; then
+    CURL+=" -F \"id=$ID\""
+fi
+
+# Finally add the skeleton host and arguments.
+CURL+=" http://${HOST}:8442/skeleton?convert=true"
+
+eval $CURLXS
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/skeleton.sh
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/skeleton.sh
@@ -130,5 +130,5 @@ fi
 # Finally add the skeleton host and arguments.
 CURL+=" http://${HOST}:8442/skeleton?convert=true"
 
-eval $CURLXS
+eval $CURL
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/auxfile/SkeletonAuxfileWriter.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/auxfile/SkeletonAuxfileWriter.scala
@@ -2,7 +2,7 @@ package edu.gemini.phase2.skeleton.auxfile
 
 import edu.gemini.auxfile.api.AuxFile
 import edu.gemini.auxfile.copier.AuxFileCopier
-import edu.gemini.model.p1.immutable.{Meta, ProposalIo, Proposal}
+import edu.gemini.model.p1.immutable.{ProposalIo, Proposal}
 import edu.gemini.model.p1.pdf.P1PDF
 import edu.gemini.shared.util.immutable.ImOption
 import edu.gemini.spModel.core.SPProgramID
@@ -13,10 +13,10 @@ import scala.xml.XML
 
 object SkeletonAuxfileWriter {
 
-  case class ProposalFiles(progId: SPProgramID, auxfileDir: File) {
-    val proposalXml           = mkFile("proposal",   "xml")
-    val proposalAttachmentPdf = mkFile("attachment", "pdf")
-    val proposalSummaryPdf    = mkFile("summary",    "pdf")
+  final case class ProposalFiles(progId: SPProgramID, auxfileDir: File) {
+    val proposalXml: File           = mkFile("proposal",   "xml")
+    val proposalAttachmentPdf: File = mkFile("attachment", "pdf")
+    val proposalSummaryPdf: File    = mkFile("summary",    "pdf")
 
     def proposalAuxfile: AuxFile =
       auxfile(proposalXml, "Proposal Document")

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/auxfile/SkeletonAuxfileWriter.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/auxfile/SkeletonAuxfileWriter.scala
@@ -11,24 +11,43 @@ import java.io.File
 import java.time.Instant
 import scala.xml.XML
 
+import scalaz._
+import Scalaz._
+
 object SkeletonAuxfileWriter {
 
-  final case class ProposalFiles(progId: SPProgramID, auxfileDir: File) {
-    val proposalXml: File           = mkFile("proposal",   "xml")
-    val proposalAttachmentPdf: File = mkFile("attachment", "pdf")
-    val proposalSummaryPdf: File    = mkFile("summary",    "pdf")
+  final case class Pdf(in: File, out: File, aux: AuxFile)
+
+  final case class ProposalFiles(progId: SPProgramID, attachments: List[File], auxfileDir: File) {
+
+    val proposalXml: File  =
+      mkFile("proposal",   "xml")
+
+    val proposalAttachmentPdfs: List[Pdf] =
+      attachments match {
+
+        case in :: Nil =>
+          val out = mkFile("attachment", "pdf")
+          List(Pdf(in, out, auxfile(out, "Proposal Attachment")))
+
+        case _        =>
+          attachments.zipWithIndex.map { case (in, i) =>
+            val out = mkFile(s"attachment${i+1}", "pdf")
+            Pdf(in, out, auxfile(out, s"Proposal Attachment ${i+1}"))
+          }
+      }
+
+    val proposalSummaryPdf: File =
+      mkFile("summary",    "pdf")
 
     def proposalAuxfile: AuxFile =
       auxfile(proposalXml, "Proposal Document")
-
-    def proposalAttachmentAuxfile: AuxFile =
-      auxfile(proposalAttachmentPdf, "Proposal Attachment")
 
     def proposalSummaryAuxfile: AuxFile =
       auxfile(proposalSummaryPdf, "Proposal Summary")
 
     def auxfiles: List[AuxFile] =
-      List(proposalAuxfile, proposalAttachmentAuxfile, proposalSummaryAuxfile)
+      proposalAuxfile :: (proposalAttachmentPdfs.map(_.aux) :+ proposalSummaryAuxfile)
 
     private def auxfile(f: File, desc: String): AuxFile =
       new AuxFile(progId, f.getName, desc, f.length(), f.lastModified(), false, ImOption.empty[Instant])
@@ -37,9 +56,9 @@ object SkeletonAuxfileWriter {
       new File(auxfileDir, "%s_%s.%s".format(progId.toString, suffix, extension))
   }
 
-  def write(id: SPProgramID, proposal: Proposal, pdfAttachment: File, auxfileDir: File, copier:AuxFileCopier): Either[FileError, List[AuxFile]] = {
+  def write(id: SPProgramID, proposal: Proposal, pdfAttachments: List[File], auxfileDir: File, copier:AuxFileCopier): Either[FileError, List[AuxFile]] = {
     // Get the proposal files that will be written.
-    val files = ProposalFiles(id, auxfileDir)
+    val files = ProposalFiles(id, pdfAttachments, auxfileDir)
 
     // Update the proposal attachment name.  Use a path relative to the cwd.
     // FIXME
@@ -53,10 +72,14 @@ object SkeletonAuxfileWriter {
       _ <- writeProposal(updatedProposal, files.proposalXml).right
       _ <- writeMeta(files.proposalXml, files.proposalAuxfile).right
 
-      _ <- writeAttachment(pdfAttachment, files.proposalAttachmentPdf).right
-      _ <- writeMeta(files.proposalAttachmentPdf, files.proposalAttachmentAuxfile).right
+      _ <- files.proposalAttachmentPdfs.traverseU_ { pdf =>
+        for {
+          _ <- writeAttachment(pdf.in, pdf.out).right
+          _ <- writeMeta(pdf.out, pdf.aux).right
+        } yield ()
+      }
 
-      _ <- writeSummary(updatedProposal, pdfAttachment, files.proposalSummaryPdf).right
+      _ <- writeSummary(updatedProposal, pdfAttachments, files.proposalSummaryPdf).right
       _ <- writeMeta(files.proposalSummaryPdf, files.proposalSummaryAuxfile).right
 
       _ <- sftp(id,files,copier).right
@@ -68,7 +91,7 @@ object SkeletonAuxfileWriter {
   private def sftp(id: SPProgramID, files: ProposalFiles, copier: AuxFileCopier): Either[FileError, Unit] = {
     for {
       _ <- sftp(id, files.proposalXml, copier).right
-      _ <- sftp(id, files.proposalAttachmentPdf, copier).right
+      _ <- files.proposalAttachmentPdfs.traverseU_(pdf => sftp(id, pdf.out, copier).right)
       _ <- sftp(id, files.proposalSummaryPdf, copier).right
     } yield Unit
   }
@@ -95,12 +118,11 @@ object SkeletonAuxfileWriter {
   private def writeAttachment(in: File, out: File): Either[FileError, File] =
     writeTo(out) { tmp => in.eCopyTo(tmp) }
 
-  private def writeSummary(p: Proposal, attachment: File, out: File): Either[FileError, File] = {
+  private def writeSummary(p: Proposal, attachments: List[File], out: File): Either[FileError, File] = {
     writeTo(out) { tmp =>
       try {
         val xml = ProposalIo.writeToXml(p)
-        // FIXME: Support multiple attachmens
-        P1PDF.createFromNode(xml, List(attachment), P1PDF.GeminiDARP, tmp, None)
+        P1PDF.createFromNode(xml, attachments, P1PDF.GeminiDARP, tmp, None)
         Right(())
       } catch {
         case ex: Exception => Left(FileError(out, ex))


### PR DESCRIPTION
Updates the skeleton creation servlet (and the `skeleton` bash script that calls it) to allow multiple attachment arguments.  The existing single `attachment` parameter is still supported, but alternatively any number of `attachment`# parameters (`attachment1`, `attachment2`, ...) can be sent instead.  If old-style `attachment` is used, any indexed attachment parameters are ignored.