### PR TITLE
REL-4210: use Site coords in horizons queries

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiHorizonsConstants.java
+++ b/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiHorizonsConstants.java
@@ -1,5 +1,8 @@
 package edu.gemini.horizons.server.backend;
 
+import edu.gemini.spModel.core.Angle$;
+import edu.gemini.spModel.core.Site;
+
 /**
  * Define a set of constants to be used to talk to the CGI
  * offered by the JPL Horizons service
@@ -27,8 +30,15 @@ public final class CgiHorizonsConstants {
     public static final String COORD_TYPE = "COORD_TYPE";
     public static final String COORD_TYPE_GEO = "GEODETIC";
     public static final String SITE_COORD = "SITE_COORD";
-    public static final String SITE_COORD_GS = "'289.23944,-30.237778,2.743'";
-    public static final String SITE_COORD_GN = "'204.53094,19.823806,4.2134'";
+
+    public static String formatSiteCoord(Site site) {
+        return String.format(
+            "'%1.6f,%1.6f,%1.3f'",
+            Angle$.MODULE$.fromDegrees(site.longitude).toDegrees(),
+            site.latitude,
+            site.altitude / 1000.0
+        );
+    }
 
     public static final String EXTRA_PRECISION = "extra_prec";
     public static final String TIME_DIGITS     = "time_digits";

--- a/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiQueryExecutor.java
+++ b/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiQueryExecutor.java
@@ -1,8 +1,6 @@
 package edu.gemini.horizons.server.backend;
 
 import edu.gemini.shared.util.immutable.ImOption;
-import edu.gemini.spModel.core.Angle;
-import edu.gemini.spModel.core.Angle$;
 import edu.gemini.spModel.core.Site;
 
 import edu.gemini.horizons.api.HorizonsException;

--- a/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiQueryExecutor.java
+++ b/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiQueryExecutor.java
@@ -1,6 +1,8 @@
 package edu.gemini.horizons.server.backend;
 
 import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.spModel.core.Angle;
+import edu.gemini.spModel.core.Angle$;
 import edu.gemini.spModel.core.Site;
 
 import edu.gemini.horizons.api.HorizonsException;
@@ -111,10 +113,8 @@ public enum CgiQueryExecutor implements IQueryExecutor {
      * @param query the query to be executed. Contains the site information
      */
     private void _initSite(final HorizonsQuery query, final Map<String, String> queryParams) {
-        queryParams.put(CgiHorizonsConstants.SITE_COORD,
-                query.getSite() == Site.GN ?
-                        CgiHorizonsConstants.SITE_COORD_GN :
-                        CgiHorizonsConstants.SITE_COORD_GS);
+        final Site site = query.getSite();
+        queryParams.put(CgiHorizonsConstants.SITE_COORD, CgiHorizonsConstants.formatSiteCoord(site));
     }
 
     /**

--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -154,12 +154,6 @@ object HorizonsService2 {
     def formatDate(date: Date): String =
       s"'${DateFormat.format(date.toInstant)}'"
 
-    def siteCoord(site: Site): String =
-      site match {
-        case Site.GN => SITE_COORD_GN
-        case Site.GS => SITE_COORD_GS
-      }
-
     def toEphemeris(r: HorizonsReply): Long ==>> E =
       ==>>.fromList {
         r.getEphemeris.asScala.toList.map { e =>
@@ -178,7 +172,7 @@ object HorizonsService2 {
         CENTER           -> CENTER_COORD,
         COORD_TYPE       -> COORD_TYPE_GEO,
         COMMAND          -> s"'${target.queryString}'",
-        SITE_COORD       -> siteCoord(site),
+        SITE_COORD       -> formatSiteCoord(site),
         START_TIME       -> formatDate(start),
         STOP_TIME        -> formatDate(stop),
         STEP_SIZE        -> s"${stepSize}m",


### PR DESCRIPTION
Uses core `Site` to extract site coordinates instead of a separate constant.