### PR TITLE
Change the offsets applied to GHOST targets for p2 calculations

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -276,8 +276,8 @@ def cquiroz(version: Version) = AppConfig(
     "-Dedu.gemini.site=south"
   ),
   props = Map(
-    "edu.gemini.spdb.dir"                  -> "/Users/cquiroz/.spdb/",
-    "edu.gemini.auxfile.root"              -> "/Users/cquiroz/.auxfile",
+    "edu.gemini.spdb.dir"                  -> "/Users/carlos.quiroz/.spdb/",
+    "edu.gemini.auxfile.root"              -> "/Users/carlos.quiroz/.auxfile",
     "edu.gemini.dataman.gsa.summit.host"   -> "cpofits-lv1new.cl.gemini.edu",
     "edu.gemini.services.server.start"     -> "false",
     "edu.gemini.util.trpc.name"            -> "Carlos's ODB (Test)",

--- a/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
+++ b/bundle/edu.gemini.horizons.api/src/test/scala/edu/gemini/horizons/server/backend/HS2Spec.scala
@@ -17,15 +17,15 @@ object HS2Spec extends Specification with ScalaCheck {
   import HorizonsService2.{ HS2Error, Row, Search, search, lookupEphemeris, lookupEphemerisE, EphemerisEmpty }
   import edu.gemini.spModel.core.{ HorizonsDesignation => HD, Semester, Site, Ephemeris }
   import edu.gemini.horizons.api.EphemerisEntry
-  
+
   def runSearch[A](s: Search[A]): HS2Error \/ List[Row[A]] =
     search(s).run.unsafePerformIO
 
   def runLookup(d: HD, n: Int): HS2Error \/ Ephemeris =
     lookupEphemeris(d, Site.GS, n).run.unsafePerformIO
 
-  def runLookupE(d: HD, n: Int): HS2Error \/ (Long ==>> EphemerisEntry) = {    
-    val sem = Semester.parse("2023A") // pick a point in time    
+  def runLookupE(d: HD, n: Int): HS2Error \/ (Long ==>> EphemerisEntry) = {
+    val sem = Semester.parse("2023A") // pick a point in time
     lookupEphemerisE(d, Site.GS, sem.getStartDate(Site.GS), sem.getEndDate(Site.GS), n)(_.some).run.unsafePerformIO
   }
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostIfuPatrolField.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostIfuPatrolField.scala
@@ -3,12 +3,11 @@
 
 package edu.gemini.spModel.gemini.ghost
 
-import edu.gemini.spModel.core.{Angle, Coordinates, Offset}
+import edu.gemini.spModel.core.{Angle, Coordinates, Offset, OffsetP, OffsetQ}
 import edu.gemini.spModel.obs.context.ObsContext
 import edu.gemini.spModel.telescope.IssPort
 
 import java.awt.geom.{AffineTransform, Area, Rectangle2D}
-
 import scala.collection.JavaConverters._
 
 
@@ -32,6 +31,20 @@ object GhostIfuPatrolField {
   val ScaleMmToArcsec: Double = 1.0 / 0.61  // arcsec / mm
   val TransformMmToArcsec: AffineTransform =
     AffineTransform.getScaleInstance(ScaleMmToArcsec, ScaleMmToArcsec)
+
+  // From REL-4199 there are offsets to be applied for p2 checks
+  val SRIFU1SeparationOffset: Offset =
+    Offset(OffsetP(Angle.fromArcsecs(-ScaleMmToArcsec)), OffsetQ(Angle.fromArcsecs(ScaleMmToArcsec)))
+
+  val SRIFU2SeparationOffset: Offset =
+    Offset(OffsetP(Angle.zero), OffsetQ(Angle.fromArcsecs(ScaleMmToArcsec)))
+
+  val HRIFUSeparationOffset: Offset =
+    Offset(OffsetP(Angle.zero), OffsetQ(Angle.fromArcsecs(-ScaleMmToArcsec)))
+
+  val HRSkySeparationOffset: Offset =
+    Offset(OffsetP(Angle.zero), OffsetQ(Angle.fromArcsecs(-ScaleMmToArcsec)))
+  // End offsets for REL-4199
 
   val HrSkyFiberOffset: Angle =
     Angle.fromArcsecs(2.0 * ScaleMmToArcsec)


### PR DESCRIPTION
According ot the latest requirements we need to apply different offsets to GHOST targets only for purposes of p2 checks:

SRIFU1: p = -1mm = -1.64 arcsec, q = +1mm = 1.64 arcsec

SRIFU2: p = 0 arcsec, q = +1mm = 1.64 arcsec

HRIFU: p = 0 arcsec, q = -1mm = -1.64 arcsec

HRSKY: p = 0 arcsec, q = -1mm = -1.64 arcsec

