### PR TITLE
REL-4122: switch the PDF format

### DIFF
--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/auxfile/SkeletonAuxfileWriter.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/auxfile/SkeletonAuxfileWriter.scala
@@ -122,7 +122,7 @@ object SkeletonAuxfileWriter {
     writeTo(out) { tmp =>
       try {
         val xml = ProposalIo.writeToXml(p)
-        P1PDF.createFromNode(xml, attachments, P1PDF.GeminiDARP, tmp, None)
+        P1PDF.createFromNode(xml, attachments, P1PDF.GeminiStandard, tmp, None)
         Right(())
       } catch {
         case ex: Exception => Left(FileError(out, ex))


### PR DESCRIPTION
It appears we select the wrong PDF format when the skeleton is created.