### PR TITLE
uncomment negative lst handler

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -119,7 +119,9 @@ object HS2Spec extends Specification with ScalaCheck {
       runSearch(Search.MajorBody("mar")).map(_.take(5)) must_== \/-(List(
         Row(HD.MajorBody(4), "Mars Barycenter"),
         Row(HD.MajorBody(499), "Mars"),
-        Row(HD.MajorBody(723), "Margaret")
+        Row(HD.MajorBody(723), "Margaret"),
+        Row(HD.MajorBody(65803), "Didymos (primary body)"), // RCN: these two cases started showing
+        Row(HD.MajorBody(136199), "Eris (primary body)")    //  up in October of 2022 (no idea why)
       ))
     }
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/ImprovedSkyCalcMethods.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/ImprovedSkyCalcMethods.java
@@ -922,9 +922,9 @@ public class ImprovedSkyCalcMethods {
             sid_g = sid_g + 1.0027379093 * ut - longit / 24.;
             sid_int = (long) sid_g;
             sid_g = (sid_g - sid_int) * 24.;
-    //        if (sid_g < 0.) {
-    //            sid_g = sid_g + 24.;
-    //        }
+           if (sid_g < 0.) {
+               sid_g = sid_g + 24.;
+           }
             return (sid_g);
         }
 

--- a/bundle/edu.gemini.util.skycalc/src/main/java/edu/gemini/skycalc/ImprovedSkyCalcMethods.java
+++ b/bundle/edu.gemini.util.skycalc/src/main/java/edu/gemini/skycalc/ImprovedSkyCalcMethods.java
@@ -1082,9 +1082,9 @@ public class ImprovedSkyCalcMethods {
 	        sid_g = sid_g + 1.0027379093 * ut - longit / 24.;
 	        sid_int = (long) sid_g;
 	        sid_g = (sid_g - sid_int) * 24.;
-	//        if (sid_g < 0.) {
-	//            sid_g = sid_g + 24.;
-	//        }
+	       if (sid_g < 0.) {
+	           sid_g = sid_g + 24.;
+	       }
 	        return (sid_g);
 	    }
 


### PR DESCRIPTION
This has been commented out forever but it's actually a case that happens and it was messing up the RA bucket calculation in ITAC. We'll see if it breaks any testcases.

Ok well a HORIZONS testcase is failing because a sample query we're using just started returning more answers. Not important, just added those to the testcase.