### PR TITLE
REL-4002: copy/paste incompatible asterism + instrument

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/nsp/SPTreeEditUtil.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/nsp/SPTreeEditUtil.java
@@ -14,6 +14,7 @@ import edu.gemini.pot.sp.validator.NodeCardinality;
 import edu.gemini.pot.sp.validator.NodeType;
 import edu.gemini.pot.sp.validator.Validator$;
 import edu.gemini.pot.spdb.IDBDatabaseService;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.obscomp.SPNote;
 import edu.gemini.spModel.seqcomp.SeqBase;
@@ -138,6 +139,7 @@ public class SPTreeEditUtil {
         if (node instanceof ISPObsComponent &&
                 parent instanceof ISPObsComponentContainer) {
             ((ISPObsComponentContainer)parent).addObsComponent((ISPObsComponent)node);
+            ImOption.apply(parent.getContextObservation()).foreach(o -> AsterismEditUtil.matchAsterismToInstrument(o));
             return true;
         }
         if (node instanceof ISPGroup && parent instanceof ISPGroupContainer) {
@@ -575,6 +577,7 @@ public class SPTreeEditUtil {
 
         public void apply() {
             target.setDataObject(source.getDataObject());
+            ImOption.apply(target.getContextObservation()).foreach(o -> AsterismEditUtil.matchAsterismToInstrument(o));
         }
     }
 
@@ -674,7 +677,7 @@ public class SPTreeEditUtil {
         }
     }
 
-      /**
+    /**
      * Move the given ISPNodes to the new parent ISPNode.
      *
      * If the nodes are obsComponents (excepting Notes) or sequenceComponents that already exists in the new

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/AddObsCompAction.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/action/AddObsCompAction.java
@@ -43,7 +43,7 @@ public class AddObsCompAction extends AbstractViewerAction implements Comparable
             final ISPObsComponent toAdd =
                 viewer.getFactory().createObsComponent(getProgram(), componentType, init.getOrNull(), null);
 
-            parent.addObsComponent(toAdd);
+            SPTreeEditUtil.addNode(getProgram(), parent, toAdd);
         } catch (Exception ex) {
             DialogUtil.error(ex);
         }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/nsp/AsterismEditUtil.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/nsp/AsterismEditUtil.scala
@@ -1,0 +1,88 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package jsky.app.ot.nsp
+
+import edu.gemini.pot.sp.ISPObsComponent
+import edu.gemini.pot.sp.ISPObservation
+import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.spModel.gemini.ghost.GhostAsterism
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.GuideFiberState.Enabled
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostTarget
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.env.Asterism
+import edu.gemini.spModel.target.env.UserTarget
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+import edu.gemini.spModel.util.SPTreeUtil
+import scalaz.NonEmptyList
+
+object AsterismEditUtil {
+
+  private def switchAsterism(
+    tn:  ISPObsComponent,
+    toc: TargetObsComp,
+    ast: Asterism,
+    f:   SPTarget => Asterism
+  ): Unit = {
+
+    val newAsterism =
+      f(ast.allSpTargets.head.clone)
+
+    val userTargets =
+      ast.allSpTargets
+        .tail
+        .map(u => new UserTarget(UserTarget.Type.other, u.clone))
+        .toList
+        .asImList
+
+    val oldEnv = toc.getTargetEnvironment
+
+    val env =
+      oldEnv
+        .setAsterism(newAsterism)
+        .setUserTargets(userTargets.append(oldEnv.getUserTargets))
+
+    toc.setTargetEnvironment(env)
+    tn.setDataObject(toc)
+
+  }
+
+  private def switchToGhostAsterism(
+    tn:  ISPObsComponent,
+    toc: TargetObsComp,
+    ast: Asterism
+  ): Unit =
+    switchAsterism(
+      tn,
+      toc,
+      ast,
+      t => GhostAsterism.SingleTarget(GhostTarget(t, Enabled), None)
+    )
+
+  private def switchToDefaultAsterism(
+    tn:  ISPObsComponent,
+    toc: TargetObsComp,
+    gst: GhostAsterism
+  ): Unit =
+    switchAsterism(
+      tn,
+      toc,
+      gst,
+      Asterism.Single(_)
+    )
+
+  def matchAsterismToInstrument(obs: ISPObservation): Unit =
+    for {
+      tn <- Option(SPTreeUtil.findTargetEnvNode(obs))
+      toc = tn.getDataObject.asInstanceOf[TargetObsComp]
+      a   = toc.getAsterism
+      i  <- Option(SPTreeUtil.findInstrument(obs)).map(_.getType)
+    } (i, a) match {
+      case (SPComponentType.INSTRUMENT_GHOST, _: GhostAsterism) => // do nothing
+      case (SPComponentType.INSTRUMENT_GHOST, a)                => switchToGhostAsterism(tn, toc, a)
+      case (_, g: GhostAsterism)                                => switchToDefaultAsterism(tn, toc, g)
+      case _                                                    => // do nothing
+    }
+
+}


### PR DESCRIPTION
We developed a type tree / cardinality validity checker for science programs when we were working on program synchronization.  It works reasonably well but now we're confronted with an issue it cannot handle.  In particular, asterisms are stored in the target component but nevertheless tied to particular instruments.  The GHOST asterisms only apply to GHOST observations, and the non-GHOST single target asterism cannot be used with GHOST.  The validity checker doesn't prevent incpompatibilies because it doesn't drill into the component content but rather bases its decisions on component type alone.

This PR introduces an OT hack to prevent the worst issues that can arise.  After an observation component is pasted or added, an asterism/instrument compatibility check is performed and the asterism is adjusted if necessary.  Fixing or preventing incompatibilities at a lower level would be ideal, but risks program synchronization problems. 