### PR TITLE
Return ghost observing wavelength

### DIFF
--- a/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
+++ b/bundle/edu.gemini.wdba.xmlrpc.server/src/main/java/edu/gemini/wdba/tcc/GhostSupport.java
@@ -27,7 +27,7 @@ final public class GhostSupport implements ITccInstrumentSupport {
 
     @Override
     public String getWavelength() {
-        return null;
+        return "0.655";
     }
 
     @Override


### PR DESCRIPTION
My understanding is that we return this in microns, It was specified as 655 nanometers