### PR TITLE
REL-4229: adds PRV mode to GHOST HR asterism

### DIFF
--- a/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/rules/ghost/GhostRule.scala
+++ b/bundle/edu.gemini.p2checker/src/main/scala/edu/gemini/p2checker/rules/ghost/GhostRule.scala
@@ -86,7 +86,7 @@ object GhostRule extends IRule {
             base,
             Some(s.coordinates.offset(SRIFU1SeparationOffset.p.toAngle, SRIFU1SeparationOffset.q.toAngle)),
             t.coordinates(when).map(_.offset(SRIFU2SeparationOffset.p.toAngle, SRIFU2SeparationOffset.q.toAngle)))
-        case GhostAsterism.HighResolutionTargetPlusSky(t, sky, _) =>
+        case GhostAsterism.HighResolutionTargetPlusSky(t, sky, _, _) =>
           // The sky position is taken from the user configuration, but the
           // actual SRIFU2 is positioned just south of that.  For the range
           // check we need to use the actual SRIFU2 location.

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
@@ -13,42 +13,72 @@ import java.util.TreeSet;
 import java.util.function.Supplier;
 
 public enum AsterismType implements DisplayableSpType {
-    Single("single", "Single Target", None.instance(), Asterism$.MODULE$::createSingleAsterism),
 
-    GhostSingleTarget("ghostSingleTarget", "Single Target",
-            new Some<>(AsterismConverters.GhostSingleTargetConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptySingleTargetAsterism),
+    Single(
+        "single",
+        "Single Target",
+        ResolutionMode.Standard,
+        None.instance()
+    ),
 
-    GhostDualTarget("ghostDualTarget", "Dual Target",
-            new Some<>(AsterismConverters.GhostDualTargetConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptyDualTargetAsterism),
+    GhostSingleTarget(
+        "ghostSingleTarget",
+         "Single Target",
+         ResolutionMode.GhostStandard,
+         new Some<>(AsterismConverters.GhostSingleTargetConverter$.MODULE$)
+    ),
 
-    GhostTargetPlusSky("ghostTargetPlusSky", "SRIFU1 Target, SRIFU2 Sky",
-            new Some<>(AsterismConverters.GhostTargetPlusSkyConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptyTargetPlusSkyAsterism),
+    GhostDualTarget(
+        "ghostDualTarget",
+        "Dual Target",
+        ResolutionMode.GhostStandard,
+        new Some<>(AsterismConverters.GhostDualTargetConverter$.MODULE$)
+    ),
 
-    GhostSkyPlusTarget("ghostSkyPlusTarget", "SRIFU1 Sky, SRIFU2 Target",
-            new Some<>(AsterismConverters.GhostSkyPlusTargetConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptySkyPlusTargetAsterism),
+    GhostTargetPlusSky(
+        "ghostTargetPlusSky",
+        "SRIFU1 Target, SRIFU2 Sky",
+        ResolutionMode.GhostStandard,
+        new Some<>(AsterismConverters.GhostTargetPlusSkyConverter$.MODULE$)
+    ),
 
-    GhostHighResolutionTargetPlusSky("ghostHRTargetPlusSky", "HRIFU Target, Sky",
-            new Some<>(AsterismConverters.GhostHRTargetPlusSkyConverter$.MODULE$),
-            GhostAsterism$.MODULE$::createEmptyTargetPlusSkyAsterism)
+    GhostSkyPlusTarget(
+        "ghostSkyPlusTarget",
+        "SRIFU1 Sky, SRIFU2 Target",
+        ResolutionMode.GhostStandard,
+        new Some<>(AsterismConverters.GhostSkyPlusTargetConverter$.MODULE$)
+    ),
 
+    GhostHighResolutionTargetPlusSky(
+        "ghostHRTargetPlusSky",
+        "HRIFU Target, Sky",
+        ResolutionMode.GhostHigh,
+        new Some<>(AsterismConverters.GhostHRTargetPlusSkyConverter$.MODULE$)
+    ),
+
+    GhostHighResolutionTargetPlusSkyPrv(
+        "ghostHRTargetPlusSkyPrv",
+        "HRIFU Target, Sky (PRV)",
+        ResolutionMode.GhostPRV,
+        new Some<>(AsterismConverters.GhostHRTargetPlusSkyPrvConverter$.MODULE$)
+    )
     ;
 
     public final String tag;
-    public final Option<AsterismConverters.AsterismConverter> converter;
     public final String displayName;
-    public final Supplier<Asterism> emptyAsterismCreator;
+    public final ResolutionMode resolutionMode;
+    public final Option<AsterismConverters.AsterismConverter> converter;
 
-    AsterismType(final String tag, final String displayName,
-                 final Option<AsterismConverters.AsterismConverter> converter,
-                 final Supplier<Asterism> emptyAsterismCreator) {
-        this.tag                  = tag;
-        this.displayName          = displayName;
-        this.converter            = converter;
-        this.emptyAsterismCreator = emptyAsterismCreator;
+    AsterismType(
+        String tag,
+        String displayName,
+        ResolutionMode resolutionMode,
+        Option<AsterismConverters.AsterismConverter> converter
+    ) {
+        this.tag            = tag;
+        this.displayName    = displayName;
+        this.resolutionMode = resolutionMode;
+        this.converter      = converter;
     }
 
     @Override
@@ -72,6 +102,7 @@ public enum AsterismType implements DisplayableSpType {
             s.add(GhostTargetPlusSky);
             s.add(GhostSkyPlusTarget);
             s.add(GhostHighResolutionTargetPlusSky);
+            s.add(GhostHighResolutionTargetPlusSkyPrv);
             result = Collections.unmodifiableSortedSet(s);
         } else {
             final SortedSet<AsterismType> s = new TreeSet<>();

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/ResolutionMode.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/ResolutionMode.java
@@ -3,38 +3,25 @@ package edu.gemini.spModel.target.env;
 import edu.gemini.spModel.type.DisplayableSpType;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public enum ResolutionMode implements DisplayableSpType {
     // This will be used by every instrument other than GHOST and thus can be considered disjoint;
     // the overlapping name should not make a difference.
-    Standard("standard", "Standard Resolution", Collections.emptyList()),
+    Standard("standard", "Standard Resolution"),
 
-    GhostStandard("ghostStandard", "Standard Resolution",
-            Arrays.asList(
-                    AsterismType.GhostSingleTarget,
-                    AsterismType.GhostDualTarget,
-                    AsterismType.GhostTargetPlusSky,
-                    AsterismType.GhostSkyPlusTarget)
-    ),
-    GhostHigh("ghostHigh", "High Resolution",
-            Collections.singletonList(
-                    AsterismType.GhostHighResolutionTargetPlusSky
-            )),
-    GhostPRV("ghostPRV", "Precision Radial Velocity",
-            Collections.singletonList(
-                    AsterismType.GhostHighResolutionTargetPlusSky
-            ));
+    GhostStandard("ghostStandard", "Standard Resolution"),
+    GhostHigh("ghostHigh", "High Resolution"),
+    GhostPRV("ghostPRV", "Precision Radial Velocity")
+    ;
 
     public final String tag;
     public final String displayName;
-    public final List<AsterismType> asterismTypes;
 
     ResolutionMode(final String tag,
-                   final String displayName,
-                   final List<AsterismType> asterismTypes) {
+                   final String displayName) {
         this.tag           = tag;
         this.displayName   = displayName;
-        this.asterismTypes = asterismTypes;
     }
 
     @Override
@@ -45,5 +32,12 @@ public enum ResolutionMode implements DisplayableSpType {
     @Override
     public String displayValue() {
         return displayName;
+    }
+
+    public SortedSet<AsterismType> asterismTypes() {
+        return Arrays
+            .stream(AsterismType.values())
+            .filter(a -> a.resolutionMode == this)
+            .collect(Collectors.toCollection(() -> new TreeSet<AsterismType>()));
     }
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismConverters.scala
@@ -27,11 +27,11 @@ object AsterismConverters {
       env.getAsterism match {
         case ga: GhostAsterism =>
           ga match {
-            case SingleTarget(t, b)                   => creator(env, t,     None,   None, b).some
-            case DualTarget(t1, t2, b)                => creator(env, t1, t2.some,   None, b).some
-            case TargetPlusSky(t, s, b)               => creator(env, t,     None, s.some, b).some
-            case SkyPlusTarget(s, t, b)               => creator(env, t,     None, s.some, b).some
-            case HighResolutionTargetPlusSky(t, s, b) => creator(env, t,     None, s.some, b).some
+            case SingleTarget(t, b)                      => creator(env, t,     None,   None, b).some
+            case DualTarget(t1, t2, b)                   => creator(env, t1, t2.some,   None, b).some
+            case TargetPlusSky(t, s, b)                  => creator(env, t,     None, s.some, b).some
+            case SkyPlusTarget(s, t, b)                  => creator(env, t,     None, s.some, b).some
+            case HighResolutionTargetPlusSky(t, s, _, b) => creator(env, t,     None, s.some, b).some
           }
         case _                 =>
           None
@@ -87,7 +87,7 @@ object AsterismConverters {
     override def name: String = "GhostAsterism.HighResolutionTargetPlusSky"
 
     override protected def creator(env: TargetEnvironment, t: GhostTarget, t2: Option[GhostTarget], s: SkyPosition, b: BasePosition): TargetEnvironment = {
-      val asterism    = HighResolutionTargetPlusSky(t, s.getOrElse(new SPCoordinates), b)
+      val asterism    = HighResolutionTargetPlusSky(t, s.getOrElse(new SPCoordinates), PrvMode.PrvOff, b)
       val userTargets = appendTarget(env.getUserTargets, gT2UT(t2))
       TargetEnvironment.createWithClonedTargets(asterism, env.getGuideEnvironment, userTargets)
     }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismConverters.scala
@@ -83,16 +83,21 @@ object AsterismConverters {
     }
   }
 
-  case object GhostHRTargetPlusSkyConverter extends GhostAsterismConverter {
-    override def name: String = "GhostAsterism.HighResolutionTargetPlusSky"
-
+  abstract class GhostHrConverter(val prv: PrvMode) extends GhostAsterismConverter {
     override protected def creator(env: TargetEnvironment, t: GhostTarget, t2: Option[GhostTarget], s: SkyPosition, b: BasePosition): TargetEnvironment = {
-      val asterism    = HighResolutionTargetPlusSky(t, s.getOrElse(new SPCoordinates), PrvMode.PrvOff, b)
+      val asterism = HighResolutionTargetPlusSky(t, s.getOrElse(new SPCoordinates), prv, b)
       val userTargets = appendTarget(env.getUserTargets, gT2UT(t2))
       TargetEnvironment.createWithClonedTargets(asterism, env.getGuideEnvironment, userTargets)
     }
   }
 
+  case object GhostHRTargetPlusSkyConverter extends GhostHrConverter(PrvMode.PrvOff) {
+    override def name: String = "GhostAsterism.HighResolutionTargetPlusSky"
+  }
+
+  case object GhostHRTargetPlusSkyPrvConverter extends GhostHrConverter(PrvMode.PrvOn) {
+    override def name: String = "GhostAsterism.HighResolutionTargetPlusSkyPrv"
+  }
 
   private def appendCoords(userTargets: ImList[UserTarget], c: Option[SPCoordinates]): ImList[UserTarget] =
     appendTarget(userTargets, c.map(c2UT))

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/AsterismTypeConverters.scala
@@ -7,27 +7,13 @@ import edu.gemini.spModel.target.env.ResolutionMode._
 object AsterismTypeConverters {
 
   /**
-   * Given:
-   * 1. An initial ResolutionMode RM1 amd an AsterismType AT1
-   * 2. A desired ResolutionMode RM2
-   * Find the AsterismType that best matches.
-   * This is in place so that when the resolution mode is changed, a conversion can be performed so that the target
-   * data is maintained.
+   * Called when the desired resolution mode changes, yields the new asterism
+   * type to use.
    */
-  val asterismTypeConverters: ((ResolutionMode, AsterismType, ResolutionMode)) => Option[AsterismType] = Map(
-      (GhostStandard, GhostSingleTarget,  GhostHigh) -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostSingleTarget,  GhostPRV)  -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostDualTarget,    GhostHigh) -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostDualTarget,    GhostPRV)  -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostTargetPlusSky, GhostHigh) -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostTargetPlusSky, GhostPRV)  -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostSkyPlusTarget, GhostHigh) -> GhostHighResolutionTargetPlusSky,
-      (GhostStandard, GhostSkyPlusTarget, GhostPRV)  -> GhostHighResolutionTargetPlusSky,
-
-      (GhostHigh, GhostHighResolutionTargetPlusSky, GhostStandard) -> GhostTargetPlusSky,
-      (GhostHigh, GhostHighResolutionTargetPlusSky, GhostPRV)      -> GhostHighResolutionTargetPlusSky,
-
-      (GhostPRV, GhostHighResolutionTargetPlusSky, GhostStandard) -> GhostSingleTarget,
-      (GhostPRV, GhostHighResolutionTargetPlusSky, GhostHigh)     -> GhostHighResolutionTargetPlusSky
-  ).lift
+  val asterismTypeConverters: ResolutionMode => Option[AsterismType] =
+    Map(
+      GhostStandard -> GhostTargetPlusSky,  // HR modes that we're changing from are all Target + Sky
+      GhostHigh     -> GhostHighResolutionTargetPlusSky,
+      GhostPRV      -> GhostHighResolutionTargetPlusSkyPrv
+    ).lift
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -529,6 +529,8 @@ object Ghost {
   val HRIFU2_RA_HMS: String    = "hrifu2CoordsRAHMS"
   val HRIFU2_DEC_DMS: String   = "hrifu2CoordsDecDMS"
 
+  val RESOLUTION_MODE: String  = "resolutionMode"
+
   // Property names for user targets
   def userTargetParams(index: Int): (String, String, String, String, String) =
     (s"userTarget${index}Name", s"userTarget${index}CoordsRADeg", s"userTarget${index}CoordsDecDeg", s"userTarget${index}CoordsRAHMS", s"userTarget${index}CoordsDecDMS")

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -299,22 +299,6 @@ object GhostAsterism {
     StandardResolution.emptySingleTarget.copyWithClonedTargets
   }
 
-//  def createEmptyDualTargetAsterism: Asterism = {
-//    StandardResolution.emptyDualTarget.copyWithClonedTargets
-//  }
-//
-//  def createEmptyTargetPlusSkyAsterism: Asterism = {
-//    StandardResolution.emptyTargetPlusSky.copyWithClonedTargets
-//  }
-//
-//  def createEmptySkyPlusTargetAsterism: Asterism = {
-//    StandardResolution.emptySkyPlusTarget.copyWithClonedTargets
-//  }
-//
-//  def createEmptyHRTargetPlusSkyAsterism(prv: PrvMode): Asterism = {
-//    HighResolution.emptyHRTargetPlusSky(prv).copyWithClonedTargets
-//  }
-
   // Names of the IFUs.
   val SRIFU1: String = "SRIFU1"
   val SRIFU2: String = "SRIFU2"

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -299,21 +299,21 @@ object GhostAsterism {
     StandardResolution.emptySingleTarget.copyWithClonedTargets
   }
 
-  def createEmptyDualTargetAsterism: Asterism = {
-    StandardResolution.emptyDualTarget.copyWithClonedTargets
-  }
-
-  def createEmptyTargetPlusSkyAsterism: Asterism = {
-    StandardResolution.emptyTargetPlusSky.copyWithClonedTargets
-  }
-
-  def createEmptySkyPlusTargetAsterism: Asterism = {
-    StandardResolution.emptySkyPlusTarget.copyWithClonedTargets
-  }
-
-  def createEmptyHRTargetPlusSkyAsterism(prv: PrvMode): Asterism = {
-    HighResolution.emptyHRTargetPlusSky(prv).copyWithClonedTargets
-  }
+//  def createEmptyDualTargetAsterism: Asterism = {
+//    StandardResolution.emptyDualTarget.copyWithClonedTargets
+//  }
+//
+//  def createEmptyTargetPlusSkyAsterism: Asterism = {
+//    StandardResolution.emptyTargetPlusSky.copyWithClonedTargets
+//  }
+//
+//  def createEmptySkyPlusTargetAsterism: Asterism = {
+//    StandardResolution.emptySkyPlusTarget.copyWithClonedTargets
+//  }
+//
+//  def createEmptyHRTargetPlusSkyAsterism(prv: PrvMode): Asterism = {
+//    HighResolution.emptyHRTargetPlusSky(prv).copyWithClonedTargets
+//  }
 
   // Names of the IFUs.
   val SRIFU1: String = "SRIFU1"

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
@@ -97,6 +97,7 @@ final class GhostCB(obsComp: ISPObsComponent) extends AbstractObsComponentCB(obs
             coordParam(ut.target, Some(a), b, c, d, e)
             config.putParameter(systemName, DefaultParameter.getInstance(s"userTarget${i+1}Type", ut.`type`))
           }
+          config.putParameter(systemName, DefaultParameter.getInstance(Ghost.RESOLUTION_MODE, t.getAsterism.resolutionMode.tag))
           t.getAsterism match {
 
             /** STANDARD RESOLUTION

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
@@ -97,7 +97,7 @@ final class GhostCB(obsComp: ISPObsComponent) extends AbstractObsComponentCB(obs
             coordParam(ut.target, Some(a), b, c, d, e)
             config.putParameter(systemName, DefaultParameter.getInstance(s"userTarget${i+1}Type", ut.`type`))
           }
-          config.putParameter(systemName, DefaultParameter.getInstance(Ghost.RESOLUTION_MODE, t.getAsterism.resolutionMode.tag))
+          config.putParameter(systemName, DefaultParameter.getInstance(Ghost.RESOLUTION_MODE, t.getAsterism.resolutionMode))
           t.getAsterism match {
 
             /** STANDARD RESOLUTION

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostParamSetCodecs.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostParamSetCodecs.scala
@@ -13,9 +13,13 @@ object GhostParamSetCodecs {
   private val Target  = "target"
   private val GFState = "guideFiberState"
   private val Base    = "base"
+  private val Prv     = "prv"
 
   implicit val GuideFiberStateParamCodec: ParamCodec[GuideFiberState] =
     ParamCodec[String].xmap(GuideFiberState.unsafeFromString, _.name)
+
+  implicit val PrvModeParamCodec: ParamCodec[PrvMode] =
+    ParamCodec[String].xmap(PrvMode.unsafeFromTag, _.tag)
 
   implicit val GhostTargetParamSetCodec: ParamSetCodec[GhostTarget] =
     ParamSetCodec.initial(GhostTarget.empty)
@@ -46,8 +50,9 @@ object GhostParamSetCodecs {
       .withOptionalParamSet(Base, SkyPlusTargetOverriddenBase)
 
   implicit val HRTargetPlusSkyParamSetCodec: ParamSetCodec[HighResolutionTargetPlusSky] =
-    ParamSetCodec.initial(emptyHRTargetPlusSky)
+    ParamSetCodec.initial(emptyHRTargetPlusSky(PrvMode.PrvOff))
       .withParamSet(IFU1, HRTargetPlusSkyIFU1)
       .withParamSet(IFU2, HRTargetPlusSkyIFU2)
+      .withParam(Prv, HRTargetPlusSkyPrvMode)
       .withOptionalParamSet(Base, HRTargetPlusSkyOverriddenBase)
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/ghost/AsterismConvertersSpec.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/ghost/AsterismConvertersSpec.scala
@@ -60,6 +60,10 @@ object AsterismConvertersSpec extends Specification with ScalaCheck with Arbitra
       twoWayTest(genGhostHighResTargetPlusSkyAsterismTargetEnvironment, GhostSkyPlusTargetConverter, GhostHRTargetPlusSkyConverter)
     }
 
+    "Convert between HighResolutionTargetPlusSky and HighResolutionTargetPlusSkyPrv losslessly" in {
+      twoWayTest(genGhostHighResTargetPlusSkyAsterismTargetEnvironment, GhostHRTargetPlusSkyConverter, GhostHRTargetPlusSkyPrvConverter)
+    }
+
     "Be able to convert any GHOST asterism to any other" in {
       forAll(genGhostAsterismTargetEnvironment) { env =>
         GhostConverters.forall(_.convert(env) should not(beEmpty))
@@ -78,7 +82,8 @@ object AsterismConvertersSpec extends Specification with ScalaCheck with Arbitra
     GhostDualTargetConverter,
     GhostTargetPlusSkyConverter,
     GhostSkyPlusTargetConverter,
-    GhostHRTargetPlusSkyConverter
+    GhostHRTargetPlusSkyConverter,
+    GhostHRTargetPlusSkyPrvConverter
   )
 
   private def oneWayTest(gen: Gen[TargetEnvironment], converter: AsterismConverter): Prop =

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/target/env/Arbitraries.scala
@@ -249,13 +249,13 @@ trait Arbitraries extends edu.gemini.spModel.core.Arbitraries {
       for {
         tc :: s :: _ <- coordinateGen(2)
         t <- ghostTargetWithCoords(tc)
-      } yield HighResolutionTargetPlusSky(t, new SPCoordinates(s), None)
+      } yield HighResolutionTargetPlusSky(t, new SPCoordinates(s), PrvMode.PrvOff, None)
 
     val genHighResTargetPlusSkyWithBase: Gen[HighResolutionTargetPlusSky] =
       for {
         bc :: tc :: s :: _ <- coordinateGen(3)
         t <- ghostTargetWithCoords(tc)
-      } yield HighResolutionTargetPlusSky(t, new SPCoordinates(s), Some(new SPCoordinates(bc)))
+      } yield HighResolutionTargetPlusSky(t, new SPCoordinates(s), PrvMode.PrvOff, Some(new SPCoordinates(bc)))
   }
 
   implicit val arbGuideFiberState: Arbitrary[GhostAsterism.GuideFiberState] =

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -1232,7 +1232,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
                     break;
                 case GhostHighResolutionTargetPlusSky:
                     final GhostAsterism.HighResolutionTargetPlusSky ghtsa = (GhostAsterism.HighResolutionTargetPlusSky) oldA;
-                    newA = ghtsa.copy(ghtsa.target(), ghtsa.sky(), coords(ghtsa, linked));
+                    newA = ghtsa.copy(ghtsa.target(), ghtsa.sky(), ghtsa.prv(), coords(ghtsa, linked));
                     break;
                 default: // This should never happen.
                     newA = oldA;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
@@ -130,7 +130,7 @@ final class TpeGhostIfuFeature extends TpeImageFeature("GHOST", "Show the patrol
               val p2 = pm.getLocationFromTag(t.spTarget)
               drawStandardResolutionIfu(g2d, p2, Ifu2, AsTarget)
 
-            case GhostAsterism.HighResolutionTargetPlusSky(t, s, _) =>
+            case GhostAsterism.HighResolutionTargetPlusSky(t, s, _, _) =>
               // IFU1
               val p1 = pm.getLocationFromTag(t.spTarget)
               drawHighResolutionIfu(g2d, p1)

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/tpe/feat/TpeGhostIFUFeature.scala
@@ -295,7 +295,7 @@ final class TpeGhostIfuFeature extends TpeImageFeature("GHOST", "Show the patrol
    * Determine if IFU2 is in use.
    */
   private def usingIFU2(env: TargetEnvironment): Boolean = env.getAsterism.asterismType match {
-    case AsterismType.GhostDualTarget | AsterismType.GhostTargetPlusSky | AsterismType.GhostSkyPlusTarget | AsterismType.GhostHighResolutionTargetPlusSky => true
+    case AsterismType.GhostDualTarget | AsterismType.GhostTargetPlusSky | AsterismType.GhostSkyPlusTarget | AsterismType.GhostHighResolutionTargetPlusSky | AsterismType.GhostHighResolutionTargetPlusSkyPrv => true
     case AsterismType.GhostSingleTarget => false
     case AsterismType.Single => sys.error("Invalid asterism type for GHOST")
   }


### PR DESCRIPTION
@cquiroz discovered that PRV mode was not being sent to the seqexec.  Upon investigation I learned that we aren't even storing it when selected.  This PR adds code to track it and puts `resolutionMode` (with value of type `ResolutionMode`) in the GHOST sequence.