### PR TITLE
Fix "duplicate Cc" bounce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ metals.sbt
 
 # Vim
 *.swp
+
+.jvmopts
+.sdkmanrc
+
+

--- a/bundle/edu.gemini.oodb.too.window/src/main/java/edu/gemini/too/email/TooEmail.java
+++ b/bundle/edu.gemini.oodb.too.window/src/main/java/edu/gemini/too/email/TooEmail.java
@@ -320,13 +320,13 @@ public class TooEmail {
 
         try {
             if (toAddrs.length > 0) {
-                mess.addRecipients(Message.RecipientType.TO, toAddrs);
+                mess.setRecipients(Message.RecipientType.TO, toAddrs);
             }
             if (ccAddrs.length > 0) {
-                mess.addRecipients(Message.RecipientType.CC, ccAddrs);
+                mess.setRecipients(Message.RecipientType.CC, ccAddrs);
             }
             if (bccAddrs.length > 0) {
-                mess.addRecipients(Message.RecipientType.BCC, bccAddrs);
+                mess.setRecipients(Message.RecipientType.BCC, bccAddrs);
             }
             mess.setFrom(_sender);
             mess.setSubject(subj);

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/mail/PrepareMessageAction.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/mail/PrepareMessageAction.java
@@ -11,7 +11,6 @@ import javax.mail.Message;
 import static javax.mail.Message.RecipientType.*;
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
Adding recipients in separate calls produces a `Cc` header per call apparently, which Google is now rejecting:

```
Bounced
550-5.7.1 [209.85.220.97] This message is not RFC 5322 compliant, the issue is: 550-5.7.1 duplicate CC headers. To reduce the amount of spam sent to Gmail, 550-5.7.1 this message has been blocked. Please review 550 5.7.1 RFC 5322 specifications for more information. s144-20020a1f2c96000000b003be18067bcasor4079229vks.5 - gsmtp
```

This is an attempt to fix the problem but adding all recipients in a single call.
