### PR TITLE
REL-3919: tweak GAIA search limits

### DIFF
--- a/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsCatalogChoice.java
+++ b/bundle/edu.gemini.ags/src/main/java/edu/gemini/ags/gems/GemsCatalogChoice.java
@@ -13,7 +13,7 @@ public enum GemsCatalogChoice {
     UCAC4_GEMINI(UCAC4$.MODULE$, "UCAC4 at Gemini"),
     ;
 
-    public static final GemsCatalogChoice DEFAULT = GAIA_ESA;
+    public static final GemsCatalogChoice DEFAULT = GAIA_Gemini;
 
     private final CatalogName _catalogName;
     private final String      _displayValue;

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsVoTableCatalog.scala
@@ -151,7 +151,8 @@ object GemsVoTableCatalog {
       b1,
       radiusConstraint(ctx),
       magnitudeConstraints(ctx, mt),
-      catalog
+      catalog,
+      lgs = true
     )
 
 }

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategyParams.scala
@@ -35,7 +35,13 @@ sealed trait SingleProbeStrategyParams {
       mc   <- magnitudeCalc(ctx, mt)
       rc   <- radiusConstraint(ctx)
       ml   <- AgsMagnitude.manualSearchConstraints(mc)
-    } yield CatalogQuery.coneSearch(base.toNewModel, rc, ml, catalogName)
+    } yield {
+      val isLgs = this match {
+        case SingleProbeStrategyParams.AltairAowfsParams => true
+        case _                                           => false
+      }
+      CatalogQuery.coneSearch(base.toNewModel, rc, ml, catalogName, isLgs)
+    }
 
   def radiusConstraint(ctx: ObsContext): Option[RadiusConstraint] =
     RadiusLimitCalc.getAgsQueryRadiusLimits(guideProbe, ctx)

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/mascot/MascotGuideStarSpec.scala
@@ -246,7 +246,7 @@ class MascotGuideStarSpec extends Specification {
     "find best asterism by query result" in {
       val coordinates = Coordinates(RightAscension.fromAngle(Angle.fromHMS(3, 19, 48.2341).getOrElse(Angle.zero)), Declination.fromAngle(Angle.fromDMS(41, 30, 42.078).getOrElse(Angle.zero)).getOrElse(Declination.zero))
 
-      val query = ConeSearchCatalogQuery(None, coordinates, RadiusConstraint.between(Angle.fromArcmin(MascotCat.defaultMinRadius), Angle.fromArcmin(MascotCat.defaultMaxRadius)), Nil, PPMXL)
+      val query = ConeSearchCatalogQuery(None, coordinates, RadiusConstraint.between(Angle.fromArcmin(MascotCat.defaultMinRadius), Angle.fromArcmin(MascotCat.defaultMaxRadius)), Nil, PPMXL, isLgs = true)
       val r = VoTableClient.catalog(query, Some(TestVoTableBackend("/mascotquery.xml")))(implicitly).map { t =>
         val base = new SPTarget(coordinates.ra.toAngle.toDegrees, coordinates.dec.toDegrees)
         val env = TargetEnvironment.create(base)

--- a/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
+++ b/bundle/edu.gemini.catalog/src/main/scala/edu/gemini/catalog/api/CatalogQuery.scala
@@ -96,7 +96,8 @@ final case class ConeSearchCatalogQuery(
   base:                 Coordinates,
   radiusConstraint:     RadiusConstraint,
   magnitudeConstraints: List[MagnitudeConstraints],
-  catalog:              CatalogName
+  catalog:              CatalogName,
+  isLgs:                Boolean
 ) extends CatalogQuery {
 
   val filters: NonEmptyList[QueryResultsFilter] =
@@ -171,12 +172,13 @@ case class NameCatalogQuery(search: String, catalog: CatalogName) extends Catalo
 object CatalogQuery {
 
   def coneSearch(
-    c: edu.gemini.spModel.core.Coordinates,
-    r: RadiusConstraint,
-    m: MagnitudeConstraints,
-    n: CatalogName
+    c:   edu.gemini.spModel.core.Coordinates,
+    r:   RadiusConstraint,
+    m:   MagnitudeConstraints,
+    n:   CatalogName,
+    lgs: Boolean = false
   ): CatalogQuery =
-    ConeSearchCatalogQuery(None, c, r, List(m), n)
+    ConeSearchCatalogQuery(None, c, r, List(m), n, lgs)
 
   def nameSearch(search: String): CatalogQuery =
     NameCatalogQuery(search, CatalogName.SIMBAD)

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/tpe/gems/GemsGuideStarSearchDialog.java
@@ -46,10 +46,10 @@ public class GemsGuideStarSearchDialog extends JFrame {
         SELECTION("Select asterisms to add to the target list.", 1);
 
         // Message to display at top
-        private String _message;
+        private final String _message;
 
         // Index of tab to show in tabbed pane
-        private int _tabIndex;
+        private final int _tabIndex;
 
         State(String message, int tabIndex) {
             _message = message;
@@ -65,7 +65,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         }
     }
 
-    private AbstractAction _useDefaultsAction = new AbstractAction("Use Defaults") {
+    private final AbstractAction _useDefaultsAction = new AbstractAction("Use Defaults") {
         {
             setEnabled(false);
         }
@@ -76,7 +76,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         }
     };
 
-    private AbstractAction _queryAction = new AbstractAction("Query") {
+    private final AbstractAction _queryAction = new AbstractAction("Query") {
         public void actionPerformed(ActionEvent evt) {
             try {
                 query();
@@ -86,19 +86,19 @@ public class GemsGuideStarSearchDialog extends JFrame {
         }
     };
 
-    private AbstractAction _cancelAction = new AbstractAction("Cancel") {
+    private final AbstractAction _cancelAction = new AbstractAction("Cancel") {
         public void actionPerformed(ActionEvent evt) {
             cancel();
         }
     };
 
-    private AbstractAction _stopAction = new AbstractAction("Stop") {
+    private final AbstractAction _stopAction = new AbstractAction("Stop") {
         public void actionPerformed(ActionEvent evt) {
             stop();
         }
     };
 
-    private AbstractAction _analyzeAction = new AbstractAction("Analyze") {
+    private final AbstractAction _analyzeAction = new AbstractAction("Analyze") {
         public void actionPerformed(ActionEvent evt) {
             try {
                 analyze();
@@ -108,7 +108,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         }
     };
 
-    private AbstractAction _addAction = new AbstractAction("Add") {
+    private final AbstractAction _addAction = new AbstractAction("Add") {
         public void actionPerformed(ActionEvent evt) {
             try {
                 add();
@@ -118,7 +118,7 @@ public class GemsGuideStarSearchDialog extends JFrame {
         }
     };
 
-    private static NumberFormat NF = NumberFormat.getInstance(Locale.US);
+    private static final NumberFormat NF = NumberFormat.getInstance(Locale.US);
 
     static {
         NF.setMaximumFractionDigits(1);

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/QueryResultsFrame.scala
@@ -520,10 +520,10 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
         case SelectionChanged(_) =>
           // REL-2910 Set the radius range to the selected guider settings
           selection.item.query.headOption.foreach {
-            case ConeSearchCatalogQuery(_, _, rc, _, _) =>
+            case ConeSearchCatalogQuery(_, _, rc, _, _, _) =>
               radiusStart.updateAngle(rc.minLimit)
               radiusEnd.updateAngle(rc.maxLimit)
-            case _                                      =>
+            case _                                         =>
           }
           updateGuideSpeedText()
           magnitudeFiltersFromControls(selection.item.query.headOption)
@@ -737,7 +737,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
       */
     def magnitudeFiltersFromControls(query: Option[CatalogQuery]): Unit = {
       query.collect {
-        case ConeSearchCatalogQuery(_, _, _, mc, _) =>
+        case ConeSearchCatalogQuery(_, _, _, mc, _, _) =>
           magnitudeControls.clear()
           magnitudeControls ++= mc.zipWithIndex.flatMap(Function.tupled(filterControls))
       }
@@ -863,7 +863,7 @@ object QueryResultsFrame extends Frame with PreferredSizeFrame {
 
         val coordinates = Coordinates(ra.value, dec.value)
         val info = observationInfoFromForm
-        val defaultQuery = ConeSearchCatalogQuery(None, coordinates, radiusConstraint, currentFilters, selectedCatalog)
+        val defaultQuery = ConeSearchCatalogQuery(None, coordinates, radiusConstraint, currentFilters, selectedCatalog, isLgs = true)
 
         // Start with the guider's query and update it with the values on the UI
         val calculatedQuery = guider.selection.item.query.headOption.collect {

--- a/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
+++ b/bundle/jsky.app.ot/src/main/scala/edu/gemini/catalog/ui/package.scala
@@ -70,8 +70,9 @@ case class ObservationInfo(ctx: Option[ObsContext],
                            offsets: Set[Offset],
                            catalog: CatalogName,
                            mt: MagnitudeTable) {
-  def catalogQuery:List[CatalogQuery] = validStrategies.collect {
-      case SupportedStrategy(s, query, _) if s == strategy => query
+  def catalogQuery: List[CatalogQuery] =
+    validStrategies.collect {
+      case SupportedStrategy(s, query, _) if strategy.map(_.strategy).contains(s) => query
     }.flatten
 
   /**


### PR DESCRIPTION
Addresses two issues raised in REL-3919:

1. Hacks in an `isLgs` parameter in order to use different faint limits for LGS guide star searches vs. non-LGS.  Ideally we'd use the actually magnitude limits in the search parameters but for that we need to translate all the AGS limits to `phot_g_mean_mag`.
2. Switches the catalog default to Gemini GAIA instead of ESA GAIA for GeMS manual searches.