### PR TITLE
REL-4024: switch to magenta for GHOST targets

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeAsterismFeature.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/feat/TpeAsterismFeature.java
@@ -186,7 +186,7 @@ public class TpeAsterismFeature extends TpePositionFeature {
     ) {
         final Color color =
             patrolField.inRange(Coordinates.difference(base, pos.ifuPosition).offset()) ?
-                    (pos.isTarget ? Color.yellow : Color.cyan)                          :
+                    (pos.isTarget ? Color.magenta : Color.cyan)                          :
                     Color.red;
 
         // For debugging, it can be useful to turn on IFU position.  For HR


### PR DESCRIPTION
By request, switching to magenta for GHOST targets to better contrast with light backgrounds.
![Screen Shot 2022-05-09 at 09 39 44](https://user-images.githubusercontent.com/4906023/167423535-234b7be4-f6cb-4cce-8ea3-f8c9b65c04e2.png)
.