### PR TITLE
[REL-3999] change base name for dual target

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/BaseCoordinatesRow.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/BaseCoordinatesRow.java
@@ -10,10 +10,13 @@ import edu.gemini.spModel.target.env.TargetEnvironment;
  */
 final class BaseCoordinatesRow extends CoordinatesRow {
     BaseCoordinatesRow(final SPCoordinates coordinates, boolean enabled) {
+        this(coordinates, enabled, "Sky");
+    }
+    BaseCoordinatesRow(final SPCoordinates coordinates, boolean enabled, String name) {
         super(enabled,
                 true,
                 TargetEnvironment.BASE_NAME,
-                "Sky",
+                name,
                 coordinates,
                 None.instance());
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/TelescopePosTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/TelescopePosTableModel.java
@@ -127,11 +127,11 @@ final public class TelescopePosTableModel extends AbstractTableModel {
         // coordinates into an SPCoordinates.
         if (a.asterismType() == AsterismType.GhostDualTarget) {
             if (a.overriddenBase().isDefined()) {
-                row = new BaseCoordinatesRow(a.overriddenBase().get(), true);
+                row = new BaseCoordinatesRow(a.overriddenBase().get(), true, "Base");
             }
             else {
                 final Coordinates c = Utils.getCoordinates(a, when).getOrElse(Coordinates.zero());
-                row = new BaseCoordinatesRow(new SPCoordinates(c), false);
+                row = new BaseCoordinatesRow(new SPCoordinates(c), false, "Base");
             }
         }
         else {


### PR DESCRIPTION
This changes the base name from `Sky` to `Base` for Ghost target environments in dual-target mode.