### PR TITLE
REL-1632: copy on-hold obs bug

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/util/DBCopyService.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/util/DBCopyService.java
@@ -131,7 +131,7 @@ public class DBCopyService {
             ISPGroup group = _factory.createGroupCopy(_targetProg, existingGroup, false);
             // need to reset the observations in the group
             for (ISPObservation o : group.getObservations()) {
-                ObservationNI.reset(o, sameProgram(group, _targetProg));
+                ObservationNI.reset(o, sameProgram(existingGroup, _targetProg));
             }
             return group;
         }


### PR DESCRIPTION
When copying an On Hold ToO observation to a different program we're supposed to reset the status to Phase 2.  This was working for individual observations but not for observations within a group.  The issue was the calculation of whether the group is being copied into the same or a different program.  We were making a group copy for the target program and then comparing that new group's program key to the target program key.  Instead we needed to compare the existing group's program key to the target program's key.