### PR TITLE
Add optional version token for the itc json servlets

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/servlets/JsonServlet.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/servlets/JsonServlet.scala
@@ -14,7 +14,8 @@ import scalaz._, Scalaz._
  * supported) and responds with a JSON-encoded `ItcResult` on success, or `SC_BAD_REQUEST` with
  * an error message on failure. JSON codecs are defined in package `edu.gemini.itc.web.json`.
  */
-class JsonServlet(versionToken: String = "") extends HttpServlet with ItcParametersCodec with ItcResultCodec {
+class JsonServlet(versionToken: String) extends HttpServlet with ItcParametersCodec with ItcResultCodec {
+  def this() = this("")
 
   override def doPost(req: HttpServletRequest, res: HttpServletResponse) = {
 
@@ -59,6 +60,7 @@ class JsonServlet(versionToken: String = "") extends HttpServlet with ItcParamet
  * an error message on failure. JSON codecs are defined in package `edu.gemini.itc.web.json`.
  */
 class JsonChartServlet(versionToken: String = "") extends HttpServlet with ItcParametersCodec with ItcResultCodec {
+  def this() = this("")
 
   override def doPost(req: HttpServletRequest, res: HttpServletResponse) = {
 

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/servlets/JsonServlet.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/servlets/JsonServlet.scala
@@ -14,7 +14,7 @@ import scalaz._, Scalaz._
  * supported) and responds with a JSON-encoded `ItcResult` on success, or `SC_BAD_REQUEST` with
  * an error message on failure. JSON codecs are defined in package `edu.gemini.itc.web.json`.
  */
-class JsonServlet extends HttpServlet with ItcParametersCodec with ItcResultCodec {
+class JsonServlet(versionToken: String = "") extends HttpServlet with ItcParametersCodec with ItcResultCodec {
 
   override def doPost(req: HttpServletRequest, res: HttpServletResponse) = {
 
@@ -40,7 +40,12 @@ class JsonServlet extends HttpServlet with ItcParametersCodec with ItcResultCode
         res.setStatus(SC_OK)
         res.setContentType("text/json; charset=UTF-8")
         val writer = res.getWriter // can only be called once :-\
-        writer.write(itcRes.asJson.spaces2)
+        val json: Json =
+          if (versionToken.isEmpty)
+            itcRes.asJson
+          else
+            itcRes.asJson.->:(("versionToken", jString(versionToken)))
+        writer.write(json.spaces2)
         writer.close
     }
 
@@ -49,11 +54,11 @@ class JsonServlet extends HttpServlet with ItcParametersCodec with ItcResultCode
 }
 
 /**
- * Servlet that accepts a JSON-encoded `ItcParameters` as its POST payload 
+ * Servlet that accepts a JSON-encoded `ItcParameters` as its POST payload
  * and responds with a JSON-encoded `ItcResult` on success, or `SC_BAD_REQUEST` with
  * an error message on failure. JSON codecs are defined in package `edu.gemini.itc.web.json`.
  */
-class JsonChartServlet extends HttpServlet with ItcParametersCodec with ItcResultCodec {
+class JsonChartServlet(versionToken: String = "") extends HttpServlet with ItcParametersCodec with ItcResultCodec {
 
   override def doPost(req: HttpServletRequest, res: HttpServletResponse) = {
 
@@ -78,7 +83,12 @@ class JsonChartServlet extends HttpServlet with ItcParametersCodec with ItcResul
         res.setStatus(SC_OK)
         res.setContentType("text/json; charset=UTF-8")
         val writer = res.getWriter
-        writer.write(itcRes.asJson.spaces2)
+        val json: Json =
+          if (versionToken.isEmpty)
+            itcRes.asJson
+          else
+            itcRes.asJson.->:(("versionToken", jString(versionToken)))
+        writer.write(json.spaces2)
         writer.close
     }
 


### PR DESCRIPTION
To enable better caching of itc results we need to know if the data or algorithms from the ocs have changed.

This is added only at the edge on the Json servlets for itc rather than in the ITC itself to avoid breaking the TRPC protocol used by the OT