### PR TITLE
REL-3977 - Add Gaia bands to the ITC & OT

### DIFF
--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/votable/VoTableParser.scala
@@ -325,6 +325,15 @@ object CatalogAdapter {
     override def parseAngularVelocity(ucd: Ucd, v: String): CatalogProblem \/ AngularVelocity =
       CatalogAdapter.parseDoubleValue(ucd, v).map(AngularVelocity.fromDegreesPerYear)
 
+    // PPXML g mag is mapped to Sloan 'g
+    override def parseBand(id: FieldId, band: String): Option[MagnitudeBand] =
+      (id.id, id.ucd) match {
+        case ("gmag" | "gmag_err", ucd) if ucd.includes(UcdWord("em.opt.g")) =>
+          Some(MagnitudeBand._g)
+        case _                                                               =>
+          super.parseBand(id, band)
+      }
+
     override def filterAndDeduplicateMagnitudes(magnitudeFields: List[(FieldId, Magnitude)]): List[Magnitude] = {
       // Read all magnitudes, including duplicates
       val magMap1 = (Map.empty[String, Magnitude]/:magnitudeFields) {

--- a/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
+++ b/bundle/edu.gemini.catalog/src/test/scala/edu/gemini/catalog/votable/VoTableParserSpec.scala
@@ -731,9 +731,6 @@ class VoTableParserSpec extends Specification with VoTableParser {
     }
     "be able to validate and parse an v1.4 xml from ucac4" in {
       val xmlFile = "votable-ucac4-v1_4.xml"
-
-      println(VoTableParser.parse(CatalogName.UCAC4, getClass.getResourceAsStream(s"/$xmlFile")))
-
       VoTableParser.parse(CatalogName.UCAC4, getClass.getResourceAsStream(s"/$xmlFile")).map(_.tables.forall(!_.containsError)) must beEqualTo(\/.right(true))
       VoTableParser.parse(CatalogName.UCAC4, getClass.getResourceAsStream(s"/$xmlFile")).getOrElse(ParsedVoResource(Nil)).tables should be size 1
     }

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -100,6 +100,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2022-Feb-05</footer>
+<footer>Last updated 2022-Apr-12</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCacqCam.html
@@ -80,13 +80,16 @@
                     <select name="WavebandDefinition" size="1">
                         <option value="U">U (0.36 µm)</option>
                         <option value="B">B (0.44 µm)</option>
-                        <option value="g">g' (0.48 µm) </option>
+                        <option value="g">g' (0.48 µm)</option>
+ 						<option value="G_BP">G_BP (0.51 µm)</option>
                         <option value="V">V (0.55 µm)</option>
-                        <option value="r">r' (0.62 µm) </option>
+                        <option value="r">r' (0.62 µm)</option>
+						<option value="G">G (0.64 µm)</option>
                         <option value="R" selected>R (0.67 µm)</option>
-                        <option value="i">i' (0.77 µm) </option>
+                        <option value="i">i' (0.77 µm)</option>
+						<option value="G_RP">G_RP (0.78 µm)</option>
                         <option value="I">I (0.87 µm)</option>
-                        <option value="z">z' (0.92 µm) </option>
+                        <option value="z">z' (0.92 µm)</option>
                         <option value="Y">Y (1.02 µm)</option>
                         <option value="J">J (1.25 µm)</option>
                         <option value="H">H (1.65 µm)</option>
@@ -101,7 +104,9 @@
 
             <tr>
                 <td colspan="3">
-                    <p align="right"><input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;"></p>
+                    <p align="right">
+                        <input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
+                    </p>
                 </td>
             </tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -78,18 +78,20 @@
             </tr>
 
             <tr>
-                <td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>
-                    with the above <b>brightness normalisation</b> applied in filter
+                <td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter
                     <select name="WavebandDefinition" size="1">
                         <option value="U">U (0.36 µm)</option>
                         <option value="B">B (0.44 µm)</option>
-                        <option value="g">g' (0.48 µm) </option>
+                        <option value="g">g' (0.48 µm)</option>
+ 						<option value="G_BP">G_BP (0.51 µm)</option>
                         <option value="V">V (0.55 µm)</option>
-                        <option value="r">r' (0.62 µm) </option>
+                        <option value="r">r' (0.62 µm)</option>
+ 						<option value="G">G (0.64 µm)</option>
                         <option value="R">R (0.67 µm)</option>
-                        <option value="i">i' (0.77 µm) </option>
+                        <option value="i">i' (0.77 µm)</option>
+						<option value="G_RP">G_RP (0.78 µm)</option>
                         <option value="I">I (0.87 µm)</option>
-                        <option value="z">z' (0.92 µm) </option>
+                        <option value="z">z' (0.92 µm)</option>
                         <option value="Y">Y (1.02 µm)</option>
                         <option value="J">J (1.25 µm)</option>
                         <option value="H">H (1.65 µm)</option>
@@ -104,7 +106,7 @@
 
             <tr>
                 <td colspan="3">
-                    <p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->
+                    <p align="right">
                         <input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
                     </p>
                 </td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -80,13 +80,16 @@
 					<select name="WavebandDefinition" size="1">
 						<option value="U">U (0.36 µm)</option>
 						<option value="B">B (0.44 µm)</option>
-						<option value="g">g' (0.48 µm) </option>
+						<option value="g">g' (0.48 µm)</option>
+						<option value="G_BP">G_BP (0.51 µm)</option>
 						<option value="V">V (0.55 µm)</option>
-						<option value="r">r' (0.62 µm) </option>
+						<option value="r">r' (0.62 µm)</option>
+						<option value="G">G (0.64 µm)</option>
 						<option value="R" selected>R (0.67 µm)</option>
-						<option value="i">i' (0.77 µm) </option>
+						<option value="i">i' (0.77 µm)</option>
+						<option value="G_RP">G_RP (0.78 µm)</option>
 						<option value="I">I (0.87 µm)</option>
-						<option value="z">z' (0.92 µm) </option>
+						<option value="z">z' (0.92 µm)</option>
 						<option value="Y">Y (1.02 µm)</option>
 						<option value="J">J (1.25 µm)</option>
 						<option value="H">H (1.65 µm)</option>
@@ -101,9 +104,9 @@
 
 			<tr>
 				<td colspan="3">
-				<p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->
-					<input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
-				</p>
+					<p align="right">
+						<input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
+					</p>
 				</td>
 			</tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -78,33 +78,35 @@
             <tr>
                 <td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter
                     <select name="WavebandDefinition" size="1">
-                    <option value="U">U (0.36 µm)</option>
-                    <option value="B">B (0.44 µm)</option>
-                    <option value="g">g' (0.48 µm) </option>
-                    <option value="V">V (0.55 µm)</option>
-                    <option value="r">r' (0.62 µm) </option>
-                    <option value="R" selected>R (0.67 µm)</option>
-                    <option value="i">i' (0.77 µm) </option>
-                    <option value="I">I (0.87 µm)</option>
-                    <option value="z">z' (0.92 µm) </option>
-                    <option value="Y">Y (1.02 µm)</option>
-                    <option value="J">J (1.25 µm)</option>
-                    <option value="H">H (1.65 µm)</option>
-                    <option value="K">K (2.2 µm)</option>
-                    <option value="L">L' (3.76 µm)</option>
-                    <option value="M">M' (4.77 µm)</option>
-                    <option value="N">N (10.5 µm)</option>
-                    <option value="Q">Q (20.1 µm)</option>
-                </select> band
+                        <option value="U">U (0.36 µm)</option>
+                        <option value="B">B (0.44 µm)</option>
+                        <option value="g">g' (0.48 µm)</option>
+						<option value="G_BP">G_BP (0.51 µm)</option>
+                        <option value="V">V (0.55 µm)</option>
+                        <option value="r">r' (0.62 µm)</option>
+						<option value="G">G (0.64 µm)</option>
+                        <option value="R" selected>R (0.67 µm)</option>
+                        <option value="i">i' (0.77 µm)</option>
+						<option value="G_RP">G_RP (0.78 µm)</option>
+                        <option value="I">I (0.87 µm)</option>
+                        <option value="z">z' (0.92 µm)</option>
+                        <option value="Y">Y (1.02 µm)</option>
+                        <option value="J">J (1.25 µm)</option>
+                        <option value="H">H (1.65 µm)</option>
+                        <option value="K">K (2.2 µm)</option>
+                        <option value="L">L' (3.76 µm)</option>
+                        <option value="M">M' (4.77 µm)</option>
+                        <option value="N">N (10.5 µm)</option>
+                        <option value="Q">Q (20.1 µm)</option>
+                    </select> band
                 </td>
             </tr>
 
             <tr>
                 <td colspan="3">
-                <p align="right">
-                   <!-- <input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->
-                    <input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
-                </p>
+                    <p align="right">
+                        <input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
+                    </p>
                 </td>
             </tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -84,13 +84,16 @@
 					<select name="WavebandDefinition" size="1">
 						<option value="U">U (0.36 µm)</option>
 						<option value="B">B (0.44 µm)</option>
-						<option value="g">g' (0.48 µm) </option>
+						<option value="g">g' (0.48 µm)</option>
+						<option value="G_BP">G_BP (0.51 µm)</option>
 						<option value="V">V (0.55 µm)</option>
-						<option value="r">r' (0.62 µm) </option>
+						<option value="r">r' (0.62 µm)</option>
+						<option value="G">G (0.64 µm)</option>
 						<option value="R">R (0.67 µm)</option>
-						<option value="i">i' (0.77 µm) </option>
+						<option value="i">i' (0.77 µm)</option>
+						<option value="G_RP">G_RP (0.78 µm)</option>
 						<option value="I">I (0.87 µm)</option>
-						<option value="z">z' (0.92 µm) </option>
+						<option value="z">z' (0.92 µm)</option>
 						<option value="Y">Y (1.02 µm)</option>
 						<option value="J">J (1.25 µm)</option>
 						<option value="H">H (1.65 µm)</option>
@@ -105,9 +108,9 @@
 
 			<tr>
 				<td colspan="3">
-				<p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->
-					<input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
-				</p>
+					<p align="right">
+						<input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
+					</p>
 			</td>
 			</tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgsaoi.html
@@ -83,13 +83,16 @@
 					<select name="WavebandDefinition" size="1">
 						<option value="U">U (0.36 µm)</option>
 						<option value="B">B (0.44 µm)</option>
-						<option value="g">g' (0.48 µm) </option>
+						<option value="g">g' (0.48 µm)</option>
+ 						<option value="G_BP">G_BP (0.51 µm)</option>
 						<option value="V">V (0.55 µm)</option>
-						<option value="r">r' (0.62 µm) </option>
+						<option value="r">r' (0.62 µm)</option>
+ 						<option value="G">G (0.64 µm)</option>
 						<option value="R">R (0.67 µm)</option>
-						<option value="i">i' (0.77 µm) </option>
+						<option value="i">i' (0.77 µm)</option>
+						<option value="G_RP">G_RP (0.78 µm)</option>
 						<option value="I">I (0.87 µm)</option>
-						<option value="z">z' (0.92 µm) </option>
+						<option value="z">z' (0.92 µm)</option>
 						<option value="Y">Y (1.02 µm)</option>
 						<option value="J">J (1.25 µm)</option>
 						<option value="H">H (1.65 µm)</option>
@@ -104,7 +107,7 @@
 
 			<tr>
 				<td colspan="3">
-					<p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->
+					<p align="right">
 						<input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
 					</p>
 				</td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCmichelle.html
@@ -74,35 +74,38 @@
                         <option value="ERGS_FREQUENCY_PSA">erg/s/cm²/Hz/arcsec²</option>
                     </select> (e.g. 21.6 mag/arcsec²)
                 </td>
-
 			</tr>
+
 			<tr>
-				<td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter <select name="WavebandDefinition" size="1">
-
-                    <option value="U">U (0.36 µm)</option>
-                    <option value="B">B (0.44 µm)</option>
-                    <option value="g">g' (0.48 µm) </option>
-                    <option value="V">V (0.55 µm)</option>
-                    <option value="r">r' (0.62 µm) </option>
-                    <option value="R">R (0.67 µm)</option>
-                    <option value="i">i' (0.77 µm) </option>
-                    <option value="I">I (0.87 µm)</option>
-                    <option value="z">z' (0.92 µm) </option>
-					<option value="Y">Y (1.02 µm)</option>
-					<option value="J">J (1.25 µm)</option>
-                    <option value="H">H (1.65 µm)</option>
-                    <option value="K">K (2.2 µm)</option>
-                    <option value="L">L' (3.76 µm)</option>
-                    <option value="M">M' (4.77 µm)</option>
-                    <option value="N">N (10.5 µm)</option>
-                    <option value="Q">Q (20.1 µm)</option>
-
-				</select> band</td>
-
+				<td colspan="3"><img src="/spacer.gif" height="40" width="1" style="opacity:0.0"/>with the above <b>brightness normalisation</b> applied in filter
+					<select name="WavebandDefinition" size="1">
+						<option value="U">U (0.36 µm)</option>
+						<option value="B">B (0.44 µm)</option>
+						<option value="g">g' (0.48 µm)</option>
+ 						<option value="G_BP">G_BP (0.51 µm)</option>
+						<option value="V">V (0.55 µm)</option>
+						<option value="r">r' (0.62 µm)</option>
+ 						<option value="G">G (0.64 µm)</option>
+						<option value="R">R (0.67 µm)</option>
+						<option value="i">i' (0.77 µm)</option>
+						<option value="G_RP">G_RP (0.78 µm)</option>
+						<option value="I">I (0.87 µm)</option>
+						<option value="z">z' (0.92 µm)</option>
+						<option value="Y">Y (1.02 µm)</option>
+						<option value="J">J (1.25 µm)</option>
+						<option value="H">H (1.65 µm)</option>
+						<option value="K">K (2.2 µm)</option>
+						<option value="L">L' (3.76 µm)</option>
+						<option value="M">M' (4.77 µm)</option>
+						<option value="N">N (10.5 µm)</option>
+						<option value="Q">Q (20.1 µm)</option>
+					</select> band
+				</td>
 			</tr>
+
 			<tr>
 				<td colspan="3">
-					<p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->
+					<p align="right">
 						<input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
 					</p>
 				</td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCnifs.html
@@ -81,13 +81,16 @@
 					<select name="WavebandDefinition" size="1">
 						<option value="U">U (0.36 µm)</option>
 						<option value="B">B (0.44 µm)</option>
-						<option value="g">g' (0.48 µm) </option>
+						<option value="g">g' (0.48 µm)</option>
+ 						<option value="G_BP">G_BP (0.51 µm)</option>
 						<option value="V">V (0.55 µm)</option>
-						<option value="r">r' (0.62 µm) </option>
+						<option value="r">r' (0.62 µm)</option>
+ 						<option value="G">G (0.64 µm)</option>
 						<option value="R">R (0.67 µm)</option>
-						<option value="i">i' (0.77 µm) </option>
+						<option value="i">i' (0.77 µm)</option>
+						<option value="G_RP">G_RP (0.78 µm)</option>
 						<option value="I">I (0.87 µm)</option>
-						<option value="z">z' (0.92 µm) </option>
+						<option value="z">z' (0.92 µm)</option>
 						<option value="Y">Y (1.02 µm)</option>
 						<option value="J">J (1.25 µm)</option>
 						<option value="H">H (1.65 µm)</option>
@@ -102,7 +105,7 @@
 
 			<tr>
 				<td colspan="3">
-					<p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->
+					<p align="right">
 						<input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
 					</p>
 				</td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCniri.html
@@ -83,13 +83,16 @@
 					<select name="WavebandDefinition" size="1">
 						<option value="U">U (0.36 µm)</option>
 						<option value="B">B (0.44 µm)</option>
-						<option value="g">g' (0.48 µm) </option>
+						<option value="g">g' (0.48 µm)</option>
+						<option value="G_BP">G_BP (0.51 µm)</option>
 						<option value="V">V (0.55 µm)</option>
-						<option value="r">r' (0.62 µm) </option>
+						<option value="r">r' (0.62 µm)</option>
+						<option value="G">G (0.64 µm)</option>
 						<option value="R">R (0.67 µm)</option>
-						<option value="i">i' (0.77 µm) </option>
+						<option value="i">i' (0.77 µm)</option>
+						<option value="G_RP">G_RP (0.78 µm)</option>
 						<option value="I">I (0.87 µm)</option>
-						<option value="z">z' (0.92 µm) </option>
+						<option value="z">z' (0.92 µm)</option>
 						<option value="Y">Y (1.02 µm)</option>
 						<option value="J">J (1.25 µm)</option>
 						<option value="H">H (1.65 µm)</option>
@@ -104,7 +107,7 @@
 
 			<tr>
 				<td colspan="3">
-					<p align="right"> <!--<input src="https://www.gemini.edu/sciops/instruments/itc/calcButton.gif" align="absbottom" border="0" height="24" type="image" width="78" /> -->
+					<p align="right">
 						<input value="Calculate" type="submit" style="background-color: gold; padding: 3px 8px;">
 					</p>
 				</td>

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/ZeroMagnitudeStar.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/ZeroMagnitudeStar.scala
@@ -39,9 +39,13 @@ object ZeroMagnitudeStar {
     case `_i` => 93600000
     case `_z` => 79800000
 
+    // Gaia values derived from synphot:
+    case `GB` => 103400000
+    case `G`  =>  79500000
+    case `GR` =>  50390000
+
     // Other bands are not supported, in particular AP and UC
     case _ => sys.error("unsupported waveband " + band.name)
-
 
   }
 }

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/MagnitudeBand.scala
@@ -2,20 +2,16 @@ package edu.gemini.spModel.core
 
 import edu.gemini.spModel.core.WavelengthConversions._
 
-sealed abstract class MagnitudeBand private (val name: String, val center: Wavelength, val width: Wavelength, val description: Option[String], val defaultSystem: MagnitudeSystem) extends Product with Serializable {
+sealed abstract class MagnitudeBand private (val name: String, val start: Wavelength, val center: Wavelength, val end: Wavelength, val description: Option[String], val defaultSystem: MagnitudeSystem) extends Product with Serializable {
 
-  private def this(name: String, center: Wavelength, width: Wavelength) =
-    this(name, center, width, None, MagnitudeSystem.Vega)
+  private def this(name: String, start: Wavelength, center: Wavelength, end: Wavelength) =
+    this(name, start, center, end, None, MagnitudeSystem.Vega)
 
-  private def this(name: String, center: Wavelength, width: Wavelength, description: String) =
-    this(name, center, width, Some(description), MagnitudeSystem.Vega)
+  private def this(name: String, start: Wavelength, center: Wavelength, end: Wavelength, description: String) =
+    this(name, start, center, end, Some(description), MagnitudeSystem.Vega)
 
-  private def this(name: String, center: Wavelength, width: Wavelength, description: String, defaultMagnitudeSystem: MagnitudeSystem) =
-    this(name, center, width, Some(description), defaultMagnitudeSystem)
-
-  val start: Wavelength = center - width / 2
-
-  val end:   Wavelength = center + width / 2
+  private def this(name: String, start: Wavelength, center: Wavelength, end: Wavelength, description: String, defaultMagnitudeSystem: MagnitudeSystem) =
+    this(name, start, center, end, Some(description), defaultMagnitudeSystem)
 
   final override def toString = name
 
@@ -26,32 +22,37 @@ object MagnitudeBand {
   // Class files clobber one another on OS X so names can't differ only in case.
   // We may need to revisit and come up with better names.
   // Values for Sloan filters (u', g', r', i', z') taken from Fukugita et al. (1996)
-  case object _u extends MagnitudeBand("u",   356.nm,   46.nm, "UV",             MagnitudeSystem.AB)
-  case object _g extends MagnitudeBand("g",   483.nm,   99.nm, "green",          MagnitudeSystem.AB)
-  case object _r extends MagnitudeBand("r",   626.nm,   96.nm, "red",            MagnitudeSystem.AB)
-  case object _i extends MagnitudeBand("i",   767.nm,  106.nm, "far red",        MagnitudeSystem.AB)
-  case object _z extends MagnitudeBand("z",   910.nm,  125.nm, "near-infrared",  MagnitudeSystem.AB)
+  case object _u extends MagnitudeBand("u",   333.nm,  356.nm,  379.nm, "UV",             MagnitudeSystem.AB)
+  case object _g extends MagnitudeBand("g",   433.nm,  483.nm,  533.nm, "green",          MagnitudeSystem.AB)
+  case object _r extends MagnitudeBand("r",   578.nm,  626.nm,  674.nm, "red",            MagnitudeSystem.AB)
+  case object _i extends MagnitudeBand("i",   714.nm,  767.nm,  820.nm, "far red",        MagnitudeSystem.AB)
+  case object _z extends MagnitudeBand("z",   847.nm,  910.nm,  973.nm, "near-infrared",  MagnitudeSystem.AB)
 
-  case object U  extends MagnitudeBand("U",   360.nm,   75.nm, "ultraviolet")
-  case object B  extends MagnitudeBand("B",   440.nm,   90.nm, "blue")
-  case object V  extends MagnitudeBand("V",   550.nm,   85.nm, "visual")
-  case object UC extends MagnitudeBand("UC",  610.nm,   63.nm, "UCAC")
-  case object R  extends MagnitudeBand("R",   670.nm,  100.nm, "red")
-  case object I  extends MagnitudeBand("I",   870.nm,  100.nm, "infrared")
-  case object Y  extends MagnitudeBand("Y",  1020.nm,  120.nm)
-  case object J  extends MagnitudeBand("J",  1250.nm,  240.nm)
-  case object H  extends MagnitudeBand("H",  1650.nm,  300.nm)
-  case object K  extends MagnitudeBand("K",  2200.nm,  410.nm)
-  case object L  extends MagnitudeBand("L",  3760.nm,  700.nm)
-  case object M  extends MagnitudeBand("M",  4770.nm,  240.nm)
-  case object N  extends MagnitudeBand("N", 10470.nm, 5230.nm)
-  case object Q  extends MagnitudeBand("Q", 20130.nm, 1650.nm)
+  case object U  extends MagnitudeBand("U",   322.nm,   360.nm,   398.nm, "ultraviolet")
+  case object B  extends MagnitudeBand("B",   395.nm,   440.nm,   485.nm, "blue")
+  case object V  extends MagnitudeBand("V",   507.nm,   550.nm,   593.nm, "visual")
+  case object UC extends MagnitudeBand("UC",  578.nm,   610.nm,   642.nm, "UCAC")
+  case object R  extends MagnitudeBand("R",   620.nm,   670.nm,   720.nm, "red")
+  case object I  extends MagnitudeBand("I",   820.nm,   870.nm,   920.nm, "infrared")
+  case object Y  extends MagnitudeBand("Y",   960.nm,  1020.nm,  1080.nm)
+  case object J  extends MagnitudeBand("J",  1130.nm,  1250.nm,  1370.nm)
+  case object H  extends MagnitudeBand("H",  1500.nm,  1650.nm,  1800.nm)
+  case object K  extends MagnitudeBand("K",  1995.nm,  2200.nm,  2405.nm)
+  case object L  extends MagnitudeBand("L",  3410.nm,  3760.nm,  4110.nm)
+  case object M  extends MagnitudeBand("M",  4650.nm,  4770.nm,  4890.nm)
+  case object N  extends MagnitudeBand("N",  7855.nm, 10470.nm, 13085.nm)
+  case object Q  extends MagnitudeBand("Q", 19305.nm, 20130.nm, 20955.nm)
+
+  // Using 1% transmission to characterize "start" and "end"
+  case object GB extends MagnitudeBand("G_BP", 328.nm,  513.nm,  671.nm, "Gaia Blue Passband")
+  case object G  extends MagnitudeBand("G",    330.nm,  641.nm, 1037.nm, "Gaia Passband")
+  case object GR extends MagnitudeBand("G_RP", 626.nm,  778.nm, 1051.nm, "Gaia Red Passband")
 
   // use V-Band center and width for apparent magnitudes
-  case object AP extends MagnitudeBand("AP", V.center, V.width, Some("apparent"), MagnitudeSystem.Vega)
+  case object AP extends MagnitudeBand("AP", V.start, V.center, V.end, Some("apparent"), MagnitudeSystem.Vega)
 
   lazy val all: List[MagnitudeBand] =
-    List(_u, _g, _r, _i, _z, U, B, V, UC, R, I, Y, J, H, K, L, M, N, Q, AP)
+    List(_u, _g, _r, _i, _z, U, B, V, UC, R, I, Y, J, H, K, L, M, N, Q, AP, G, GB, GR)
 
   def fromString(s: String): Option[MagnitudeBand] =
     all.find(_.name == s)
@@ -73,4 +74,3 @@ object MagnitudeBand {
   implicit val equals = scalaz.Equal.equalA[MagnitudeBand]
 
 }
-


### PR DESCRIPTION
This adds the three Gaia bands (G_BP, G, G_RP) to the OT and ITC.

Note that the tests are currently failing, so this will need a bit of help.