### PR TITLE
REL-4211: fix ephemeris parsing

### DIFF
--- a/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiHorizonsConstants.java
+++ b/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiHorizonsConstants.java
@@ -43,6 +43,7 @@ public final class CgiHorizonsConstants {
     public static final String EXTRA_PRECISION = "extra_prec";
     public static final String TIME_DIGITS     = "time_digits";
     public static final String FRACTIONAL_SEC  = "FRACSEC";
+    public static final String QUANTITIES      = "QUANTITIES";
 
     public static final String YES = "YES";
     public static final String NO = "NO";

--- a/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiReplyBuilder.java
+++ b/bundle/edu.gemini.horizons.api/src/main/java/edu/gemini/horizons/server/backend/CgiReplyBuilder.java
@@ -415,6 +415,11 @@ public class CgiReplyBuilder {
         } catch (NumberFormatException ex) {
             airmass = -1;
         }
+
+        // Next quantity is extinction (which we get for free along with airmass) but we don't
+        // care about it so we skip it.
+        scanner.next();
+
         double magnitude;
         String strMag;
         try {

--- a/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
+++ b/bundle/edu.gemini.horizons.api/src/main/scala/edu/gemini/horizons/server/backend/HS2.scala
@@ -177,7 +177,8 @@ object HorizonsService2 {
         STOP_TIME        -> formatDate(stop),
         STEP_SIZE        -> s"${stepSize}m",
         EXTRA_PRECISION  -> YES,
-        TIME_DIGITS      -> FRACTIONAL_SEC
+        TIME_DIGITS      -> FRACTIONAL_SEC,
+        QUANTITIES       -> "'1,3,8,9'" // see 3. Observer Table at https://ssd.jpl.nasa.gov/horizons/manual.html#output
       )
 
     val replyType = target match {

--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -14,14 +14,20 @@ import org.specs2.mutable.Specification
   */
 object HS2Spec extends Specification with ScalaCheck {
 
-  import HorizonsService2.{ HS2Error, Row, Search, search, lookupEphemeris, EphemerisEmpty }
-  import edu.gemini.spModel.core.{ HorizonsDesignation => HD, Site, Ephemeris }
-
+  import HorizonsService2.{ HS2Error, Row, Search, search, lookupEphemeris, lookupEphemerisE, EphemerisEmpty }
+  import edu.gemini.spModel.core.{ HorizonsDesignation => HD, Semester, Site, Ephemeris }
+  import edu.gemini.horizons.api.EphemerisEntry
+  
   def runSearch[A](s: Search[A]): HS2Error \/ List[Row[A]] =
     search(s).run.unsafePerformIO
 
   def runLookup(d: HD, n: Int): HS2Error \/ Ephemeris =
     lookupEphemeris(d, Site.GS, n).run.unsafePerformIO
+
+  def runLookupE(d: HD, n: Int): HS2Error \/ (Long ==>> EphemerisEntry) = {    
+    val sem = Semester.parse("2023A") // pick a point in time    
+    lookupEphemerisE(d, Site.GS, sem.getStartDate(Site.GS), sem.getEndDate(Site.GS), n)(_.some).run.unsafePerformIO
+  }
 
   "comet search" should {
 
@@ -173,6 +179,29 @@ object HS2Spec extends Specification with ScalaCheck {
 
     "return an empty ephemeris on bogus lookup" in {
       runLookup(HD.Comet("29134698698376"), 100).map(_.size) must_== -\/(EphemerisEmpty)
+    }
+
+  }
+
+  "ephemeris element lookup" should {
+
+    // sanity check with a known ephemeris, to catch changes in output format
+    "return a correct ephemeris for Halley (comet)" in {
+      val result = runLookupE(HD.Comet("1P"), 10).toOption.map(_.toList.map(_.toString.replace('\t', ' ')))
+      // result.foreach(_.foreach(println))
+      result must_== Some(List(
+        "(1675184400000,2023-Jan-31 17:00:00 UTC 08:17:44.423 +02:15:52.58 -4.29131 1.183281 -1.0 25.535)",
+        "(1676748600000,2023-Feb-18 19:30:00 UTC 08:15:43.624 +02:25:31 -3.88567 1.474407 -1.0 25.54)",
+        "(1678312800000,2023-Mar-08 22:00:00 UTC 08:14:01.534 +02:36:42.31 -3.10269 1.605413 2.3 25.55)",
+        "(1679877000000,2023-Mar-27 00:30:00 UTC 08:12:47.94 +02:48:16.16 -2.01608 1.573011 1.192 25.565)",
+        "(1681441200000,2023-Apr-14 03:00:00 UTC 08:12:09.054 +02:59:03.78 -0.74028 1.38962 2.016 25.583)",
+        "(1683005400000,2023-May-02 05:30:00 UTC 08:12:07.022 +03:08:06.46 0.577456 1.085775 -1.0 25.601)",
+        "(1684569600000,2023-May-20 08:00:00 UTC 08:12:40.294 +03:14:39.1 1.767352 0.701981 -1.0 25.619)",
+        "(1686133800000,2023-Jun-07 10:30:00 UTC 08:13:44.373 +03:18:12.92 2.707549 0.271758 -1.0 25.634)",
+        "(1687698000000,2023-Jun-25 13:00:00 UTC 08:15:12.407 +03:18:36.17 3.351082 -0.17043 20.718 25.646)",
+        "(1689262200000,2023-Jul-13 15:30:00 UTC 08:16:56.008 +03:15:51.91 3.688434 -0.58833 1.412 25.653)",
+        "(1690826400000,2023-Jul-31 18:00:00 UTC 08:18:45.968 +03:10:17.27 3.734413 -0.95298 1.306 25.655)"
+      ))
     }
 
   }


### PR DESCRIPTION
At some point Horizons started sending many more columns than we expected, which resulted in incorrect values for RA/Dec tracking and apparent magnitude. This PR adds an explicit column selection to the HTTP request, makes a change to the parser since we can't get back exactly what we were getting before, and adds a sanity test.