### PR TITLE
REL-4205: copy/paste targets and coordinates

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPSkyObject.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPSkyObject.scala
@@ -1,6 +1,7 @@
 package edu.gemini.spModel.target
 
 import edu.gemini.spModel.core.Coordinates
+import edu.gemini.shared.util.immutable.ImOption
 import edu.gemini.shared.util.immutable.{Option => GOption}
 import edu.gemini.skycalc.{ Coordinates => SCoordinates }
 
@@ -12,6 +13,9 @@ abstract class SPSkyObject extends WatchablePos {
   def getSkycalcCoordinates(time: GOLong): GOption[SCoordinates]
 
   def getCoordinates(time: Option[Long]): Option[Coordinates]
+
+  def getCoordinatesAsJava(time: GOLong): GOption[Coordinates] =
+    ImOption.fromScalaOpt(getCoordinates(time.toScalaOpt.map(_.longValue)))
 
   def setRaDegrees(ra: Double): Unit
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1312,7 +1312,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                 final TableTargetSelection s = (TableTargetSelection) contents;
                 final SPTarget tSrc = s.getTarget();
 
-                // Paste: garget -> target
+                // Paste: target -> target
                 final Option<SPTarget> tOpt = TargetSelection.getTargetForNode(env, obsComponent);
                 tOpt.foreach(t -> {
                     t.setTarget(tSrc.getTarget());


### PR DESCRIPTION
Allows both targets and coordinates in the OT target environment table to be copied and pasted interchangeably.