### PR TITLE
REL-3995 Enable GMOS Fov by default

### DIFF
--- a/bundle/jsky.app.ot.testlauncher/build.sbt
+++ b/bundle/jsky.app.ot.testlauncher/build.sbt
@@ -38,3 +38,5 @@ OsgiKeys.additionalHeaders +=
 OsgiKeys.dynamicImportPackage := Seq("*") // hmm
 
 OsgiKeys.exportPackage := Seq()
+
+fork := true

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/tpe/CatalogImageDisplay.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/tpe/CatalogImageDisplay.scala
@@ -91,7 +91,7 @@ abstract class CatalogImageDisplay(parent: Component, navigatorPane: NavigatorPa
     *
     * @param before set to true before the image is loaded and false afterwards
     */
-  protected override def newImage(before: Boolean) {
+  protected override def newImage(before: Boolean): Unit = {
     super.newImage(before)
     if (!before) {
       // replot
@@ -103,7 +103,7 @@ abstract class CatalogImageDisplay(parent: Component, navigatorPane: NavigatorPa
     * Transform the image graphics using the given AffineTransform.
     */
   @Deprecated
-  protected override def transformGraphics(trans: AffineTransform) {
+  protected override def transformGraphics(trans: AffineTransform): Unit = {
     super.transformGraphics(trans)
     plotter.transformGraphics(trans)
   }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
@@ -322,6 +322,7 @@ final class TpeGhostIfuFeature extends TpeImageFeature("GHOST", "Show the patrol
 
   override def isEnabled(ctx: TpeContext): Boolean = super.isEnabled(ctx) && ctx.instrument.is(SPComponentType.INSTRUMENT_GHOST)
 
+  override def isEnabledByDefault: Boolean = true
 
   // A property has changed.
   override def propertyChange(propName: String): Unit = _iw.repaint()


### PR DESCRIPTION
This is a bit tricky as if we have started the OT before with GHOST this will be disabled and the override won't work

It is probably not worth trying to reset the value on `jsky.properties` or what do you think @swalker2m ?