### PR TITLE
Keep obslog from blowing up

### DIFF
--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/instruments/GHOSTLogSegment.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/instruments/GHOSTLogSegment.java
@@ -1,0 +1,120 @@
+package edu.gemini.obslog.instruments;
+
+import edu.gemini.obslog.config.model.OlLogItem;
+import edu.gemini.obslog.core.OlSegmentType;
+import edu.gemini.obslog.obslog.ConfigMap;
+import edu.gemini.obslog.obslog.InstrumentLogSegment;
+import edu.gemini.obslog.obslog.OlLogOptions;
+import edu.gemini.spModel.type.LoggableSpType;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * ObsLog support for visitor instruments
+ */
+public class GHOSTLogSegment extends InstrumentLogSegment {
+    public static final Logger LOG = Logger.getLogger(GHOSTLogSegment.class.getName());
+
+    private static final String NARROW_TYPE = "GHOST";
+    public static final OlSegmentType SEG_TYPE = new OlSegmentType(NARROW_TYPE);
+
+    private static final String SEGMENT_CAPTION = "GHOST Observing Log";
+
+    private String EMPTY_STRING = "";
+
+    private static final String NAME_KEY         = "name";
+    private static final String EXPOSURETIME_KEY = "exposureTime";
+
+    public GHOSTLogSegment(List<OlLogItem> logItems, OlLogOptions obsLogOptions) {
+        super(SEG_TYPE, logItems, obsLogOptions);
+    }
+
+    private static abstract class SimpleDecorator {
+        private String key;
+
+        SimpleDecorator(String key) {
+            this.key = key;
+        }
+
+        void decorate(ConfigMap map) {
+            if (map == null) return;
+
+            String strval = map.sget(key);
+            if (strval == null) return;
+
+            LoggableSpType val;
+            try {
+                val = lookup(strval);
+                map.put(key, val.logValue());
+            } catch (Exception ex) {
+                LOG.log(Level.WARNING, "Unknown " + key + " value: " + strval);
+                map.put(key, strval);
+            }
+        }
+
+        abstract LoggableSpType lookup(String value);
+    }
+
+    private static final SimpleDecorator NAME_DECORATOR = new SimpleDecorator(NAME_KEY) {
+        LoggableSpType lookup(final String value) {
+            return new NameLoggableSpType(value);
+        }
+    };
+
+    private void _decorateExposureTime(ConfigMap map) {
+        if (map == null) return;
+
+        final String exposureTimeValue = map.sget(EXPOSURETIME_KEY);
+        if (exposureTimeValue == null) {
+            LOG.severe("No exposureTime property in GHOST Instrument items");
+        } else {
+            map.put(EXPOSURETIME_KEY, exposureTimeValue);
+        }
+    }
+
+    /**
+     * Given an ObservationData object, create its possibly specialized bean
+     * data.  This method is a factory for the particular segments type of bean
+     * data.
+     *
+     * @param map <code>UniqueConfigMap</code>
+     */
+    public void decorateObservationData(ConfigMap map) {
+        NAME_DECORATOR.decorate(map);
+        _decorateExposureTime(map);
+    }
+
+    /**
+     * Return the segment caption.
+     *
+     * @return The caption.
+     */
+    public String getSegmentCaption() {
+        return SEGMENT_CAPTION;
+    }
+
+    private static class NameLoggableSpType implements LoggableSpType {
+        private final String value;
+
+        public NameLoggableSpType(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String logValue() {
+            return value;
+        }
+
+        @Override
+        public String name() {
+            return "Name";
+        }
+
+        @Override
+        public int ordinal() {
+            return 0;
+        }
+    }
+}

--- a/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/InstrumentSegmentBuilder.java
+++ b/bundle/edu.gemini.obslog/src/main/java/edu/gemini/obslog/obslog/InstrumentSegmentBuilder.java
@@ -129,6 +129,8 @@ public class InstrumentSegmentBuilder {
             return new VisitorInstrumentLogSegment(logData.getLogTableData(), _getObsLogOptions());
         } else if (type.equals(GpiLogSegment.SEG_TYPE)) {
             return new GpiLogSegment(logData.getLogTableData(), _getObsLogOptions());
+        } else if (type.equals(GHOSTLogSegment.SEG_TYPE)) {
+            return new GHOSTLogSegment(logData.getLogTableData(), _getObsLogOptions());
         }
         // Default catches unknown instruments
         return new UnknownLogSegment(logData.getLogTableData(), _getObsLogOptions());

--- a/bundle/edu.gemini.obslog/src/main/resources/ObsLogConfig.xml
+++ b/bundle/edu.gemini.obslog/src/main/resources/ObsLogConfig.xml
@@ -976,6 +976,18 @@
         <entry key="datasetcomments"/>
     </logEntry>
 
+    <logEntry key="GHOST">
+        <entry key="observationid"/>
+        <entry key="datasetut"/>
+        <entry key="datalabels"/>
+        <entry key="filename"/>
+        <entry key="targetname"/>
+        <entry key="observe_exposuretime"/>
+        <entry key="comment"/>
+        <entry key="observe_status"/>
+        <entry key="datasetcomments"/>
+    </logEntry>
+
     <logEntry key="GPI">
         <entry key="observationid"/>
         <entry key="datasetut"/>


### PR DESCRIPTION
Currently the obslog will quit with an exception if it encounters a GHOST observation.  I've copied the visitor instrument log setup and lightly edited it for GHOST so that it will at least continue to work.  The PR does not attempt to produce a great or even useful GHOST obslog.

<img width="1639" alt="Screen Shot 2022-09-12 at 11 51 14" src="https://user-images.githubusercontent.com/4906023/189685831-0cda4ebd-66e0-43cc-802c-a8f618e645df.png">
