### PR TITLE
REL-4024: adjust HR Sky location

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/rules/ghost/GhostRule.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/rules/ghost/GhostRule.scala
@@ -61,7 +61,7 @@ object GhostRule extends IRule {
           // The sky position is taken from the user configuration, but the
           // actual SRIFU2 is positioned just south of that.  For the range
           // check we need to use the actual SRIFU2 location.
-          checkBoth(ctx, node, base, t.coordinates(when), Some(hr.srifu2.coordinates))
+          checkBoth(ctx, node, base, t.coordinates(when), Some(hr.srifu2(ctx.getPositionAngle)))
         case _                                                  =>
           Nil
       }

--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/rules/ghost/GhostRule.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/rules/ghost/GhostRule.scala
@@ -57,8 +57,11 @@ object GhostRule extends IRule {
           checkBoth(ctx, node, base, t.coordinates(when), Some(s.coordinates))
         case GhostAsterism.SkyPlusTarget(s, t, _)               =>
           checkBoth(ctx, node, base, Some(s.coordinates), t.coordinates(when))
-        case GhostAsterism.HighResolutionTargetPlusSky(t, s, _) =>
-          checkBoth(ctx, node, base, t.coordinates(when), Some(s.coordinates))
+        case hr@GhostAsterism.HighResolutionTargetPlusSky(t, _, _) =>
+          // The sky position is taken from the user configuration, but the
+          // actual SRIFU2 is positioned just south of that.  For the range
+          // check we need to use the actual SRIFU2 location.
+          checkBoth(ctx, node, base, t.coordinates(when), Some(hr.srifu2.coordinates))
         case _                                                  =>
           Nil
       }
