### PR TITLE
REL-4020: set a 'rotator' param instead of 'posAngle' for MaroonX

### DIFF
--- a/bundle/edu.gemini.wdba.xmlrpc.server/README.md
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/README.md
@@ -23,6 +23,23 @@ $ curl --data @req.xml http://gsodbtest:8442/wdba
 <?xml version="1.0" encoding="UTF-8"?><methodResponse xmlns:ex="http://ws.apache.org/xmlrpc/namespaces/extensions"><params><param><value><array><data><value><struct><member><name>OBS_ID</name><value>GS-ENG20210827-5</value></member><member><name>TITLE</name><value>GMOS Grating tilt LUT check</value></member></struct></value></data></array></value></param></params></methodResponse>
 ```
 
+### Example TCC configuration fetch
+
+```commandline
+$ cat GetCoordinates.xml 
+<?xml version="1.0"?>
+<methodCall>
+  <methodName>WDBA_Tcc.getCoordinates</methodName>
+  <params>
+    <param>
+      <value><string>GN-2022A-LP-202-54</string></value>
+    </param>
+  </params>
+</methodCall>
+
+$ curl --data @GetCoordinates.xml http://gnodb:8442/wdba | python3 -c 'import html, sys; [print(html.unescape(l), end="") for l in sys.stdin]'
+```
+
 ### Provenance
 
 This bundle originated from `edu.gemini.wdba.xmlrpc.server` in the OCS 1.5 build. It subsumes the following OCS 1.5 bundles, which no longer exist on their own.

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/TccFieldConfig.java
@@ -53,21 +53,16 @@ public class TccFieldConfig extends ParamSet {
         putParameter(TccNames.GUIDE_GROUP, getPrimaryGuideGroupName());
 
         // Add a rotator parameter and then create the config
-        // Note: If the config name contains "Fixed" in some way, it's assumed to be a Fixed rotator config
-        RotatorConfig rc = new RotatorConfig(_oe);
+        final RotatorConfig rc = new RotatorConfig(_oe);
         if (rc.build()) {
-            String rotConfigName = rc.getConfigName();
-            if (rotConfigName.equals(TccNames.ALTAIR_FIXED)) {
-                putParameter(TccNames.ROTATOR, rotConfigName);
-            } else
             // If the instrument adds something, create a rotator config and add it in
-            if (rotConfigName.contains(TccNames.FIXED)) {
-                putParameter(TccNames.ROTATOR, rotConfigName);
-                add(rc);
-            } else {
-                putParameter(TccNames.POSANGLE, rotConfigName);
-                add(rc);
-            }
+            ImOption.apply(rc.attributeValue(TYPE)).foreach(t -> {
+                final String name = rc.getConfigName();
+                putParameter(t, name);
+                if (!TccNames.ALTAIR_FIXED.equals(name)) {
+                    add(rc);
+                }
+            });
         }
 
         GuideConfig gc = new GuideConfig(_oe);

--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/RotatorConfigTest.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/test/java/edu/gemini/wdba/tcc/RotatorConfigTest.java
@@ -13,6 +13,8 @@ import edu.gemini.spModel.gemini.gpi.Gpi;
 import edu.gemini.spModel.gemini.nici.InstNICI;
 import edu.gemini.spModel.gemini.nici.NICIParams;
 import edu.gemini.spModel.gemini.niri.InstNIRI;
+import edu.gemini.spModel.gemini.visitor.VisitorConfig;
+import edu.gemini.spModel.gemini.visitor.VisitorInstrument;
 import org.dom4j.Document;
 import org.dom4j.Element;
 
@@ -52,6 +54,14 @@ public class RotatorConfigTest extends TestBase {
 
     private Gpi addGpi() throws Exception {
         return (Gpi) addInstrument(Gpi.SP_TYPE).getDataObject();
+    }
+
+    private VisitorInstrument addMaroonX() throws Exception {
+        final ISPObsComponent   oc = addInstrument(SPComponentType.INSTRUMENT_VISITOR);
+        final VisitorInstrument vi = (VisitorInstrument) oc.getDataObject();
+        vi.setVisitorConfig(VisitorConfig.MaroonX$.MODULE$);
+        oc.setDataObject(vi);
+        return vi;
     }
 
     private InstGmosSouth addGmos() throws Exception {
@@ -265,6 +275,20 @@ public class RotatorConfigTest extends TestBase {
         val.type  = Type.rotator;
         val.name  = "GPIFixed";
         val.ipa   = "180";
+        val.cosys = TccNames.FIXED;
+        val.validate();
+    }
+
+    @Test public void testMaroonXFixed() throws Exception {
+        VisitorInstrument vi = addMaroonX();
+        vi.setPosAngleDegrees(15.0); // this should be ignored due to Maroon X position angle mode
+        instObsComp.setDataObject(vi);
+
+        RotConfigValidator val = new RotConfigValidator();
+        val.site  = Site.north;
+        val.type  = Type.rotator;
+        val.name  = "fixed";
+        val.ipa   = "0"; // should always be 0 for Maroon X
         val.cosys = TccNames.FIXED;
         val.validate();
     }


### PR DESCRIPTION
Because `fixed` is not the same as `Fixed`, we were adding

```
    <param name="posAngle" value="fixed"/>
```

instead of 

```
    <param name="rotator" value="fixed"/>
```

Hilarity ensued. 