### PR TITLE
REL-4013: Missing Start/EndVisit logging

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/ISPNode.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/ISPNode.java
@@ -2,6 +2,7 @@ package edu.gemini.pot.sp;
 
 import edu.gemini.pot.sp.version.LifespanId;
 import edu.gemini.shared.util.VersionVector;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.spModel.data.ISPDataObject;
 
@@ -100,6 +101,12 @@ public interface ISPNode {
      * <code>null</code> otherwise
      */
     ISPObservation getContextObservation();
+
+    /**
+     * Gets the observation ID associated with this node (if any).
+     * @return the observation in which this node lives, if any
+     */
+    Option<SPObservationID> getContextObservationId();
 
     /**
      * Returns <code>true</code> if events are enabled, <code>false</code>

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemAbstractBase.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemAbstractBase.java
@@ -3,6 +3,8 @@ package edu.gemini.pot.sp.memImpl;
 import edu.gemini.pot.sp.*;
 import edu.gemini.pot.sp.version.LifespanId;
 import edu.gemini.shared.util.VersionVector;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.util.ReadableNodeName;
@@ -182,6 +184,11 @@ public abstract class MemAbstractBase implements ISPNode, Serializable {
             obs = (_parent == null) ? null : _parent.getContextObservation();
         }
         return obs;
+    }
+
+    public Option<SPObservationID> getContextObservationId() {
+        return ImOption.apply(getContextObservation())
+               .flatMap(o -> ImOption.apply(o.getObservationID()));
     }
 
     /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObsExecLog.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObsExecLog.java
@@ -72,7 +72,7 @@ public final class MemObsExecLog extends MemProgramNodeBase implements ISPObsExe
         try {
             final Option<String>        oid = getObsId();
             final StringBuilder         buf = new StringBuilder();
-            final List<ObsExecEvent> before = getVisitEvents(name, getDocumentData());
+            final List<ObsExecEvent> before = getVisitEvents(name, getDataObject());
             final List<ObsExecEvent>  after = getVisitEvents(name, obj);
             final boolean         logEvents = !before.equals(after);
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObsExecLog.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObsExecLog.java
@@ -3,16 +3,13 @@ package edu.gemini.pot.sp.memImpl;
 import edu.gemini.pot.sp.*;
 import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.shared.util.immutable.Option;
-import edu.gemini.spModel.event.EndVisitEvent;
 import edu.gemini.spModel.event.ObsExecEvent;
-import edu.gemini.spModel.event.StartVisitEvent;
 import edu.gemini.spModel.obslog.ObsExecLog;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import static edu.gemini.pot.sp.SPComponentType.OBS_EXEC_LOG;
 
@@ -40,30 +37,14 @@ public final class MemObsExecLog extends MemProgramNodeBase implements ISPObsExe
     @Override public MemProgram getProgram() { return program; }
 
     // Start REL-3986 ------ logging to debug an issue with missing events
-    private String formatEvents(List<ObsExecEvent> events) {
-        final StringBuilder buf = new StringBuilder();
-        events.forEach(e -> buf.append(String.format("\t%s\n", e)));
-        return buf.toString();
-    }
-
-    private List<ObsExecEvent> getVisitEvents(ObsExecLog log) {
-        return log.getRecord()
-                  .getAllEventList()
-                  .stream()
-                  .filter(e -> (e instanceof StartVisitEvent) || (e instanceof EndVisitEvent))
-                  .collect(Collectors.toList());
-    }
-
-    private List<ObsExecEvent> getVisitEvents(String name, Object obj) {
+    private static List<ObsExecEvent> getVisitEvents(String name, Object obj) {
         return (DATA_OBJECT_KEY.equals(name) && (obj instanceof ObsExecLog)) ?
-                getVisitEvents((ObsExecLog) obj)                             :
+                ((ObsExecLog) obj).getVisitEvents()                          :
                 Collections.emptyList();
     }
 
     private Option<String> getObsId() {
-        return ImOption.apply(getContextObservation())
-                       .flatMap(o -> ImOption.apply(o.getObservationID()))
-                       .map(SPObservationID::stringValue);
+        return getContextObservationId().map(SPObservationID::stringValue);
     }
 
     @Override public PropagationId putClientData(String name, Object obj) {
@@ -79,14 +60,14 @@ public final class MemObsExecLog extends MemProgramNodeBase implements ISPObsExe
             if (logEvents) {
                 buf.append(String.format("Updating ObsExecRecord for %s (%s)\n", oid.getOrElse("<unknown>"), getDocumentData().getLifespanId()));
                 buf.append(String.format("Before....: %s\n", getDocumentData().versionVector(this.getNodeKey())));
-                buf.append(formatEvents(before));
+                buf.append(ObsExecLog.formatEvents(before));
             }
 
             final PropagationId propid = super.putClientData(name, obj);
 
             if (logEvents) {
                 buf.append(String.format("After.....: %s\n", getDocumentData().versionVector(this.getNodeKey())));
-                buf.append(formatEvents(after));
+                buf.append(ObsExecLog.formatEvents(after));
 
                 LOG.log(Level.INFO, buf.toString(), new Throwable());
             }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obslog/ObsExecLog.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obslog/ObsExecLog.java
@@ -16,7 +16,9 @@ import edu.gemini.spModel.config2.ConfigSequence;
 import edu.gemini.spModel.config2.ItemKey;
 import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.dataset.DatasetLabel;
+import edu.gemini.spModel.event.EndVisitEvent;
 import edu.gemini.spModel.event.ObsExecEvent;
+import edu.gemini.spModel.event.StartVisitEvent;
 import edu.gemini.spModel.gemini.calunit.calibration.CalConfigFactory;
 import edu.gemini.spModel.gemini.calunit.calibration.CalConfigPio;
 import edu.gemini.spModel.gemini.init.SimpleNodeInitializer;
@@ -28,6 +30,7 @@ import edu.gemini.spModel.pio.PioParseException;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 
 /**
@@ -266,6 +269,27 @@ public final class ObsExecLog extends AbstractDataObject implements ISPMergeable
                 LOG.info(String.format("%s completed obslog update (label=%s, evt=%s)", obsId, label.getOrNull(), evt.getOrNull()));
             }
         });
+    }
+
+    // REL-4013: Extracts all start/end visit events, if any.
+    public List<ObsExecEvent> getVisitEvents() {
+        return getRecord()
+                 .getAllEventList()
+                 .stream()
+                 .filter(e -> (e instanceof StartVisitEvent) || (e instanceof EndVisitEvent))
+                 .collect(Collectors.toList());
+    }
+
+    // REL-4013: Extracts all start/end visit events, if any.
+    public static String formatEvents(List<ObsExecEvent> events) {
+        final StringBuilder buf = new StringBuilder();
+        events.forEach(e -> buf.append(String.format("\t%s\n", e)));
+        return buf.toString();
+    }
+
+    // REL-4013
+    public String getFormattedVisitEvents() {
+        return formatEvents(getVisitEvents());
     }
 
 }

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
@@ -46,7 +46,7 @@ class VcsServer(odb: IDBDatabaseService) { vs =>
     * version of the program in the database.
     *
     * The caller provides three functions, `evaluate`, `filter`, and `update`.
-    * Evaluate should not modify anything in the progrm but rather calculate
+    * Evaluate should not modify anything in the program but rather calculate
     * a value.  The value is handed to `filter` to decide whether to continue
     * with the write operation (and make the program copy).  In either case,
     * the value is returned as the result of the action.  The `update` takes a

--- a/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/progstate/LeafNodeFetchFunctor.java
+++ b/bundle/jsky.app.ot.shared/src/main/java/jsky/app/ot/shared/progstate/LeafNodeFetchFunctor.java
@@ -1,31 +1,47 @@
 package jsky.app.ot.shared.progstate;
 
-import edu.gemini.pot.sp.ISPContainerNode;
-import edu.gemini.pot.sp.ISPNode;
-import edu.gemini.pot.sp.ISPProgram;
-import edu.gemini.pot.sp.SPNodeKey;
+import edu.gemini.pot.sp.*;
 import edu.gemini.pot.sp.version.LifespanId;
 import edu.gemini.pot.spdb.DBAbstractFunctor;
 import edu.gemini.pot.spdb.IDBDatabaseService;
 import edu.gemini.shared.util.VersionVector;
 import edu.gemini.spModel.core.SPProgramID;
+import edu.gemini.spModel.data.ISPDataObject;
+import edu.gemini.spModel.obslog.ObsExecLog;
 
 import java.security.Principal;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Fetch information about any leaf nodes with a key in the provided collection
  * of keys.
  */
 public final class LeafNodeFetchFunctor extends DBAbstractFunctor {
+    private static final Logger Log = Logger.getLogger(LeafNodeFetchFunctor.class.getName());
+
     private final SPProgramID progId;
-    private final Collection<SPNodeKey> leafKeys = new ArrayList<SPNodeKey>();
+    private final Collection<SPNodeKey> leafKeys = new ArrayList<>();
     private Map<SPNodeKey, LeafNodeData> result  = Collections.emptyMap();
 
     public LeafNodeFetchFunctor(SPProgramID progId, Collection<SPNodeKey> leafKeys) {
         if (progId == null) throw new NullPointerException("progId is null");
         this.progId = progId;
         this.leafKeys.addAll(leafKeys);
+    }
+
+    private LeafNodeData leafNodeData(ISPNode node) {
+        final SPNodeKey key = node.getNodeKey();
+
+        node.getProgramReadLock();
+        try {
+            final ISPDataObject dataObject              = node.getDataObject();
+            final VersionVector<LifespanId, Integer> vv = node.getProgram().getVersions(key);
+            return new LeafNodeData(key, dataObject, vv);
+        } finally {
+            node.returnProgramReadLock();
+        }
     }
 
     private void search(ISPNode node, Set<SPNodeKey> remaining, Map<SPNodeKey, LeafNodeData> result) {
@@ -36,16 +52,26 @@ public final class LeafNodeFetchFunctor extends DBAbstractFunctor {
                     search(child, remaining, result);
                 }
             } else if (remaining.remove(node.getNodeKey())) {
-                final SPNodeKey key = node.getNodeKey();
-                final VersionVector<LifespanId, Integer> vv = node.getProgram().getVersions(key);
-                result.put(key, new LeafNodeData(key, node.getDataObject(), vv));
+                final LeafNodeData data = leafNodeData(node);
+                result.put(node.getNodeKey(), data);
+
+                // REL-4013: Logging for missing start/end visit events
+                if (data.dataObject instanceof ObsExecLog) {
+                    final ObsExecLog log = (ObsExecLog) data.dataObject;
+
+                    final StringBuilder buf = new StringBuilder();
+                    buf.append(String.format("OT requested update for: %s\n", node.getContextObservationId().map(SPObservationID::stringValue).getOrElse("<unknown>")));
+                    buf.append(String.format("Versions: %s\n", data.versions));
+                    buf.append(log.getFormattedVisitEvents());
+                    Log.log(Level.INFO, buf.toString());
+                }
             }
         }
     }
 
     @Override public void execute(IDBDatabaseService db, ISPNode node, Set<Principal> principals) {
-        final Map<SPNodeKey, LeafNodeData> result = new HashMap<SPNodeKey, LeafNodeData>();
-        final Set<SPNodeKey> keys = new HashSet<SPNodeKey>(leafKeys);
+        final Map<SPNodeKey, LeafNodeData> result = new HashMap<>();
+        final Set<SPNodeKey> keys = new HashSet<>(leafKeys);
         final ISPProgram p = db.lookupProgramByID(progId);
         if (p != null) search(p, keys, result);
         this.result = result;


### PR DESCRIPTION
More logging to illuminate, hopefully, what is happening in REL-4013.  The issue appears to be that execution events like start and end visit, which are kept in the `ObsExecLog`, are getting overwritten somehow in the sync/merge process. 