### PR TITLE
REL-4013: hold the lock during sync updates

### DIFF
--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsFailure.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsFailure.scala
@@ -16,68 +16,44 @@ object VcsFailure {
   /** Indicates that the program has no program id. */
   case object MissingId extends VcsFailure
 
-  val missingId: VcsFailure = MissingId
+  /** Indicates that the given program already exists in the database. */
+  case class IdAlreadyExists(id: SPProgramID) extends VcsFailure
 
   /** Indicates that the given program already exists in the database. */
-  final case class IdAlreadyExists(id: SPProgramID) extends VcsFailure
-
-  def idAlreadyExists(id: SPProgramID): VcsFailure = IdAlreadyExists(id)
-
-  /** Indicates that the given program already exists in the database. */
-  final case class KeyAlreadyExists(id: SPProgramID, key: SPNodeKey) extends VcsFailure
-
-  def keyAlreadyExists(id: SPProgramID, key: SPNodeKey): VcsFailure = KeyAlreadyExists(id, key)
+  case class KeyAlreadyExists(id: SPProgramID, key: SPNodeKey) extends VcsFailure
 
   /** Two distinct programs share the same program id. */
-  final case class IdClash(id: SPProgramID, key0: SPNodeKey, key1: SPNodeKey) extends VcsFailure
-
-  def idClash(id: SPProgramID, key0: SPNodeKey, key1: SPNodeKey): VcsFailure = IdClash(id, key0, key1)
+  case class IdClash(id: SPProgramID, key0: SPNodeKey, key1: SPNodeKey) extends VcsFailure
 
   /** The program associated with the given id could not be found. */
-  final case class NotFound(id: SPProgramID) extends VcsFailure
-
-  def notFound(id: SPProgramID): VcsFailure = NotFound(id)
+  case class NotFound(id: SPProgramID) extends VcsFailure
 
   /** Indicates that the user tried to do something for which he doesn't have
     * permission. */
-  final case class Forbidden(why: String) extends VcsFailure
-
-  def forbidden(why: String): VcsFailure = Forbidden(why)
+  case class Forbidden(why: String) extends VcsFailure
 
   /** Indicates that the program you're trying to commit is out of date with
     * respect to the server's version.  Commit only works when the incoming
     * program is strictly newer than the existing version. */
   case object NeedsUpdate extends VcsFailure
 
-  val needsUpdate: VcsFailure = NeedsUpdate
-
   /** Indicates that the program you're trying to commit has conflicts which
     * must be resolved before committing. */
   case object HasConflict extends VcsFailure
 
-  val hasConflict: VcsFailure = HasConflict
-
   /** Indicates that the local program cannot be merged with the remote
     * program.  For example, because it contains executed observations that
     * would be renumbered. */
-  final case class Unmergeable(msg: String) extends VcsFailure
-
-  def unmergeable(msg: String): VcsFailure = Unmergeable(msg)
+  case class Unmergeable(msg: String) extends VcsFailure
 
   /** Indicates an unexpected problem while performing a vcs operation. */
-  final case class Unexpected(msg: String) extends VcsFailure
-
-  def unexpected(msg: String): VcsFailure = Unexpected(msg)
+  case class Unexpected(msg: String) extends VcsFailure
 
   /** Exception thrown while performing a vcs operation. */
-  final case class VcsException(ex: Throwable) extends VcsFailure
-
-  def vcsException(ex: Throwable): VcsFailure = VcsException(ex)
+  case class VcsException(ex: Throwable) extends VcsFailure
 
   /** User cancelled a vcs operation. */
   case object Cancelled extends VcsFailure
-
-  val cancelled: VcsFailure = Cancelled
 
   def idClash(ex: DBIDClashException): VcsFailure =
     IdClash(ex.id, ex.existingKey, ex.newKey)

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsFailure.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsFailure.scala
@@ -16,44 +16,68 @@ object VcsFailure {
   /** Indicates that the program has no program id. */
   case object MissingId extends VcsFailure
 
-  /** Indicates that the given program already exists in the database. */
-  case class IdAlreadyExists(id: SPProgramID) extends VcsFailure
+  val missingId: VcsFailure = MissingId
 
   /** Indicates that the given program already exists in the database. */
-  case class KeyAlreadyExists(id: SPProgramID, key: SPNodeKey) extends VcsFailure
+  final case class IdAlreadyExists(id: SPProgramID) extends VcsFailure
+
+  def idAlreadyExists(id: SPProgramID): VcsFailure = IdAlreadyExists(id)
+
+  /** Indicates that the given program already exists in the database. */
+  final case class KeyAlreadyExists(id: SPProgramID, key: SPNodeKey) extends VcsFailure
+
+  def keyAlreadyExists(id: SPProgramID, key: SPNodeKey): VcsFailure = KeyAlreadyExists(id, key)
 
   /** Two distinct programs share the same program id. */
-  case class IdClash(id: SPProgramID, key0: SPNodeKey, key1: SPNodeKey) extends VcsFailure
+  final case class IdClash(id: SPProgramID, key0: SPNodeKey, key1: SPNodeKey) extends VcsFailure
+
+  def idClash(id: SPProgramID, key0: SPNodeKey, key1: SPNodeKey): VcsFailure = IdClash(id, key0, key1)
 
   /** The program associated with the given id could not be found. */
-  case class NotFound(id: SPProgramID) extends VcsFailure
+  final case class NotFound(id: SPProgramID) extends VcsFailure
+
+  def notFound(id: SPProgramID): VcsFailure = NotFound(id)
 
   /** Indicates that the user tried to do something for which he doesn't have
     * permission. */
-  case class Forbidden(why: String) extends VcsFailure
+  final case class Forbidden(why: String) extends VcsFailure
+
+  def forbidden(why: String): VcsFailure = Forbidden(why)
 
   /** Indicates that the program you're trying to commit is out of date with
     * respect to the server's version.  Commit only works when the incoming
     * program is strictly newer than the existing version. */
   case object NeedsUpdate extends VcsFailure
 
+  val needsUpdate: VcsFailure = NeedsUpdate
+
   /** Indicates that the program you're trying to commit has conflicts which
     * must be resolved before committing. */
   case object HasConflict extends VcsFailure
 
+  val hasConflict: VcsFailure = HasConflict
+
   /** Indicates that the local program cannot be merged with the remote
     * program.  For example, because it contains executed observations that
     * would be renumbered. */
-  case class Unmergeable(msg: String) extends VcsFailure
+  final case class Unmergeable(msg: String) extends VcsFailure
+
+  def unmergeable(msg: String): VcsFailure = Unmergeable(msg)
 
   /** Indicates an unexpected problem while performing a vcs operation. */
-  case class Unexpected(msg: String) extends VcsFailure
+  final case class Unexpected(msg: String) extends VcsFailure
+
+  def unexpected(msg: String): VcsFailure = Unexpected(msg)
 
   /** Exception thrown while performing a vcs operation. */
-  case class VcsException(ex: Throwable) extends VcsFailure
+  final case class VcsException(ex: Throwable) extends VcsFailure
+
+  def vcsException(ex: Throwable): VcsFailure = VcsException(ex)
 
   /** User cancelled a vcs operation. */
   case object Cancelled extends VcsFailure
+
+  val cancelled: VcsFailure = Cancelled
 
   def idClash(ex: DBIDClashException): VcsFailure =
     IdClash(ex.id, ex.existingKey, ex.newKey)
@@ -75,7 +99,7 @@ object VcsFailure {
         "Give your program an id and try again."
 
       case KeyAlreadyExists(i,k)              =>
-        s"Program $i cannot be added because a program with the same internal key already exists in the database."
+        s"Program $i cannot be added because a program with the same internal key ($k) already exists in the database."
 
       case IdAlreadyExists(i)                 =>
         s"Program $i cannot be added because a program with the same ID already exists in the database."

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/VcsServer.scala
@@ -209,7 +209,7 @@ class VcsServer(odb: IDBDatabaseService) { vs =>
 
     VcsAction(recordAndLock()) >>
       // catch exceptions in the calculation of `body` itself
-      (try { body } catch { case e: Throwable => VcsFailure.vcsException(e).liftVcs[A] })
+      (try { body } catch { case e: Throwable => VcsFailure.VcsException(e).liftVcs[A] })
         .run
         .onFinish(_ => Task.delay(checkAndUnlock()))
         .liftVcs

--- a/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/package.scala
+++ b/bundle/edu.gemini.sp.vcs/src/main/scala/edu/gemini/sp/vcs2/package.scala
@@ -87,7 +87,11 @@ package object vcs2 {
     def liftVcs: VcsAction[A] = EitherT(Task.delay(e))
   }
 
-  implicit val ShowConflicts = Show.shows[Conflicts] { c =>
+  implicit class VcsFailureOps(f: => VcsFailure) {
+    def liftVcs[A]: VcsAction[A] = f.left[A].liftVcs
+  }
+
+  implicit val ShowConflicts: Show[Conflicts] = Show.shows[Conflicts] { c =>
     def showNote(cn: Conflict.Note): String =
       cn match {
         case n: Conflict.Moved                  => s"Move(${n.nodeKey}, ${n.to})"


### PR DESCRIPTION
This is a slightly modified version of (#2025) for the release branch.  It was changed to remove insignificant but possibly serialization-incompatible changes.