### PR TITLE
REL-4113: AGS / GHOST / Explicit base bug

### DIFF
--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
@@ -27,7 +27,7 @@ import scalaz._
 import Scalaz._
 
 class AgsHashSpec extends Specification with ScalaCheck with edu.gemini.spModel.test.SpModelArbitraries {
-  val now = Instant.now()
+  val now: Instant = Instant.now()
 
   def hashSame(ctx0: ObsContext, ctx1: ObsContext): Boolean =
     AgsHash.hash(ctx0, now) == AgsHash.hash(ctx1, now)

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeAsterismFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeAsterismFeature.java
@@ -16,13 +16,11 @@ import edu.gemini.spModel.target.env.TargetEnvironment;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.target.obsComp.TargetSelection;
 import jsky.app.ot.tpe.*;
-import jsky.app.ot.util.OtColor;
 
 import java.awt.*;
 import java.awt.geom.Point2D;
 import java.time.Instant;
 
-// TODO:ASTERISM: Draw base position … right now we only draw the targets
 public class TpeAsterismFeature extends TpePositionFeature {
 
     public TpeAsterismFeature() {
@@ -102,7 +100,7 @@ public class TpeAsterismFeature extends TpePositionFeature {
             final int d = 2 * r;
             g.setColor(Color.cyan);
             g.drawOval((int) (p.x - r), (int) (p.y - r), d, d);
-            g.fillOval((int) (p.x - r/2), (int) (p.y - r/2), r, r);
+            g.fillOval((int) (p.x - r/2), (int) (p.y - r/2), r+1, r+1);
         });
     }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/ags/BagsManager.scala
@@ -72,7 +72,7 @@ object BagsState {
     (ErrorState, ioUnit)  // Default transition for unexpected events
 
   def hashObs(ctx: ObsContext): AgsHashVal = {
-    val when = ctx.getSchedulingBlockStart.asScalaOpt | Instant.now.toEpochMilli
+    val when = ctx.getSchedulingBlockStart.asScalaOpt.map(t => Instant.ofEpochMilli(t)) | Instant.now
     AgsHash.hash(ctx, when)
   }
 

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeCatalogFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeCatalogFeature.scala
@@ -1,6 +1,6 @@
 package jsky.app.ot.tpe.feat
 
-import edu.gemini.ags.api.{AgsRegistrar, AgsHash}
+import edu.gemini.ags.api.{AgsHash, AgsRegistrar}
 import edu.gemini.ags.conf.ProbeLimitsTable
 import edu.gemini.catalog.api.ConeSearchCatalogQuery
 import edu.gemini.catalog.ui.adapters.TableQueryResultAdapter
@@ -12,7 +12,9 @@ import edu.gemini.spModel.obs.context.ObsContext
 import jsky.app.ot.tpe._
 import jsky.app.ot.tpe.feat.TpeCatalogFeature.PlotState._
 import jsky.catalog.gui.TablePlotter
+
 import java.awt.Graphics
+import java.time.Instant
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.swing.Swing
@@ -111,7 +113,7 @@ object TpeCatalogFeature {
     val when = c.getSchedulingBlockStart.asScalaOpt.map(_.toLong).getOrElse {
       new ObservingNight(c.getSite.getOrElse(Site.GN)).getStartTime
     }
-    AgsHash.hash(c, when)
+    AgsHash.hash(c, Instant.ofEpochMilli(when))
   }
 
   /** PlotState contains all relevant information for the catalog plot. */


### PR DESCRIPTION
The `AgsHash` did not take into consideration explicit GHOST base positions that are unlinked from targets.  This prevented AGS from knowing that an update was needed when the base position changes.

Unrelatedly, I tweaking the drawing of the bullseye marking the base position in these cases so that appears centered.