### PR TITLE
REL-4193: A Very Special GHOST PWFS AGS Strategy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "ocs"
 organization in Global := "edu.gemini.ocs"
 
 // true indicates a test release, and false indicates a production release
-ocsVersion in ThisBuild := OcsVersion("2021B", true, 1, 1, 2)
+ocsVersion in ThisBuild := OcsVersion("2023A", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2023A", false, 1, 1, 1)
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GhostStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/GhostStrategy.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.ags.impl
+
+import edu.gemini.ags.api.{AgsAnalysis, AgsMagnitude, AgsStrategy, ProbeCandidates}
+import edu.gemini.catalog.api.CatalogQuery
+import edu.gemini.spModel.ags.AgsStrategyKey
+import edu.gemini.spModel.ags.AgsStrategyKey.{GhostPwfs1Key, GhostPwfs2Key}
+import edu.gemini.spModel.core.{BandsList, SiderealTarget}
+import edu.gemini.spModel.gemini.ghost.GhostAsterism
+import edu.gemini.spModel.guide.{GuideProbe, ValidatableGuideProbe}
+import edu.gemini.spModel.obs.context.ObsContext
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+/**
+ * The GHOST AGS strategy is essentially a PWFS strategy which treats the
+ * unlinked base position (if any) of the single target mode as the base
+ * position.  In other words, if Single Target with overridden base position
+ * we ignore the override and use the single target as the base.  If any other
+ * version of GHOST asterism (like Dual Target), we continue to use the
+ * actual base position.
+ */
+final case class GhostStrategy(key: AgsStrategyKey, delegate: AgsStrategy) extends AgsStrategy {
+
+  private def adjContext(ctx: ObsContext): ObsContext = {
+    val env = ctx.getTargets()
+    env.getAsterism match {
+      case GhostAsterism.SingleTarget(t, Some(_)) =>
+        // Single target w/o overridden base so that the guide star search works
+        // as if the base position is the single target.
+        ctx.withTargets(env.setAsterism(GhostAsterism.SingleTarget(t, None)))
+      case _                                      =>
+        ctx
+    }
+  }
+
+  override def magnitudes(ctx: ObsContext, mt: AgsMagnitude.MagnitudeTable): List[(GuideProbe, AgsMagnitude.MagnitudeCalc)] =
+    delegate.magnitudes(adjContext(ctx), mt)
+
+  override def analyze(ctx: ObsContext, mt: AgsMagnitude.MagnitudeTable): List[AgsAnalysis] =
+    delegate.analyze(adjContext(ctx), mt)
+
+  override def analyze(ctx: ObsContext, mt: AgsMagnitude.MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
+    delegate.analyze(adjContext(ctx), mt, guideProbe, guideStar)
+
+  override def analyzeMagnitude(ctx: ObsContext, mt: AgsMagnitude.MagnitudeTable, guideProbe: ValidatableGuideProbe, guideStar: SiderealTarget): Option[AgsAnalysis] =
+    delegate.analyzeMagnitude(adjContext(ctx), mt, guideProbe, guideStar)
+
+  override def candidates(ctx: ObsContext, mt: AgsMagnitude.MagnitudeTable)(ec: ExecutionContext): Future[List[ProbeCandidates]] =
+    delegate.candidates(adjContext(ctx), mt)(ec)
+
+  override def catalogQueries(ctx: ObsContext, mt: AgsMagnitude.MagnitudeTable): List[CatalogQuery] =
+    delegate.catalogQueries(adjContext(ctx), mt)
+
+  override def estimate(ctx: ObsContext, mt: AgsMagnitude.MagnitudeTable)(ec: ExecutionContext): Future[AgsStrategy.Estimate] =
+    delegate.estimate(adjContext(ctx), mt)(ec)
+
+  override def select(ctx: ObsContext, mt: AgsMagnitude.MagnitudeTable)(ec: ExecutionContext): Future[Option[AgsStrategy.Selection]] =
+    delegate.select(adjContext(ctx), mt)(ec)
+
+  override def guideProbes: List[GuideProbe] =
+    delegate.guideProbes
+
+  override def probeBands: BandsList =
+    delegate.probeBands
+}

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/Strategy.scala
@@ -32,7 +32,9 @@ object Strategy {
   val Pwfs1North      = SingleProbeStrategy(Pwfs1NorthKey,      PwfsParams(Site.GN, PwfsGuideProbe.pwfs1))
   val Pwfs2North      = SingleProbeStrategy(Pwfs2NorthKey,      PwfsParams(Site.GN, PwfsGuideProbe.pwfs2))
   val Pwfs1South      = SingleProbeStrategy(Pwfs1SouthKey,      PwfsParams(Site.GS, PwfsGuideProbe.pwfs1))
+  val GhostPwfs1      = GhostStrategy(GhostPwfs1Key,            Pwfs1South)
   val Pwfs2South      = SingleProbeStrategy(Pwfs2SouthKey,      PwfsParams(Site.GS, PwfsGuideProbe.pwfs2))
+  val GhostPwfs2      = GhostStrategy(GhostPwfs2Key,            Pwfs2South)
 
   val NiciOiwfs       = ScienceTargetStrategy(NiciOiwfsKey,     NiciOiwfsGuideProbe.instance, NiciBandsList)
   val Off             = OffStrategy
@@ -48,6 +50,8 @@ object Strategy {
     AltairAowfs,
     Flamingos2Oiwfs,
     GemsNgs2,
+    GhostPwfs1,
+    GhostPwfs2,
     GmosNorthOiwfs,
     GmosSouthOiwfs,
     GnirsOiwfs,
@@ -91,7 +95,7 @@ object Strategy {
       List(GemsNgs2) ++ oiStategies(ctx, Flamingos2Oiwfs)
     ),
 
-    SPComponentType.INSTRUMENT_GHOST      -> const(List(Pwfs2South, Pwfs1South)),
+    SPComponentType.INSTRUMENT_GHOST      -> const(List(GhostPwfs2, GhostPwfs1)),
 
     SPComponentType.INSTRUMENT_GMOS       -> ((ctx: ObsContext) => {
       val ao = ctx.getAOComponent.asScalaOpt
@@ -122,6 +126,7 @@ object Strategy {
     val isAvailable = GuideProbeUtil.instance.isAvailable(ctx, _: GuideProbe)
     s match {
       case SingleProbeStrategy(_, params, _) => isAvailable(params.guideProbe)
+      case GhostStrategy(_, delegate)        => guidersAvailable(ctx)(delegate)
       case ScienceTargetStrategy(_, gp, _)   => isAvailable(gp)
       case Ngs2Strategy(_, _)                => isAvailable(CanopusWfs.cwfs3) && isAvailable(PwfsGuideProbe.pwfs1)
       case _                                 => false

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ags/AgsStrategyKey.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ags/AgsStrategyKey.scala
@@ -20,6 +20,14 @@ object AgsStrategyKey {
     val id = "F2_OIWFS"
   }
 
+  case object GhostPwfs1Key extends AgsStrategyKey {
+    val id = "GHOST_PWFS1"
+  }
+
+  case object GhostPwfs2Key extends AgsStrategyKey {
+    val id = "GHOST_PWFS2"
+  }
+
   case object GmosNorthOiwfsKey extends AgsStrategyKey {
     val id = "GMOS-N_OIWFS"
   }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -400,10 +400,10 @@ final class Ghost
     GhostScienceAreaGeometry
 
   override def pwfs1VignettingClearance: Angle =
-    edu.gemini.skycalc.Angle.arcsecs(4.7)
+    edu.gemini.skycalc.Angle.arcmins(4.7)
 
   override def pwfs2VignettingClearance: Angle =
-    edu.gemini.skycalc.Angle.arcsecs(4.0)
+    edu.gemini.skycalc.Angle.arcmins(4.0)
 
 }
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -396,9 +396,14 @@ final class Ghost
     CommonStepCalculator.instance.calc(cur, prev).addAll(times)
   }
 
-  override def getVignettableScienceArea: ScienceAreaGeometry = GhostScienceAreaGeometry
+  override def getVignettableScienceArea: ScienceAreaGeometry =
+    GhostScienceAreaGeometry
 
-  override def pwfs2VignettingClearance: Angle = Angle.arcmins(5.5)
+  override def pwfs1VignettingClearance: Angle =
+    edu.gemini.skycalc.Angle.arcsecs(4.7)
+
+  override def pwfs2VignettingClearance: Angle =
+    edu.gemini.skycalc.Angle.arcsecs(4.0)
 
 }
 


### PR DESCRIPTION
When using GHOST in single-target mode with an unlinked base position, we want to make the IFU position work as though it were the base position for the purpose of AGS -- that is, as if the target and base were in fact linked.  (All other GHOST asterisms continue to work with the base position in a normal way.)

To accomplish this, I added a new GHOST strategy that delegates to the normal single probe strategy with an accordingly modified observation context.  It also hacks the PWFS TPE feature to display the probe ranges as if the target were an offset position.