@@ -105,7 +108,7 @@ object GhostRule extends IRule {
       1800
 
     val message: String =
-      s"Exposure time exceeds the recommended maximum ($limitSeconds seconds) due to cosmic ray contamination";
+      s"Exposure time exceeds the recommended maximum ($limitSeconds seconds) due to cosmic ray contamination"
 
     override def check(config: Config, step: Int, elements: ObservationElements, state: Any): Problem = {
       def checkTime(key: ItemKey): Option[Problem] =

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -223,7 +223,7 @@ object GhostAsterism {
       case HighResolutionTargetPlusSky(_,_,_) => AsterismType.GhostHighResolutionTargetPlusSky
     }
 
-    def hrifu1: GhostTarget =
+    def hrifu: GhostTarget =
       this match {
         case HighResolutionTargetPlusSky(t,_,_) => t
       }
@@ -233,16 +233,20 @@ object GhostAsterism {
         case HighResolutionTargetPlusSky(_,s,_) => s
       }
 
-    def srifu2: SPCoordinates =
+    def srifu2(posAngle: Angle): Coordinates = {
+      // Sky is at offset (0, HrSkyFiberOffset) from SRIFU1 at pos angle 0.  We
+      // hold the sky coordinates as fixed gospel, coming from the user, and
+      // figure out where SRIFU1 would have to be to get those sky coordinates.
+      val θ = -posAngle.toSignedDegrees.toRadians
+      val y = -GhostIfuPatrolField.HrSkyFiberOffset.toSignedArcsecs
+      val p = Angle.fromArcsecs(-y * Math.sin(θ))
+      val q = Angle.fromArcsecs( y * Math.cos(θ))
+
       this match {
-        case HighResolutionTargetPlusSky(_,s,_) =>
-          // The coordinates entered by the user are exactly where the HRIFU
-          // sky fibers should be placed. To get the SRIFU2 at that location we
-          // have to correct these coordinates.
-          new SPCoordinates(
-            s.coordinates.offset(Angle.zero, GhostIfuPatrolField.HrSkyFiberOffset * -1.0)
-          )
+        case HighResolutionTargetPlusSky(_, s, _) =>
+          s.coordinates.offset(p, q)
       }
+    }
   }
 
   final case class HighResolutionTargetPlusSky(target: GhostTarget,

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -223,12 +223,26 @@ object GhostAsterism {
       case HighResolutionTargetPlusSky(_,_,_) => AsterismType.GhostHighResolutionTargetPlusSky
     }
 
-    def hrifu1: GhostTarget = this match {
-      case HighResolutionTargetPlusSky(t,_,_) => t
-    }
-    def hrifu2: Option[SPCoordinates] = this match {
-      case HighResolutionTargetPlusSky(_,s,_) => Some(s)
-    }
+    def hrifu1: GhostTarget =
+      this match {
+        case HighResolutionTargetPlusSky(t,_,_) => t
+      }
+
+    def hrsky: SPCoordinates =
+      this match {
+        case HighResolutionTargetPlusSky(_,s,_) => s
+      }
+
+    def srifu2: SPCoordinates =
+      this match {
+        case HighResolutionTargetPlusSky(_,s,_) =>
+          // The coordinates entered by the user are exactly where the HRIFU
+          // sky fibers should be placed. To get the SRIFU2 at that location we
+          // have to correct these coordinates.
+          new SPCoordinates(
+            s.coordinates.offset(Angle.zero, GhostIfuPatrolField.HrSkyFiberOffset * -1.0)
+          )
+      }
   }
 
   final case class HighResolutionTargetPlusSky(target: GhostTarget,

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -286,4 +286,9 @@ object GhostAsterism {
   val SRIFU1: String = "SRIFU1"
   val SRIFU2: String = "SRIFU2"
   val HRIFU:  String = "HRIFU"
+
+  // In HR mode, the sky coordinates are not the coordinates of SRIFU2 so it is
+  // misleading to tag the sky position as SRIFU2.  Instead we'll invent a new
+  // tag that indicates they are the sky coordinates.
+  val HRSKY:  String = "HRSKY"
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
@@ -143,10 +143,10 @@ final class GhostCB(obsComp: ISPObsComponent) extends AbstractObsComponentCB(obs
                 Ghost.BASE_RA_HMS, Ghost.BASE_DEC_DMS))
 
               // Always target.
-              coordParam(ghr.hrifu1.spTarget, Some(Ghost.HRIFU1_NAME),
+              coordParam(ghr.hrifu.spTarget, Some(Ghost.HRIFU1_NAME),
                 Ghost.HRIFU1_RA_DEG, Ghost.HRIFU1_DEC_DEG,
                 Ghost.HRIFU1_RA_HMS, Ghost.HRIFU1_DEC_DMS)
-              guiding(Ghost.HRIFU1_GUIDING, ghr.hrifu1)
+              guiding(Ghost.HRIFU1_GUIDING, ghr.hrifu)
 
               // Always sky.
               coordParam(

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
@@ -4,6 +4,7 @@ import java.time.{Duration, Instant}
 import java.util.{Map => JMap}
 import edu.gemini.pot.sp.ISPObsComponent
 import edu.gemini.spModel.config.AbstractObsComponentCB
+import edu.gemini.spModel.core.Angle
 import edu.gemini.spModel.data.config._
 import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostTarget
 import edu.gemini.spModel.obscomp.InstConstants
@@ -150,9 +151,26 @@ final class GhostCB(obsComp: ISPObsComponent) extends AbstractObsComponentCB(obs
               guiding(Ghost.HRIFU1_GUIDING, ghr.hrifu1)
 
               // Always sky, if it exists.
-              ghr.hrifu2.foreach(c => coordParam(c, Some(Ghost.HRIFU2_NAME),
-                Ghost.HRIFU2_RA_DEG, Ghost.HRIFU2_DEC_DEG,
-                Ghost.HRIFU2_RA_HMS, Ghost.HRIFU2_DEC_DMS))
+              ghr.hrifu2.foreach { c =>
+
+                // We have been requested inconsistent treatment of HRIFU sky
+                // positions.  In particular, the coordinates entered by the
+                // user are exactly where the HRIFU sky fibers should be placed.
+                // To get the SRIFU2 at that location we have to correct these
+                // coordinates.
+                val cʹ = new SPCoordinates(
+                  c.coordinates.offset(Angle.zero, GhostIfuPatrolField.HrSkyFiberOffset * -1.0)
+                )
+
+                coordParam(
+                  cʹ,
+                  Some(Ghost.HRIFU2_NAME),
+                  Ghost.HRIFU2_RA_DEG,
+                  Ghost.HRIFU2_DEC_DEG,
+                  Ghost.HRIFU2_RA_HMS,
+                  Ghost.HRIFU2_DEC_DMS
+                )
+              }
 
             case _ =>
               // The asterism may not have been configured by this point.

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
@@ -1,15 +1,13 @@
 package edu.gemini.spModel.gemini.ghost
 
-import java.time.{Duration, Instant}
+import java.time.Instant
 import java.util.{Map => JMap}
 import edu.gemini.pot.sp.ISPObsComponent
 import edu.gemini.spModel.config.AbstractObsComponentCB
-import edu.gemini.spModel.core.Angle
 import edu.gemini.spModel.data.config._
 import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostTarget
 import edu.gemini.spModel.obscomp.InstConstants
 import edu.gemini.spModel.seqcomp.SeqConfigNames
-import edu.gemini.spModel.seqcomp.SeqConfigNames.OBSERVE_CONFIG_NAME
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 import edu.gemini.spModel.target.{SPCoordinates, SPSkyObject, SPTarget}
 
@@ -150,27 +148,15 @@ final class GhostCB(obsComp: ISPObsComponent) extends AbstractObsComponentCB(obs
                 Ghost.HRIFU1_RA_HMS, Ghost.HRIFU1_DEC_DMS)
               guiding(Ghost.HRIFU1_GUIDING, ghr.hrifu1)
 
-              // Always sky, if it exists.
-              ghr.hrifu2.foreach { c =>
-
-                // We have been requested inconsistent treatment of HRIFU sky
-                // positions.  In particular, the coordinates entered by the
-                // user are exactly where the HRIFU sky fibers should be placed.
-                // To get the SRIFU2 at that location we have to correct these
-                // coordinates.
-                val cʹ = new SPCoordinates(
-                  c.coordinates.offset(Angle.zero, GhostIfuPatrolField.HrSkyFiberOffset * -1.0)
-                )
-
-                coordParam(
-                  cʹ,
-                  Some(Ghost.HRIFU2_NAME),
-                  Ghost.HRIFU2_RA_DEG,
-                  Ghost.HRIFU2_DEC_DEG,
-                  Ghost.HRIFU2_RA_HMS,
-                  Ghost.HRIFU2_DEC_DMS
-                )
-              }
+              // Always sky.
+              coordParam(
+                ghr.hrsky,  // switch to ghr.srifu2 if we're supposed to send IFU2 coords
+                Some(Ghost.HRIFU2_NAME),
+                Ghost.HRIFU2_RA_DEG,
+                Ghost.HRIFU2_DEC_DEG,
+                Ghost.HRIFU2_RA_HMS,
+                Ghost.HRIFU2_DEC_DMS
+              )
 
             case _ =>
               // The asterism may not have been configured by this point.

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostIfuPatrolField.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostIfuPatrolField.scala
@@ -29,6 +29,13 @@ sealed trait GhostIfuPatrolField {
 
 object GhostIfuPatrolField {
 
+  val ScaleMmToArcsec: Double = 1.0 / 0.61  // arcsec / mm
+  val TransformMmToArcsec: AffineTransform =
+    AffineTransform.getScaleInstance(ScaleMmToArcsec, ScaleMmToArcsec)
+
+  val HrSkyFiberOffset: Angle =
+    Angle.fromArcsecs(2.0 * ScaleMmToArcsec)
+
     // The patrol fields for IFU1 and IFU2 relative to the base position.
   private val ifu1PatrolFieldRectangle = new Rectangle2D.Double(-222, -222, 222 + 3.28, 444)
   private val ifu2PatrolFieldRectangle = new Rectangle2D.Double(-3.28, -222, 222 + 3.28, 444)

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/TelescopePosTableModel.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/telescopePosTableModel/TelescopePosTableModel.java
@@ -227,7 +227,7 @@ final public class TelescopePosTableModel extends AbstractTableModel {
 
         hdr.add(createGhostBaseRow(a));
         hdr.add(new GhostTargetRow(GhostAsterism$.MODULE$.HRIFU(), gt, baseCoords, when));
-        hdr.add(new GhostSkyRow(GhostAsterism$.MODULE$.SRIFU2(), c, baseCoords));
+        hdr.add(new GhostSkyRow(GhostAsterism$.MODULE$.HRSKY(), c, baseCoords));
         return hdr;
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeAsterismFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeAsterismFeature.java
@@ -169,6 +169,15 @@ public class TpeAsterismFeature extends TpePositionFeature {
         }
     }
 
+    private void drawGhostIfuPosition(
+        final Graphics    g,
+        final Coordinates pos
+    ) {
+        final SPCoordinates spC = new SPCoordinates(pos);
+        final Point2D.Double  p = _iw.taggedPosToScreenCoords(spC);
+        markPosition(g, Color.magenta, p);
+    }
+
     private void drawGhostIfu(
       final Graphics            g,
       final GhostPosition       pos,
@@ -179,6 +188,12 @@ public class TpeAsterismFeature extends TpePositionFeature {
             patrolField.inRange(Coordinates.difference(base, pos.ifuPosition).offset()) ?
                     (pos.isTarget ? Color.yellow : Color.cyan)                          :
                     Color.red;
+
+        // For debugging, it can be useful to turn on IFU position.  For HR
+        // the IFU position is SRIFU2 and the drawing location is the sky
+        // position itself.  Normally we don't draw the IFU position though in
+        // this case.
+        //drawGhostIfuPosition(g, pos.ifuPosition);
 
         markPosition(g, color, pos.drawingLocation);
     }
@@ -270,7 +285,9 @@ public class TpeAsterismFeature extends TpePositionFeature {
                     g,
                     ctx,
                     GhostPosition.fromTarget(hrtps.target(), when, pm),
-                    ImOption.apply(GhostPosition.fromSky(hrtps.srifu2().coordinates(), hrtps.sky(), pm)),
+                    ctx.map(ObsContext::getPositionAngle).map(posAngle ->
+                       GhostPosition.fromSky(hrtps.srifu2(posAngle), hrtps.sky(), pm)
+                    ),
                     explicitBaseLocation(hrtps.overriddenBase(), pm)
                 );
                 break;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
@@ -8,6 +8,7 @@ import java.util.Collections
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.shared.util.immutable.{None => JNone, Option => JOption, Some => JSome}
 import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.spModel.gemini.ghost.GhostIfuPatrolField.{ScaleMmToArcsec, TransformMmToArcsec}
 import edu.gemini.spModel.gemini.ghost.{Ghost, GhostAsterism, GhostIfuPatrolField}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.obscomp.SPInstObsComp
@@ -15,7 +16,7 @@ import edu.gemini.spModel.target.SPSkyObject
 import edu.gemini.spModel.target.env.{Asterism, AsterismType, TargetEnvironment, TargetEnvironmentDiff}
 import javax.swing.{Icon, JLabel, JPanel, SwingConstants}
 import jsky.app.ot.tpe._
-import jsky.app.ot.tpe.feat.TpeGhostIfuFeature.{HrIfuTargetColor, ScaleMmToArcsec, SrIfuSkyColor, SrIfuTargetColor, highResolutionIfuArcsec, highResolutionSkyArcsec, standardResolutionIfuArcsec, standardResolutionSkyArcsec}
+import jsky.app.ot.tpe.feat.TpeGhostIfuFeature.{HrIfuTargetColor, SrIfuSkyColor, SrIfuTargetColor, highResolutionIfuArcsec, highResolutionSkyArcsec, standardResolutionIfuArcsec, standardResolutionSkyArcsec}
 import jsky.app.ot.util.{BasicPropertyList, OtColor, PropertyWatcher}
 
 import scala.annotation.tailrec
@@ -251,7 +252,9 @@ final class TpeGhostIfuFeature extends TpeImageFeature("GHOST", "Show the patrol
       p,
       highResolutionSkyArcsec,
       0.0,
-      -2.0
+      // IFU2 is positioned 2 mm below sky position (the demand coordinates sent
+      // are corrected by 2 mm) but we display the actual coordinates.
+      0.0
     )
   }
 
@@ -465,10 +468,6 @@ object TpeGhostIfuFeature {
   //
   // See https://docs.google.com/document/d/1aN2ZPgaRMD52Rf4YG7ahwLnvQ8bpTRudc7MTBn-Lt2Y/edit#
   //
-
-  private val ScaleMmToArcsec: Double              = 1.0 / 0.61  // arcsec / mm
-  private val TransformMmToArcsec: AffineTransform =
-    AffineTransform.getScaleInstance(ScaleMmToArcsec, ScaleMmToArcsec)
 
   // Actually SR and HR are the same size in this representation but it seems
   // useful to keep them separate and match the spec.

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
@@ -577,7 +577,7 @@ object TpeGhostIfuFeature {
 
   private[feat] def objectInIFU2(env: TargetEnvironment, skyObject: SPSkyObject): Boolean = env.getAsterism match {
     case a: GhostAsterism.StandardResolution => a.srifu2.exists(_.fold(skyObject == _, skyObject == _.spTarget))
-    case a: GhostAsterism.HighResolution => a.hrifu2.contains(skyObject)
+    case a: GhostAsterism.HighResolution => a.hrsky == skyObject
     case _ => false
   }
 


### PR DESCRIPTION
Places the HR Sky fibers on the exact coordinates entered by the user, adjusting the position of the SRIFU2 accordingly 3.28 arcseconds south.