### PR TITLE
REL-4217: asterism-dependent PWFS1 limit

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/api/AgsHash.scala
@@ -115,12 +115,12 @@ object AgsHash {
     strategyKey.foreach {
       case Pwfs1NorthKey | Pwfs1SouthKey =>
         Option(ctx.getInstrument).foreach {
-          _.pwfs1VignettingClearance.getMagnitude.## +=: buf
+          _.pwfs1VignettingClearance(ctx).getMagnitude.## +=: buf
         }
 
       case Pwfs2NorthKey | Pwfs2SouthKey =>
         Option(ctx.getInstrument).foreach {
-          _.pwfs2VignettingClearance.getMagnitude.## +=: buf
+          _.pwfs2VignettingClearance(ctx).getMagnitude.## +=: buf
         }
 
       case Ngs2Key                       =>

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/api/AgsHashSpec.scala
@@ -231,12 +231,12 @@ class AgsHashSpec extends Specification with ScalaCheck with edu.gemini.spModel.
 
     "differ if PWFS1 vignetting clearance changes" in
       forAll { (ctx0: ObsContext, n: InstNIRI, camera2: Niri.Camera) =>
-        testPwfs(ctx0, n, camera2, AgsStrategyKey.Pwfs1NorthKey, _.pwfs1VignettingClearance)
+        testPwfs(ctx0, n, camera2, AgsStrategyKey.Pwfs1NorthKey, _.pwfs1VignettingClearance(ctx0))
       }
 
     "differ if PWFS2 vignetting clearance changes" in
       forAll { (ctx0: ObsContext, n: InstNIRI, camera2: Niri.Camera) =>
-        testPwfs(ctx0, n, camera2, AgsStrategyKey.Pwfs2NorthKey, _.pwfs2VignettingClearance)
+        testPwfs(ctx0, n, camera2, AgsStrategyKey.Pwfs2NorthKey, _.pwfs2VignettingClearance(ctx0))
       }
 
     val GemsKey = agsKey(AgsStrategyKey.Ngs2Key)

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/acqcam/InstAcqCam.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/acqcam/InstAcqCam.java
@@ -21,6 +21,7 @@ import edu.gemini.spModel.data.property.PropertyProvider;
 import edu.gemini.spModel.data.property.PropertySupport;
 import edu.gemini.spModel.gemini.acqcam.AcqCamParams.*;
 import edu.gemini.spModel.gemini.init.ComponentNodeInitializer;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.InstConfigInfo;
 import edu.gemini.spModel.obscomp.InstConstants;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
@@ -553,6 +554,6 @@ public final class InstAcqCam extends SPInstObsComp implements PropertyProvider 
     private static final Angle PWFS1_VIG = Angle.arcmins(5.8);
     private static final Angle PWFS2_VIG = Angle.arcmins(5.3);
 
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -31,6 +31,7 @@ import edu.gemini.spModel.ictd.*;
 import edu.gemini.spModel.inst.ElectronicOffsetProvider;
 import edu.gemini.spModel.inst.ScienceAreaGeometry;
 import edu.gemini.spModel.inst.VignettableScienceAreaInstrument;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime;
@@ -1358,8 +1359,8 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
     private static final Angle PWFS1_VIG = Angle.arcmins(5.8);
     private static final Angle PWFS2_VIG = Angle.arcmins(5.3);
 
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 
     /**
      * Return the configuration for this component.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -24,6 +24,7 @@ import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeProvider;
 import edu.gemini.spModel.inst.ScienceAreaGeometry;
 import edu.gemini.spModel.inst.VignettableScienceAreaInstrument;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime;
@@ -1861,8 +1862,8 @@ public abstract class InstGmosCommon<
     private static final Angle PWFS1_VIG = Angle.arcmins(5.8);
     private static final Angle PWFS2_VIG = Angle.arcmins(5.3);
 
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 
     @Override
     public boolean isCompatibleWithMeanParallacticAngleMode() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gnirs/InstGNIRS.java
@@ -31,6 +31,7 @@ import edu.gemini.spModel.gemini.parallacticangle.ParallacticAngleSupportInst;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeProvider;
 import edu.gemini.spModel.guide.GuideProbeUtil;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.DefaultStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime.CategorizedTime;
@@ -1099,12 +1100,12 @@ public class InstGNIRS extends ParallacticAngleSupportInst implements PropertyPr
     private static final Angle PWFS2_VIG = Angle.arcmins(4.8);
 
     @Override
-    public Angle pwfs1VignettingClearance() {
+    public Angle pwfs1VignettingClearance(ObsContext ctx) {
         return PWFS1_VIG;
     }
 
     @Override
-    public Angle pwfs2VignettingClearance() {
+    public Angle pwfs2VignettingClearance(ObsContext ctx) {
         return PWFS2_VIG;
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gpi/Gpi.java
@@ -23,6 +23,7 @@ import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeConsumer;
 import edu.gemini.spModel.guide.GuideProbeUtil;
 import edu.gemini.spModel.guide.StandardGuideOptions;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime;
@@ -2313,7 +2314,7 @@ public class Gpi extends SPInstObsComp implements PropertyProvider, GuideProbeCo
     private static final Angle PWFS1_VIG = Angle.arcmins(5.3);
     private static final Angle PWFS2_VIG = Angle.arcmins(4.3);
 
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gsaoi/Gsaoi.java
@@ -32,6 +32,7 @@ import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeProvider;
 import edu.gemini.spModel.guide.GuideProbeUtil;
 import edu.gemini.spModel.obs.SPObservation;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.OffsetOverheadCalculator;
@@ -920,7 +921,7 @@ public final class Gsaoi extends SPInstObsComp
     );
 
     private static final Angle PWFS1_VIG = Angle.arcmins(5.8);
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
 
     @Override
     public PosAngleConstraint getPosAngleConstraint() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/michelle/InstMichelle.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/michelle/InstMichelle.java
@@ -20,6 +20,7 @@ import edu.gemini.spModel.data.property.PropertyProvider;
 import edu.gemini.spModel.data.property.PropertySupport;
 import edu.gemini.spModel.gemini.init.ComponentNodeInitializer;
 import edu.gemini.spModel.gemini.michelle.MichelleParams.*;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime.CategorizedTime;
@@ -1039,7 +1040,7 @@ public final class InstMichelle extends SPInstObsComp implements PropertyProvide
     private static final edu.gemini.skycalc.Angle PWFS1_VIG = edu.gemini.skycalc.Angle.arcmins(5.3);
     private static final edu.gemini.skycalc.Angle PWFS2_VIG = edu.gemini.skycalc.Angle.arcmins(4.8);
 
-    @Override public edu.gemini.skycalc.Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public edu.gemini.skycalc.Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public edu.gemini.skycalc.Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public edu.gemini.skycalc.Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/InstNICI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nici/InstNICI.java
@@ -21,6 +21,7 @@ import edu.gemini.spModel.gemini.init.ComponentNodeInitializer;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeProvider;
 import edu.gemini.spModel.guide.GuideProbeUtil;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.OffsetOverheadCalculator;
@@ -904,6 +905,6 @@ public final class InstNICI extends SPInstObsComp implements PropertyProvider, G
     private static final Angle PWFS1_VIG = Angle.arcmins(4.8);
     private static final Angle PWFS2_VIG = Angle.arcmins(4.3);
 
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/InstNIFS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/nifs/InstNIFS.java
@@ -28,6 +28,7 @@ import edu.gemini.spModel.gemini.nifs.NIFSParams.*;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeProvider;
 import edu.gemini.spModel.guide.GuideProbeUtil;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime.CategorizedTime;
@@ -566,6 +567,6 @@ public final class InstNIFS extends SPInstObsComp implements PropertyProvider, G
     private static final Angle PWFS1_VIG = Angle.arcmins(4.8);
     private static final Angle PWFS2_VIG = Angle.arcmins(4.0);
 
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/InstNIRI.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/niri/InstNIRI.java
@@ -34,6 +34,7 @@ import edu.gemini.spModel.gemini.niri.Niri.*;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeProvider;
 import edu.gemini.spModel.guide.GuideProbeUtil;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime;
@@ -823,23 +824,23 @@ public final class InstNIRI extends SPInstObsComp implements PropertyProvider, G
         return new CalibrationKeyImpl(config);
     }
 
-    @Override public Angle pwfs1VignettingClearance() {
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) {
         switch (getCamera()) {
             case F6:     return Angle.arcmins(5.7);
             case F14:    return Angle.arcmins(5.3);
             case F32 :   return Angle.arcmins(4.8);
             case F32_PV: return Angle.arcmins(4.8);
-            default:     return super.pwfs1VignettingClearance();
+            default:     return super.pwfs1VignettingClearance(ctx);
         }
     }
 
-    @Override public Angle pwfs2VignettingClearance() {
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) {
         switch (getCamera()) {
             case F6:     return Angle.arcmins(5.2);
             case F14:    return Angle.arcmins(4.8);
             case F32 :   return Angle.arcmins(4.3);
             case F32_PV: return Angle.arcmins(4.3);
-            default:     return super.pwfs2VignettingClearance();
+            default:     return super.pwfs2VignettingClearance(ctx);
         }
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/InstPhoenix.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/phoenix/InstPhoenix.java
@@ -18,6 +18,7 @@ import edu.gemini.spModel.gemini.init.ComponentNodeInitializer;
 import edu.gemini.spModel.gemini.phoenix.PhoenixParams.Filter;
 import edu.gemini.spModel.gemini.phoenix.PhoenixParams.Mask;
 import edu.gemini.spModel.gemini.visitor.VisitorInstrument;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.DefaultStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime.*;
 import edu.gemini.spModel.obscomp.InstConfigInfo;
@@ -340,7 +341,7 @@ public final class InstPhoenix extends SPInstObsComp implements PropertyProvider
     }
 
     // REL-2346 Use the same Vignetting clearance as Visitors
-    @Override public Angle pwfs1VignettingClearance() { return VisitorInstrument.PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return VisitorInstrument.PWFS2_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return VisitorInstrument.PWFS1_VIG; }
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) { return VisitorInstrument.PWFS2_VIG; }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/texes/InstTexes.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/texes/InstTexes.java
@@ -5,6 +5,7 @@ import edu.gemini.pot.sp.ISPObsComponent;
 import edu.gemini.skycalc.Angle;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.gemini.init.ComponentNodeInitializer;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.obscomp.InstConfigInfo;
 import edu.gemini.spModel.pio.ParamSet;
@@ -236,7 +237,7 @@ public final class InstTexes extends SPInstObsComp implements PropertyProvider {
     private static final Angle PWFS1_VIG = Angle.arcmins(4.8);
     private static final Angle PWFS2_VIG = Angle.arcmins(4.0);
 
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/trecs/InstTReCS.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/trecs/InstTReCS.java
@@ -26,6 +26,7 @@ import edu.gemini.spModel.data.property.PropertyProvider;
 import edu.gemini.spModel.data.property.PropertySupport;
 import edu.gemini.spModel.gemini.init.ComponentNodeInitializer;
 import edu.gemini.spModel.gemini.trecs.TReCSParams.*;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime.CategorizedTime;
@@ -903,7 +904,7 @@ public final class InstTReCS extends SPInstObsComp implements PropertyProvider, 
     private static final edu.gemini.skycalc.Angle PWFS1_VIG = edu.gemini.skycalc.Angle.arcmins(5.3);
     private static final edu.gemini.skycalc.Angle PWFS2_VIG = edu.gemini.skycalc.Angle.arcmins(4.8);
 
-    @Override public edu.gemini.skycalc.Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public edu.gemini.skycalc.Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public edu.gemini.skycalc.Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public edu.gemini.skycalc.Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/VisitorInstrument.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/visitor/VisitorInstrument.java
@@ -20,6 +20,7 @@ import edu.gemini.spModel.gemini.init.ComponentNodeInitializer;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.guide.GuideProbeProvider;
 import edu.gemini.spModel.guide.GuideProbeUtil;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.CommonStepCalculator;
 import edu.gemini.spModel.obs.plannedtime.ExposureCalculator;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime;
@@ -274,7 +275,7 @@ public class VisitorInstrument extends SPInstObsComp
     public static final Angle PWFS1_VIG = Angle.arcmins(5.7);
     public static final Angle PWFS2_VIG = Angle.arcmins(5.2);
 
-    @Override public Angle pwfs1VignettingClearance() { return PWFS1_VIG; }
-    @Override public Angle pwfs2VignettingClearance() { return PWFS2_VIG; }
+    @Override public Angle pwfs1VignettingClearance(ObsContext ctx) { return PWFS1_VIG; }
+    @Override public Angle pwfs2VignettingClearance(ObsContext ctx) { return PWFS2_VIG; }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
@@ -8,6 +8,7 @@ import edu.gemini.spModel.data.AbstractDataObject;
 import edu.gemini.spModel.data.config.IConfig;
 import edu.gemini.spModel.data.config.IParameter;
 import edu.gemini.spModel.data.config.ISysConfig;
+import edu.gemini.spModel.obs.context.ObsContext;
 import edu.gemini.spModel.obs.plannedtime.PlannedTime;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
@@ -405,11 +406,11 @@ public abstract class SPInstObsComp extends AbstractDataObject {
         return wavelength;
     }
 
-    public edu.gemini.skycalc.Angle pwfs1VignettingClearance() {
+    public edu.gemini.skycalc.Angle pwfs1VignettingClearance(ObsContext ctx) {
         return edu.gemini.skycalc.Angle.ANGLE_0DEGREES;
     }
 
-    public edu.gemini.skycalc.Angle pwfs2VignettingClearance() {
+    public edu.gemini.skycalc.Angle pwfs2VignettingClearance(ObsContext ctx) {
         return edu.gemini.skycalc.Angle.ANGLE_0DEGREES;
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/PwfsGuideProbe.java
@@ -33,7 +33,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
 
         @Override public Angle getVignettingClearance(ObsContext ctx) {
             final SPInstObsComp oc = ctx.getInstrument();
-            return (oc == null) ? Angle.ANGLE_0DEGREES : oc.pwfs1VignettingClearance();
+            return (oc == null) ? Angle.ANGLE_0DEGREES : oc.pwfs1VignettingClearance(ctx);
         }
     },
 
@@ -44,7 +44,7 @@ public enum PwfsGuideProbe implements ValidatableGuideProbe, OffsetValidatingGui
 
         @Override public Angle getVignettingClearance(ObsContext ctx) {
             final SPInstObsComp oc = ctx.getInstrument();
-            return (oc == null) ? Angle.ANGLE_0DEGREES : oc.pwfs2VignettingClearance();
+            return (oc == null) ? Angle.ANGLE_0DEGREES : oc.pwfs2VignettingClearance(ctx);
         }
     };
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -8,6 +8,7 @@ import edu.gemini.shared.util.immutable.{Option => JOption}
 import edu.gemini.skycalc.Angle
 import edu.gemini.spModel.config.ConfigPostProcessor
 import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
+import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.data.ISPDataObject
 import edu.gemini.spModel.data.config.{DefaultParameter, DefaultSysConfig, ISysConfig, StringParameter}
@@ -399,10 +400,15 @@ final class Ghost
   override def getVignettableScienceArea: ScienceAreaGeometry =
     GhostScienceAreaGeometry
 
-  override def pwfs1VignettingClearance: Angle =
-    edu.gemini.skycalc.Angle.arcmins(4.7)
+  override def pwfs1VignettingClearance(ctx: ObsContext): Angle = {
+    val limit = ctx.getTargets.getAsterism match {
+      case GhostAsterism.SingleTarget(_, _) => 4.7
+      case _                                => 5.75
+    }
+    edu.gemini.skycalc.Angle.arcmins(limit)
+  }
 
-  override def pwfs2VignettingClearance: Angle =
+  override def pwfs2VignettingClearance(ctx: ObsContext): Angle =
     edu.gemini.skycalc.Angle.arcmins(4.0)
 
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/phoenix/PhoenixSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/phoenix/PhoenixSpec.scala
@@ -16,8 +16,8 @@ class PhoenixSpec extends Specification {
     }
     "Use the same vignetting parameters as Visitor, REL-2436" in {
       val phoenix = new InstPhoenix()
-      phoenix.pwfs1VignettingClearance().toNewModel should beGreaterThan(Angle.zero)
-      phoenix.pwfs2VignettingClearance().toNewModel should beGreaterThan(Angle.zero)
+      phoenix.pwfs1VignettingClearance(null).toNewModel should beGreaterThan(Angle.zero)
+      phoenix.pwfs2VignettingClearance(null).toNewModel should beGreaterThan(Angle.zero)
     }
   }
 }


### PR DESCRIPTION
GHOST PWFS1 inner search range limit for AGS is now asterism-dependent.  Single target mode uses a 4.7' limit while all others use 5.75'.  This required adding a parameter to the PWFS range limit method in order to obtain the chosen asterism.