### PR TITLE
REL-4161: format 2 decimal places in time accounting editor

### DIFF
--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/progadmin/TimeAcctEditor.java
@@ -21,7 +21,7 @@ final class TimeAcctEditor implements ProgramTypeListener {
     private static final long MS_PER_HOUR = Duration.ofHours(1).toMillis();
 
     // Used to format values as strings
-    private final static DecimalFormat nf = new DecimalFormat("0.#");
+    private final static DecimalFormat nf = new DecimalFormat("0.##");
 
     private static Duration toDuration(double hours) {
         return Duration.ofMillis(Math.round(hours * MS_PER_HOUR));


### PR DESCRIPTION
Shows time accounting information with 2 decimal places of precision.  (The data itself is stored in a `Duration`.)