### PR TITLE
REL-4028: calibration + conditions rule

### DIFF
--- a/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/AbstractRuleTest.java
+++ b/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/AbstractRuleTest.java
@@ -11,6 +11,7 @@ import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.gemini.altair.AltairAowfsGuider;
 import edu.gemini.spModel.gemini.altair.AltairParams;
 import edu.gemini.spModel.gemini.altair.InstAltair;
+import edu.gemini.spModel.gemini.calunit.CalUnitParams;
 import edu.gemini.spModel.gemini.ghost.Ghost;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.gemini.gmos.InstGmosSouth;
@@ -208,16 +209,24 @@ public class AbstractRuleTest {
         obs.getSeqComponent().addSeqComponent(observeSeqComponent);
     }
 
-    protected void addSimpleFlatObserve(int count, double exposureTime, int coadds) throws SPUnknownIDException, SPTreeStateException, SPNodeNotLocalException {
+    protected void addSimpleFlatArcObserve(int count, double exposureTime, int coadds, CalUnitParams.Lamp lamp) throws SPUnknownIDException, SPTreeStateException, SPNodeNotLocalException {
         assert (obs != null);
         ISPSeqComponent observeSeqComponent = fact.createSeqComponent(prog, SeqRepeatFlatObs.SP_TYPE, null);
         SeqRepeatFlatObs seqObserve = (SeqRepeatFlatObs) observeSeqComponent.getDataObject();
         seqObserve.setStepCount(count);
         seqObserve.setExposureTime(exposureTime);
         seqObserve.setCoaddsCount(coadds);
+        seqObserve.setLamp(lamp);
         observeSeqComponent.setDataObject(seqObserve);
         obs.getSeqComponent().addSeqComponent(observeSeqComponent);
+    }
 
+    protected void addSimpleFlatObserve(int count, double exposureTime, int coadds) throws SPUnknownIDException, SPTreeStateException, SPNodeNotLocalException {
+        addSimpleFlatArcObserve(count, exposureTime, coadds, CalUnitParams.Lamp.IR_GREY_BODY_HIGH);
+    }
+
+    protected void addSimpleArcObserve(int count, double exposureTime, int coadds) throws SPUnknownIDException, SPTreeStateException, SPNodeNotLocalException {
+        addSimpleFlatArcObserve(count, exposureTime, coadds, CalUnitParams.Lamp.AR_ARC);
     }
 
     /**

--- a/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/GmosRuleTest.java
+++ b/bundle/edu.gemini.p2checker/src/test/java/edu/gemini/p2checker/rules/GmosRuleTest.java
@@ -122,6 +122,88 @@ public class GmosRuleTest extends AbstractRuleTest {
 
     }
 
+    @Test
+    public void testDayCalAnyConditions() throws Exception {
+
+        addSimpleDarkObserve(1, 1.0, 1);
+        addSiteQuality(
+            SPSiteQuality.ImageQuality.ANY,
+            SPSiteQuality.CloudCover.ANY,
+            SPSiteQuality.SkyBackground.ANY,
+            SPSiteQuality.WaterVapor.ANY
+        );
+
+        final ObservationElements elems = new ObservationElements(obs);
+        final GmosRule rules = new GmosRule();
+        final List<Problem> problems = rules.check(elems).getProblems();
+
+        assertEquals(0, problems.size());
+    }
+
+    @Test
+    public void testDayCalBetterConditions() throws Exception {
+
+        addSimpleDarkObserve(1, 1.0, 1);
+        addSiteQuality(
+            SPSiteQuality.ImageQuality.PERCENT_20,
+            SPSiteQuality.CloudCover.ANY,
+            SPSiteQuality.SkyBackground.ANY,
+            SPSiteQuality.WaterVapor.ANY
+        );
+
+        final ObservationElements elems = new ObservationElements(obs);
+        final GmosRule rules = new GmosRule();
+        final List<Problem> problems = rules.check(elems).getProblems();
+
+        assertEquals(1, problems.size());
+
+        Problem p0 = problems.get(0);
+        assertEquals(Problem.Type.WARNING, p0.getType());
+        assertTrue(p0.toString(), p0.toString().startsWith("Warning:Daytime calibrations should not have conditions constraints."));
+    }
+
+    @Test
+    public void testPartnerCalAnyConditions() throws Exception {
+
+        setDisperserNorth(GmosNorthType.DisperserNorth.B1200_G5301);
+        addSimpleArcObserve(1, 1.0, 1);
+        addSiteQuality(
+            SPSiteQuality.ImageQuality.ANY,
+            SPSiteQuality.CloudCover.ANY,
+            SPSiteQuality.SkyBackground.ANY,
+            SPSiteQuality.WaterVapor.ANY
+        );
+
+        final ObservationElements elems = new ObservationElements(obs);
+        final GmosRule rules = new GmosRule();
+        final List<Problem> problems = rules.check(elems).getProblems();
+
+        assertEquals(0, problems.size());
+    }
+
+    @Test
+    public void testPartnerCalBetterConditions() throws Exception {
+
+        setDisperserNorth(GmosNorthType.DisperserNorth.B1200_G5301);
+        addSimpleArcObserve(1, 1.0, 1);
+        addSiteQuality(
+            SPSiteQuality.ImageQuality.PERCENT_20,
+            SPSiteQuality.CloudCover.ANY,
+            SPSiteQuality.SkyBackground.ANY,
+            SPSiteQuality.WaterVapor.ANY
+        );
+
+        final ObservationElements elems = new ObservationElements(obs);
+        final GmosRule rules = new GmosRule();
+        final List<Problem> problems = rules.check(elems).getProblems();
+
+        assertEquals(1, problems.size());
+
+        Problem p0 = problems.get(0);
+        assertEquals(Problem.Type.WARNING, p0.getType());
+        assertTrue(p0.toString(), p0.toString().startsWith("Warning:GMOS baseline spectrophotometric standards should not have conditions constraints."));
+    }
+
     private void checkZeroExp(ISPObservation observation) {
         ObservationElements elems = new ObservationElements(observation);
         GmosRule rules = new GmosRule();
@@ -146,6 +228,12 @@ public class GmosRuleTest extends AbstractRuleTest {
         obs.getSeqComponent().setSeqComponents(new ArrayList<ISPSeqComponent>());
         addSimpleDarkObserve(1, 0.0, 1);
 
+        addSiteQuality(
+            SPSiteQuality.ImageQuality.ANY,
+            SPSiteQuality.CloudCover.ANY,
+            SPSiteQuality.SkyBackground.ANY,
+            SPSiteQuality.WaterVapor.ANY
+        );
         checkZeroExp(obs);
 
         // Check with flat
@@ -176,6 +264,12 @@ public class GmosRuleTest extends AbstractRuleTest {
     private void setFilterNorth(GmosNorthType.FilterNorth filter) {
         InstGmosNorth gmosDataObject = (InstGmosNorth) gmosComponent.getDataObject();
         gmosDataObject.setFilterNorth(filter);
+        gmosComponent.setDataObject(gmosDataObject);
+    }
+
+    private void setDisperserNorth(GmosNorthType.DisperserNorth disperser) {
+        InstGmosNorth gmosDataObject = (InstGmosNorth) gmosComponent.getDataObject();
+        gmosDataObject.setDisperserNorth(disperser);
         gmosComponent.setDataObject(gmosDataObject);
     }
 


### PR DESCRIPTION
Adds a new P2 Checker rule for GMOS calibrations with non-Any/Any/Any/Any conditions.