### PR TITLE
REL-4170: GHOST Template

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -223,8 +223,10 @@ def swalker(version: Version) = AppConfig(
     "-Dcron.archive.edu.gemini.dbTools.html.ftpDestDir=/Users/swalker/cron"
   ),
   props = Map(
+    "edu.gemini.auxfile.fits.enabled"            -> "false",
     "edu.gemini.auxfile.fits.dest"               -> "/gemsoft/var/data/ictd/test/GS@SEMESTER@/@PROG_ID@",
     "edu.gemini.auxfile.fits.host"               -> "gsconfig.gemini.edu",
+    "edu.gemini.auxfile.other.enabled"           -> "false",
     "edu.gemini.auxfile.other.dest"              -> "/gemsoft/var/data/finder/GSqueue/Finders-Test/@SEMESTER@/@PROG_ID@",
     "edu.gemini.auxfile.root"                    -> "/Users/swalker/.auxfile",
     "edu.gemini.dataman.gsa.summit.host"         -> "cpofits-lv1new.cl.gemini.edu",

--- a/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/copier/impl/AuxFileCopierImpl.java
+++ b/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/copier/impl/AuxFileCopierImpl.java
@@ -41,6 +41,11 @@ public final class AuxFileCopierImpl implements AuxFileCopier {
         if (!file.exists()) return true;
 
         // Do the copy using sftp.
+        if (!config.isEnabled()) {
+            LOG.log(Level.INFO, "Auxfile copy disabled, skipping copy of " + file.getName());
+            return true;
+        }
+
         final Try<BoxedUnit> result = SftpSession$.MODULE$.copy(config, file, desDir);
         if (result.isFailure()) {
             final Failure<BoxedUnit> failure = (Failure<BoxedUnit>) result;

--- a/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/copier/osgi/Activator.java
+++ b/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/copier/osgi/Activator.java
@@ -15,7 +15,7 @@ public class Activator implements BundleActivator {
     private ServiceRegistration<AuxFileCopier> _reg;
 
     public synchronized void start(BundleContext ctx) throws Exception {
-        final Map<AuxFileType, CopyConfig> configs = new HashMap<AuxFileType, CopyConfig>();
+        final Map<AuxFileType, CopyConfig> configs = new HashMap<>();
         for (AuxFileType t : AuxFileType.values()) {
             configs.put(t, OsgiCopyConfig.create(t, ctx));
         }

--- a/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/copier/osgi/OsgiCopyConfig.java
+++ b/bundle/edu.gemini.auxfile.workflow/src/main/java/edu/gemini/auxfile/copier/osgi/OsgiCopyConfig.java
@@ -2,6 +2,7 @@ package edu.gemini.auxfile.copier.osgi;
 
 import edu.gemini.auxfile.copier.AuxFileType;
 import edu.gemini.auxfile.copier.CopyConfig;
+import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.spModel.core.SPProgramID;
 import edu.gemini.util.ssh.SshConfig$;
 import org.osgi.framework.BundleContext;
@@ -19,9 +20,11 @@ final class OsgiCopyConfig extends CopyConfig {
     private static final String USER_KEY      = "user";
     private static final String PASSWORD_KEY  = "password";
     private static final String DEST_KEY      = "dest";
+    private static final String ENABLED_KEY   = "enabled";
 
-    private AuxFileType _fileType;
-    private String _destTmpl;
+    private final AuxFileType _fileType;
+    private final String _destTmpl;
+
 
     public static OsgiCopyConfig create(AuxFileType type, BundleContext ctx){
         try {
@@ -38,7 +41,9 @@ final class OsgiCopyConfig extends CopyConfig {
 	    super(getProperty(type, ctx, HOST_KEY),
 	          getProperty(type, ctx, USER_KEY),
 	          getProperty(type, ctx, PASSWORD_KEY),
-              SshConfig$.MODULE$.DEFAULT_TIMEOUT());
+              SshConfig$.MODULE$.DEFAULT_TIMEOUT(),
+              ImOption.apply(ctx.getProperty(buildPropertyName(type, ENABLED_KEY))).forall("true"::equals)
+              );
         _fileType = type;
         _destTmpl = getProperty(type, ctx, DEST_KEY);
     }
@@ -50,7 +55,7 @@ final class OsgiCopyConfig extends CopyConfig {
         final String cfg = ctx.getProperty(cfgProp);
         final String def = ctx.getProperty(defProp);
 
-        if        (cfg != null) {
+        if (cfg != null) {
             // this aux file type has a specific config, use it
             LOG.info("config for " + cfgProp + ": " + cfg);
             return cfg;

--- a/bundle/edu.gemini.auxfile.workflow/src/main/scala/edu/gemini/auxfile/copier/CopyConfig.scala
+++ b/bundle/edu.gemini.auxfile.workflow/src/main/scala/edu/gemini/auxfile/copier/CopyConfig.scala
@@ -8,8 +8,8 @@ import edu.gemini.spModel.core.SPProgramID
  * This is an abstract class: the getFileType and getDestDir methods must be implemented.
  * User: sraaphor
  */
-abstract class CopyConfig(host: String, user: String, password: String, timeout: Int = SshConfig.DEFAULT_TIMEOUT)
-  extends DefaultSshConfig(host, user, password, timeout) {
+abstract class CopyConfig(host: String, user: String, password: String, timeout: Int = SshConfig.DEFAULT_TIMEOUT, enabled: Boolean = true)
+  extends DefaultSshConfig(host, user, password, timeout, enabled) {
   def getFileType: AuxFileType
   def getDestDir(progId: SPProgramID): String
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -44,6 +44,6 @@ object Root {
 
   // REL-3769: GPI not available in 2020B.
   // GHOST not yet available
-  val choices: List[Instrument] = List(Alopeke, Flamingos2, /*Ghost,*/ GmosNorth, GmosSouth, Gnirs, /*Graces,*/ Gsaoi, Igrins, MaroonX, Nifs, /*Niri,*/ Visitor, Zorro)
+  val choices: List[Instrument] = List(Alopeke, Flamingos2, Ghost, GmosNorth, GmosSouth, Gnirs, /*Graces,*/ Gsaoi, Igrins, MaroonX, Nifs, /*Niri,*/ Visitor, Zorro)
 
 }

--- a/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
+++ b/bundle/edu.gemini.model.p1/src/main/scala/edu/gemini/model/p1/dtree/Root.scala
@@ -44,6 +44,6 @@ object Root {
 
   // REL-3769: GPI not available in 2020B.
   // GHOST not yet available
-  val choices: List[Instrument] = List(Alopeke, Flamingos2, Ghost, GmosNorth, GmosSouth, Gnirs, /*Graces,*/ Gsaoi, Igrins, MaroonX, Nifs, /*Niri,*/ Visitor, Zorro)
+  val choices: List[Instrument] = List(Alopeke, Flamingos2, /*Ghost,*/ GmosNorth, GmosSouth, Gnirs, /*Graces,*/ Gsaoi, Igrins, MaroonX, Nifs, /*Niri,*/ Visitor, Zorro)
 
 }

--- a/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
+++ b/bundle/edu.gemini.p2checker/src/main/java/edu/gemini/p2checker/rules/general/GeneralRule.java
@@ -328,7 +328,7 @@ public class GeneralRule implements IRule {
     /**
      * Rule for asterism type: the asterism type must match one available for the instrument.
      */
-    private static IRule ASTERISM_TYPE_RULE = elems -> {
+    private static final IRule ASTERISM_TYPE_RULE = elems -> {
         final Option<TargetObsComp> tocOpt = elems.getTargetObsComp();
         if (tocOpt.isEmpty())
             return null;
@@ -366,7 +366,7 @@ public class GeneralRule implements IRule {
     /**
      * WARN  if TARGET_PROPER_MOTION > 1000.0
      */
-    private static IRule TARGET_PM_RULE = new IRule() {
+    private static final IRule TARGET_PM_RULE = new IRule() {
         private static final String MESSAGE = "Very large proper motion. Please double check your proper motion";
         private static final double MAX_PM = 1000.0; //Max PM is 1000 milli-arcsecs. W
         public IP2Problems check(final ObservationElements elements)  {

--- a/bundle/edu.gemini.phase2.core/src/main/java/edu/gemini/phase2/core/model/GroupShell.java
+++ b/bundle/edu.gemini.phase2.core/src/main/java/edu/gemini/phase2/core/model/GroupShell.java
@@ -4,7 +4,6 @@ import edu.gemini.pot.sp.*;
 import edu.gemini.spModel.obscomp.SPGroup;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
-import edu.gemini.spModel.target.env.AsterismType;
 import edu.gemini.spModel.template.Phase1Group;
 import edu.gemini.spModel.template.TemplateGroup;
 import edu.gemini.spModel.template.TemplateParameters;
@@ -60,20 +59,18 @@ public final class GroupShell extends BaseGroupShell {
         }
     }
 
-    public TemplateGroupShell toTemplateGroupShell(Phase1Group pig, AsterismType astType) {
-        return toTemplateGroupShell(pig.blueprintId, pig.argsList, astType);
+    public TemplateGroupShell toTemplateGroupShell(Phase1Group pig) {
+        return toTemplateGroupShell(pig.blueprintId, pig.argsList);
     }
 
     public TemplateGroupShell toTemplateGroupShell(
         String blueprintId,
-        Collection<TemplateParameters> argList,
-        AsterismType astType
+        Collection<TemplateParameters> argList
     ) {
         final TemplateGroup dataObj = new TemplateGroup();
         dataObj.setBlueprintId(blueprintId);
         dataObj.setTitle(group.getTitle());
         dataObj.setGroupType(group.getGroupType());
-        dataObj.setAsterismType(astType);
         return new TemplateGroupShell(dataObj, argList, obsComponents, observations);
     }
 

--- a/bundle/edu.gemini.phase2.core/src/main/java/edu/gemini/phase2/core/model/GroupShell.java
+++ b/bundle/edu.gemini.phase2.core/src/main/java/edu/gemini/phase2/core/model/GroupShell.java
@@ -4,6 +4,7 @@ import edu.gemini.pot.sp.*;
 import edu.gemini.spModel.obscomp.SPGroup;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
+import edu.gemini.spModel.target.env.AsterismType;
 import edu.gemini.spModel.template.Phase1Group;
 import edu.gemini.spModel.template.TemplateGroup;
 import edu.gemini.spModel.template.TemplateParameters;
@@ -59,15 +60,20 @@ public final class GroupShell extends BaseGroupShell {
         }
     }
 
-    public TemplateGroupShell toTemplateGroupShell(Phase1Group pig) {
-        return toTemplateGroupShell(pig.blueprintId, pig.argsList);
+    public TemplateGroupShell toTemplateGroupShell(Phase1Group pig, AsterismType astType) {
+        return toTemplateGroupShell(pig.blueprintId, pig.argsList, astType);
     }
 
-    public TemplateGroupShell toTemplateGroupShell(String blueprintId, Collection<TemplateParameters> argList) {
+    public TemplateGroupShell toTemplateGroupShell(
+        String blueprintId,
+        Collection<TemplateParameters> argList,
+        AsterismType astType
+    ) {
         final TemplateGroup dataObj = new TemplateGroup();
         dataObj.setBlueprintId(blueprintId);
         dataObj.setTitle(group.getTitle());
         dataObj.setGroupType(group.getGroupType());
+        dataObj.setAsterismType(astType);
         return new TemplateGroupShell(dataObj, argList, obsComponents, observations);
     }
 

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GHOST_BP.txt
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GHOST_BP.txt
@@ -1,0 +1,38 @@
+Instrument: GHOST
+Blueprint templates : GHOST_BP.xml
+Last update: 2022 December 19, Bryan Miller, single position from PIT for dual-target
+
+Observations identified by Library IDs, indicated with {}
+
+# DEFINITIONS
+Phase I = PI
+
+**** IF INSTRUMENT MODE == SPECTROSCOPY ***
+
+INCLUDE {1}     # Science
+
+SET RESOLUTION MODE FROM PI  # Possible w/o a target component?
+
+SET TARGET MODE FROM PI      # Possible w/o a target component?
+
+ON TEMPATE INSTANTIATION (adding the target(s))
+	IF RESOLUTION MODE == STANDARD
+	    IF TARGET MODE == 'Single'
+	    	Add target from PI to SRIFU1
+	    IF TARGET MODE == 'Dual'  # Position from PI is the Base position
+	    	Add target1 from PI with RA + 1 arcmin to SRIFU1
+	    	Add target2 from PI with RA - 1 arcmin to SRIFU2	
+	    	    
+		IF TARGET MODE ==  'SRIFU1 Sky + SRIFU2 Target'
+			Add target from PI to SRIFU2
+			Add target from PI with ra + 2 arcmin to SRIFU1
+		ELSE
+			Add target from PI to SRIFU1
+			IF TARGET MODE ==  'SRIFU1 Target + SRIFU2 Sky'
+				Add target from PI with ra - 2 arcmin to SRIFU2
+
+	IF RESOLUTION MODE == HIGH or PRECISION RADIAL VELOCITY
+		Add target from PI to HRIFU
+		Add target from PI with ra - 2 arcmin to HRSKY
+		
+

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GHOST_BP.txt
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GHOST_BP.txt
@@ -1,6 +1,6 @@
 Instrument: GHOST
 Blueprint templates : GHOST_BP.xml
-Last update: 2022 December 19, Bryan Miller, single position from PIT for dual-target
+Last update: 2023 March 1, Bryan Miller, single position from PIT for dual-target is one of the targets, not a middle position
 
 Observations identified by Library IDs, indicated with {}
 
@@ -11,28 +11,23 @@ Phase I = PI
 
 INCLUDE {1}     # Science
 
-SET RESOLUTION MODE FROM PI  # Possible w/o a target component?
+SET RESOLUTION MODE FROM PI
 
-SET TARGET MODE FROM PI      # Possible w/o a target component?
+SET TARGET MODE FROM PI
 
 ON TEMPATE INSTANTIATION (adding the target(s))
 	IF RESOLUTION MODE == STANDARD
 	    IF TARGET MODE == 'Single'
 	    	Add target from PI to SRIFU1
-	    IF TARGET MODE == 'Dual'  # Position from PI is the Base position
-	    	Add target1 from PI with RA + 1 arcmin to SRIFU1
-	    	Add target2 from PI with RA - 1 arcmin to SRIFU2	
-	    	    
-		IF TARGET MODE ==  'SRIFU1 Sky + SRIFU2 Target'
-			Add target from PI to SRIFU2
-			Add target from PI with ra + 2 arcmin to SRIFU1
-		ELSE
+
+	    IF TARGET MODE == 'Dual'  # Position from PI is the fainter target
+	    	Add target from PI to SRIFU1
+	    	Add target from PI with RA - 2 arcmin to SRIFU2, set target name to 'Target 2'
+
+		IF TARGET MODE ==  'SRIFU + Sky'
 			Add target from PI to SRIFU1
-			IF TARGET MODE ==  'SRIFU1 Target + SRIFU2 Sky'
-				Add target from PI with ra - 2 arcmin to SRIFU2
+			Add target from PI with ra - 2 arcmin to SRIFU2, set target name to 'Sky'
 
 	IF RESOLUTION MODE == HIGH or PRECISION RADIAL VELOCITY
 		Add target from PI to HRIFU
-		Add target from PI with ra - 2 arcmin to HRSKY
-		
-
+		Add target from PI with ra - 2 arcmin to HRSKY, the target name should be 'Sky'

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GHOST_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GHOST_BP.xml
@@ -53,11 +53,11 @@
           <param name="issPort" value="UP_LOOKING"/>
           <param name="enableFiberAgitator1" value="false"/>
           <param name="enableFiberAgitator2" value="false"/>
-          <param name="redExposureTime" value="600.0"/>
+          <param name="redExposureTime" value="300.0"/>
           <param name="redExposureCount" value="1"/>
           <param name="redBinning" value="ONE_BY_ONE"/>
           <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
-          <param name="blueExposureTime" value="600.0"/>
+          <param name="blueExposureTime" value="300.0"/>
           <param name="blueExposureCount" value="1"/>
           <param name="blueBinning" value="ONE_BY_ONE"/>
           <param name="blueReadNoiseGain" value="SLOW_LOW"/>
@@ -88,9 +88,9 @@
         <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="668cc23e-f767-4279-94ff-7d06026703f7" name="GHOST Sequence">
           <paramset name="GHOST Sequence" kind="dataObj">
             <param name="blueExposureCount" value="1"/>
-            <param name="blueExposureTime" value="600.0"/>
+            <param name="blueExposureTime" value="300.0"/>
             <param name="redExposureCount" value="1"/>
-            <param name="redExposureTime" value="600.0"/>
+            <param name="redExposureTime" value="300.0"/>
           </paramset>
           <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="aa14b2b0-07b7-4503-beff-856455c7529a" name="Observe">
             <paramset name="Observe" kind="dataObj">
@@ -101,699 +101,1288 @@
         </container>
       </container>
     </container>
-    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="7302de0a-99d8-47c4-92d3-b2d0bf4e96c5" name="">
-      <paramset name="Observation" kind="dataObj">
-        <param name="title" value="GHOST science - SRIFU1 + sky example"/>
+    <container kind="group" type="Group" version="2009A-1" subtype="group" key="b0e8d299-49a4-4736-984e-e22a8b9ff720" name="Group">
+      <paramset name="Group" kind="dataObj">
+        <param name="title" value="Basic Examples"/>
+        <param name="GroupType" value="TYPE_FOLDER"/>
         <param name="libraryId" value=""/>
-        <param name="priority" value="LOW"/>
-        <param name="tooOverrideRapid" value="false"/>
-        <param name="phase2Status" value="PI_TO_COMPLETE"/>
-        <paramset name="schedulingBlock">
-          <param name="start" value="1667237400000"/>
-          <paramset name="duration">
-            <param name="tag" value="unstated"/>
-          </paramset>
-        </paramset>
-        <param name="qaState" value="UNDEFINED"/>
-        <param name="overrideQaState" value="false"/>
-        <param name="setupTimeType" value="FULL"/>
       </paramset>
-      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="a746d845-cffe-4ba3-8edf-abdb42c27801" name="GHOST">
-        <paramset name="GHOST" kind="dataObj">
-          <param name="posAngle" value="0"/>
-          <param name="issPort" value="UP_LOOKING"/>
-          <param name="enableFiberAgitator1" value="false"/>
-          <param name="enableFiberAgitator2" value="false"/>
-          <param name="redExposureTime" value="600.0"/>
-          <param name="redExposureCount" value="1"/>
-          <param name="redBinning" value="ONE_BY_ONE"/>
-          <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
-          <param name="blueExposureTime" value="600.0"/>
-          <param name="blueExposureCount" value="1"/>
-          <param name="blueBinning" value="ONE_BY_ONE"/>
-          <param name="blueReadNoiseGain" value="SLOW_LOW"/>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="71e6a8d8-474d-4a01-b7ec-cb83d5f3359a" name="Targets">
-        <paramset name="Targets" kind="dataObj">
-          <paramset name="targetEnv">
-            <paramset name="asterism">
-              <paramset name="ifu1">
-                <paramset name="target">
-                  <param name="name" value="HD1355"/>
-                  <param name="redshift" value="-5.0E-6"/>
-                  <param name="parallax" value="3.7153"/>
-                  <paramset name="magnitude">
-                    <param name="value" value="9.96"/>
-                    <param name="band" value="B"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.03"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="8.87"/>
-                    <param name="band" value="V"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.02"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="7.037"/>
-                    <param name="band" value="J"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.018"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="6.532"/>
-                    <param name="band" value="H"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.044"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="6.415"/>
-                    <param name="band" value="K"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.024"/>
-                  </paramset>
-                  <paramset name="coordinates">
-                    <param name="ra" value="4.423109895970015"/>
-                    <param name="dec" value="348.784820192"/>
-                  </paramset>
-                  <paramset name="proper-motion">
-                    <param name="delta-ra" value="7.57"/>
-                    <param name="delta-dec" value="-8.661"/>
-                    <param name="epoch" value="2000.0"/>
-                  </paramset>
-                  <param name="tag" value="sidereal"/>
-                </paramset>
-                <param name="guideFiberState" value="enabled"/>
-              </paramset>
-              <paramset name="ifu2">
-                <param name="ra" value="4.423108333333346"/>
-                <param name="dec" value="348.81815277777775"/>
-              </paramset>
-              <param name="tag" value="ghostTargetPlusSky"/>
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="de062e39-31e0-4295-b467-6d199416de8f" name="">
+        <paramset name="Observation" kind="dataObj">
+          <param name="title" value="GHOST science - dual target example"/>
+          <param name="libraryId" value=""/>
+          <param name="priority" value="LOW"/>
+          <param name="tooOverrideRapid" value="false"/>
+          <param name="phase2Status" value="PI_TO_COMPLETE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1667237400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
             </paramset>
-            <paramset name="guideEnv">
-              <param name="primary" value="0"/>
-              <paramset name="guideGroup">
-                <param name="tag" value="AutoActiveTag"/>
-                <param name="posAngle" value="0.0"/>
-                <paramset name="guider">
-                  <param name="key" value="PWFS2"/>
-                  <param name="primary" value="0"/>
-                  <paramset name="spTarget">
-                    <paramset name="target">
-                      <param name="name" value="Gaia DR2 2424603635247995264"/>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.633876256076077"/>
-                        <param name="band" value="V"/>
-                        <param name="system" value="Vega"/>
+          </paramset>
+          <param name="qaState" value="UNDEFINED"/>
+          <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
+        </paramset>
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="b21548a1-f66a-44e7-a851-4fc38b485ddc" name="Observing Conditions">
+          <paramset name="Observing Conditions" kind="dataObj">
+            <param name="CloudCover" value="PERCENT_80"/>
+            <param name="ImageQuality" value="ANY"/>
+            <param name="SkyBackground" value="ANY"/>
+            <param name="WaterVapor" value="ANY"/>
+            <param name="ElevationConstraintType" value="NONE"/>
+            <param name="ElevationConstraintMin" value="0.0"/>
+            <param name="ElevationConstraintMax" value="0.0"/>
+            <paramset name="timing-window-list"/>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="390bf25d-d650-4b0a-96a1-1f3373634566" name="GHOST">
+          <paramset name="GHOST" kind="dataObj">
+            <param name="posAngle" value="0"/>
+            <param name="issPort" value="UP_LOOKING"/>
+            <param name="enableFiberAgitator1" value="false"/>
+            <param name="enableFiberAgitator2" value="false"/>
+            <param name="redExposureTime" value="600.0"/>
+            <param name="redExposureCount" value="1"/>
+            <param name="redBinning" value="ONE_BY_ONE"/>
+            <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
+            <param name="blueExposureTime" value="600.0"/>
+            <param name="blueExposureCount" value="1"/>
+            <param name="blueBinning" value="ONE_BY_ONE"/>
+            <param name="blueReadNoiseGain" value="SLOW_LOW"/>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e854a9d0-0ac6-4b3a-b738-99000d4469b5" name="Targets">
+          <paramset name="Targets" kind="dataObj">
+            <paramset name="targetEnv">
+              <paramset name="asterism">
+                <paramset name="ifu1">
+                  <paramset name="target">
+                    <param name="name" value="NGC2808 star 1 "/>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.23072477955091"/>
+                      <param name="band" value="V"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="12.150290743698195"/>
+                      <param name="band" value="R"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="11.133283169636655"/>
+                      <param name="band" value="I"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="12.599432443541296"/>
+                      <param name="band" value="r"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="11.68799822472841"/>
+                      <param name="band" value="i"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="14.250653157785202"/>
+                      <param name="band" value="g"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="8.514383555398194"/>
+                      <param name="band" value="K"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="8.756784038894278"/>
+                      <param name="band" value="H"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="9.627747336078956"/>
+                      <param name="band" value="J"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="coordinates">
+                      <param name="ra" value="138.08428805253521"/>
+                      <param name="dec" value="295.12763567379943"/>
+                    </paramset>
+                    <paramset name="proper-motion">
+                      <param name="delta-ra" value="1.1413518814497048"/>
+                      <param name="delta-dec" value="0.3346264845685283"/>
+                      <param name="epoch" value="2015.5"/>
+                    </paramset>
+                    <param name="tag" value="sidereal"/>
+                  </paramset>
+                  <param name="guideFiberState" value="enabled"/>
+                </paramset>
+                <paramset name="ifu2">
+                  <paramset name="target">
+                    <param name="name" value="NGC2808 star 2"/>
+                    <paramset name="magnitude">
+                      <param name="value" value="14.725969124078764"/>
+                      <param name="band" value="V"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="14.0201028644874"/>
+                      <param name="band" value="R"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.354272681502447"/>
+                      <param name="band" value="I"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="14.282613077124529"/>
+                      <param name="band" value="r"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.82944676779055"/>
+                      <param name="band" value="i"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="15.381803930363931"/>
+                      <param name="band" value="g"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="11.577787215047401"/>
+                      <param name="band" value="K"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="11.738050785399366"/>
+                      <param name="band" value="H"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="12.350072896201958"/>
+                      <param name="band" value="J"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="coordinates">
+                      <param name="ra" value="137.97067205480164"/>
+                      <param name="dec" value="295.15336877266816"/>
+                    </paramset>
+                    <paramset name="proper-motion">
+                      <param name="delta-ra" value="0.8458675442987402"/>
+                      <param name="delta-dec" value="0.2660131714228431"/>
+                      <param name="epoch" value="2015.5"/>
+                    </paramset>
+                    <param name="tag" value="sidereal"/>
+                  </paramset>
+                  <param name="guideFiberState" value="enabled"/>
+                </paramset>
+                <param name="tag" value="ghostDualTarget"/>
+              </paramset>
+              <paramset name="guideEnv">
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoActiveTag"/>
+                  <param name="posAngle" value="0.0"/>
+                  <paramset name="guider">
+                    <param name="key" value="PWFS2"/>
+                    <param name="primary" value="0"/>
+                    <paramset name="spTarget">
+                      <paramset name="target">
+                        <param name="name" value="Gaia DR2 5248754909672194304"/>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.217195629875249"/>
+                          <param name="band" value="V"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.707163258058326"/>
+                          <param name="band" value="R"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.22410985101349"/>
+                          <param name="band" value="I"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.92282703677957"/>
+                          <param name="band" value="r"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.656343741740354"/>
+                          <param name="band" value="i"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.654860415648425"/>
+                          <param name="band" value="g"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="8.942442674948325"/>
+                          <param name="band" value="K"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="9.055339339134704"/>
+                          <param name="band" value="H"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="9.496968122250106"/>
+                          <param name="band" value="J"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="coordinates">
+                          <param name="ra" value="138.2058987921505"/>
+                          <param name="dec" value="295.05570156492513"/>
+                        </paramset>
+                        <paramset name="proper-motion">
+                          <param name="delta-ra" value="36.64160021542454"/>
+                          <param name="delta-dec" value="-1.7399778064393452"/>
+                          <param name="epoch" value="2015.5"/>
+                        </paramset>
+                        <param name="tag" value="sidereal"/>
                       </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.293584146793286"/>
-                        <param name="band" value="R"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.968376909683993"/>
-                        <param name="band" value="I"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.4838517478606"/>
-                        <param name="band" value="r"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.36244890570376"/>
-                        <param name="band" value="i"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.87175494000135"/>
-                        <param name="band" value="g"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.153477242505286"/>
-                        <param name="band" value="K"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.222237037468298"/>
-                        <param name="band" value="H"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.491788136526072"/>
-                        <param name="band" value="J"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="coordinates">
-                        <param name="ra" value="4.3382858653453695"/>
-                        <param name="dec" value="348.8563719107751"/>
-                      </paramset>
-                      <paramset name="proper-motion">
-                        <param name="delta-ra" value="-14.985691687370013"/>
-                        <param name="delta-dec" value="-6.722483282732992"/>
-                        <param name="epoch" value="2015.5"/>
-                      </paramset>
-                      <param name="tag" value="sidereal"/>
                     </paramset>
                   </paramset>
                 </paramset>
               </paramset>
             </paramset>
           </paramset>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="750d6980-8b3b-4af7-8a24-7acd5ba13faf" name="Observing Conditions">
-        <paramset name="Observing Conditions" kind="dataObj">
-          <param name="CloudCover" value="PERCENT_80"/>
-          <param name="ImageQuality" value="ANY"/>
-          <param name="SkyBackground" value="ANY"/>
-          <param name="WaterVapor" value="ANY"/>
-          <param name="ElevationConstraintType" value="NONE"/>
-          <param name="ElevationConstraintMin" value="0.0"/>
-          <param name="ElevationConstraintMax" value="0.0"/>
-          <paramset name="timing-window-list"/>
-        </paramset>
-      </container>
-      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e727993e-3e31-43ba-858a-057ca2c51b3a" name="Observing Log">
-        <paramset name="Observing Log" kind="dataObj">
-          <paramset name="obsQaRecord"/>
-        </paramset>
-      </container>
-      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="7394f7cf-2f01-47a1-8aff-39ea1d105b68" name="Observation Exec Log">
-        <paramset name="Observation Exec Log" kind="dataObj">
-          <paramset name="obsExecRecord">
-            <paramset name="datasets"/>
-            <paramset name="events"/>
-            <paramset name="configMap"/>
+        </container>
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="b17e6907-f468-4e67-9ec6-383e49706947" name="Observing Log">
+          <paramset name="Observing Log" kind="dataObj">
+            <paramset name="obsQaRecord"/>
           </paramset>
-        </paramset>
-      </container>
-      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="9ae6255a-2082-47a6-a084-0969ca5b00c2" name="Sequence">
-        <paramset name="Sequence" kind="dataObj"/>
-        <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="d2403616-71fb-46d0-a741-eb82e4a31599" name="GHOST Sequence">
-          <paramset name="GHOST Sequence" kind="dataObj">
-            <param name="blueExposureCount" value="1"/>
-            <param name="blueExposureTime" value="600.0"/>
-            <param name="redExposureCount" value="1"/>
-            <param name="redExposureTime" value="600.0"/>
-          </paramset>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="f288dd5d-5de1-4e65-a08e-1d4c31f22c16" name="Observe">
-            <paramset name="Observe" kind="dataObj">
-              <param name="repeatCount" value="1"/>
-              <param name="class" value="SCIENCE"/>
+        </container>
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="b6d12fa3-f63e-4ded-8a20-89704fad23e3" name="Observation Exec Log">
+          <paramset name="Observation Exec Log" kind="dataObj">
+            <paramset name="obsExecRecord">
+              <paramset name="datasets"/>
+              <paramset name="events"/>
+              <paramset name="configMap"/>
             </paramset>
+          </paramset>
+        </container>
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="cdb0232a-a726-4289-b548-b6c6f772469c" name="Sequence">
+          <paramset name="Sequence" kind="dataObj"/>
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="caef6c68-7aef-4c4a-a84c-d7e1a95d7601" name="GHOST Sequence">
+            <paramset name="GHOST Sequence" kind="dataObj">
+              <param name="blueExposureCount" value="1"/>
+              <param name="blueExposureTime" value="600.0"/>
+              <param name="redExposureCount" value="1"/>
+              <param name="redExposureTime" value="600.0"/>
+            </paramset>
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="922bfd1a-28a3-4584-bd54-62ac347a0032" name="Observe">
+              <paramset name="Observe" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="class" value="SCIENCE"/>
+              </paramset>
+            </container>
+          </container>
+        </container>
+      </container>
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="d83369a8-7fee-4c71-91f1-0b90ed5c74e8" name="">
+        <paramset name="Observation" kind="dataObj">
+          <param name="title" value="GHOST science - high resolution example"/>
+          <param name="libraryId" value=""/>
+          <param name="priority" value="LOW"/>
+          <param name="tooOverrideRapid" value="false"/>
+          <param name="phase2Status" value="PI_TO_COMPLETE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1667237400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
+          <param name="qaState" value="UNDEFINED"/>
+          <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
+        </paramset>
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="1dc5f526-e0d2-4fae-9f16-bfe3945c8b2d" name="GHOST">
+          <paramset name="GHOST" kind="dataObj">
+            <param name="posAngle" value="0"/>
+            <param name="issPort" value="UP_LOOKING"/>
+            <param name="enableFiberAgitator1" value="false"/>
+            <param name="enableFiberAgitator2" value="false"/>
+            <param name="redExposureTime" value="600.0"/>
+            <param name="redExposureCount" value="1"/>
+            <param name="redBinning" value="ONE_BY_ONE"/>
+            <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
+            <param name="blueExposureTime" value="600.0"/>
+            <param name="blueExposureCount" value="1"/>
+            <param name="blueBinning" value="ONE_BY_ONE"/>
+            <param name="blueReadNoiseGain" value="SLOW_LOW"/>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="4fdd9069-5642-4066-9595-3cc66697e098" name="Targets">
+          <paramset name="Targets" kind="dataObj">
+            <paramset name="targetEnv">
+              <paramset name="asterism">
+                <paramset name="ifu1">
+                  <paramset name="target">
+                    <param name="name" value="HD1355"/>
+                    <param name="redshift" value="-5.0E-6"/>
+                    <param name="parallax" value="3.7153"/>
+                    <paramset name="magnitude">
+                      <param name="value" value="9.96"/>
+                      <param name="band" value="B"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.03"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="8.87"/>
+                      <param name="band" value="V"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.02"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="7.037"/>
+                      <param name="band" value="J"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.018"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="6.532"/>
+                      <param name="band" value="H"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.044"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="6.415"/>
+                      <param name="band" value="K"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.024"/>
+                    </paramset>
+                    <paramset name="coordinates">
+                      <param name="ra" value="4.423109895970015"/>
+                      <param name="dec" value="348.784820192"/>
+                    </paramset>
+                    <paramset name="proper-motion">
+                      <param name="delta-ra" value="7.57"/>
+                      <param name="delta-dec" value="-8.661"/>
+                      <param name="epoch" value="2000.0"/>
+                    </paramset>
+                    <param name="tag" value="sidereal"/>
+                  </paramset>
+                  <param name="guideFiberState" value="enabled"/>
+                </paramset>
+                <paramset name="ifu2">
+                  <param name="ra" value="4.423108333333346"/>
+                  <param name="dec" value="348.81815277777775"/>
+                </paramset>
+                <param name="prv" value="PRV_OFF"/>
+                <param name="tag" value="ghostHRTargetPlusSky"/>
+              </paramset>
+              <paramset name="guideEnv">
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoActiveTag"/>
+                  <param name="posAngle" value="0.0"/>
+                  <paramset name="guider">
+                    <param name="key" value="PWFS2"/>
+                    <param name="primary" value="0"/>
+                    <paramset name="spTarget">
+                      <paramset name="target">
+                        <param name="name" value="Gaia DR2 2424603635247995264"/>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.633876256076077"/>
+                          <param name="band" value="V"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.293584146793286"/>
+                          <param name="band" value="R"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.968376909683993"/>
+                          <param name="band" value="I"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.4838517478606"/>
+                          <param name="band" value="r"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.36244890570376"/>
+                          <param name="band" value="i"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.87175494000135"/>
+                          <param name="band" value="g"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.153477242505286"/>
+                          <param name="band" value="K"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.222237037468298"/>
+                          <param name="band" value="H"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.491788136526072"/>
+                          <param name="band" value="J"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="coordinates">
+                          <param name="ra" value="4.3382858653453695"/>
+                          <param name="dec" value="348.8563719107751"/>
+                        </paramset>
+                        <paramset name="proper-motion">
+                          <param name="delta-ra" value="-14.985691687370013"/>
+                          <param name="delta-dec" value="-6.722483282732992"/>
+                          <param name="epoch" value="2015.5"/>
+                        </paramset>
+                        <param name="tag" value="sidereal"/>
+                      </paramset>
+                    </paramset>
+                  </paramset>
+                </paramset>
+              </paramset>
+            </paramset>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="def819c0-3401-4a66-8bd3-ca1a7408fd60" name="Observing Conditions">
+          <paramset name="Observing Conditions" kind="dataObj">
+            <param name="CloudCover" value="PERCENT_80"/>
+            <param name="ImageQuality" value="ANY"/>
+            <param name="SkyBackground" value="ANY"/>
+            <param name="WaterVapor" value="ANY"/>
+            <param name="ElevationConstraintType" value="NONE"/>
+            <param name="ElevationConstraintMin" value="0.0"/>
+            <param name="ElevationConstraintMax" value="0.0"/>
+            <paramset name="timing-window-list"/>
+          </paramset>
+        </container>
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e55abc90-eeb9-4c1b-a568-3cae239308ed" name="Observing Log">
+          <paramset name="Observing Log" kind="dataObj">
+            <paramset name="obsQaRecord"/>
+          </paramset>
+        </container>
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c61f357c-7c17-4848-8346-a3f165f34e3b" name="Observation Exec Log">
+          <paramset name="Observation Exec Log" kind="dataObj">
+            <paramset name="obsExecRecord">
+              <paramset name="datasets"/>
+              <paramset name="events"/>
+              <paramset name="configMap"/>
+            </paramset>
+          </paramset>
+        </container>
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="a9792111-9f82-4c47-8d20-abe7d1c1e143" name="Sequence">
+          <paramset name="Sequence" kind="dataObj"/>
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="179a698b-fb7c-44aa-b505-e318760e894a" name="GHOST Sequence">
+            <paramset name="GHOST Sequence" kind="dataObj">
+              <param name="blueExposureCount" value="1"/>
+              <param name="blueExposureTime" value="600.0"/>
+              <param name="redExposureCount" value="1"/>
+              <param name="redExposureTime" value="600.0"/>
+            </paramset>
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="50859f53-a112-4fe3-b679-fd574a3024cb" name="Observe">
+              <paramset name="Observe" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="class" value="SCIENCE"/>
+              </paramset>
+            </container>
+          </container>
+        </container>
+      </container>
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="7302de0a-99d8-47c4-92d3-b2d0bf4e96c5" name="">
+        <paramset name="Observation" kind="dataObj">
+          <param name="title" value="GHOST science - SRIFU1 + sky example"/>
+          <param name="libraryId" value=""/>
+          <param name="priority" value="LOW"/>
+          <param name="tooOverrideRapid" value="false"/>
+          <param name="phase2Status" value="PI_TO_COMPLETE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1667237400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
+            </paramset>
+          </paramset>
+          <param name="qaState" value="UNDEFINED"/>
+          <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
+        </paramset>
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="a746d845-cffe-4ba3-8edf-abdb42c27801" name="GHOST">
+          <paramset name="GHOST" kind="dataObj">
+            <param name="posAngle" value="0"/>
+            <param name="issPort" value="UP_LOOKING"/>
+            <param name="enableFiberAgitator1" value="false"/>
+            <param name="enableFiberAgitator2" value="false"/>
+            <param name="redExposureTime" value="600.0"/>
+            <param name="redExposureCount" value="1"/>
+            <param name="redBinning" value="ONE_BY_ONE"/>
+            <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
+            <param name="blueExposureTime" value="600.0"/>
+            <param name="blueExposureCount" value="1"/>
+            <param name="blueBinning" value="ONE_BY_ONE"/>
+            <param name="blueReadNoiseGain" value="SLOW_LOW"/>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="71e6a8d8-474d-4a01-b7ec-cb83d5f3359a" name="Targets">
+          <paramset name="Targets" kind="dataObj">
+            <paramset name="targetEnv">
+              <paramset name="asterism">
+                <paramset name="ifu1">
+                  <paramset name="target">
+                    <param name="name" value="HD1355"/>
+                    <param name="redshift" value="-5.0E-6"/>
+                    <param name="parallax" value="3.7153"/>
+                    <paramset name="magnitude">
+                      <param name="value" value="9.96"/>
+                      <param name="band" value="B"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.03"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="8.87"/>
+                      <param name="band" value="V"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.02"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="7.037"/>
+                      <param name="band" value="J"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.018"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="6.532"/>
+                      <param name="band" value="H"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.044"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="6.415"/>
+                      <param name="band" value="K"/>
+                      <param name="system" value="Vega"/>
+                      <param name="error" value="0.024"/>
+                    </paramset>
+                    <paramset name="coordinates">
+                      <param name="ra" value="4.423109895970015"/>
+                      <param name="dec" value="348.784820192"/>
+                    </paramset>
+                    <paramset name="proper-motion">
+                      <param name="delta-ra" value="7.57"/>
+                      <param name="delta-dec" value="-8.661"/>
+                      <param name="epoch" value="2000.0"/>
+                    </paramset>
+                    <param name="tag" value="sidereal"/>
+                  </paramset>
+                  <param name="guideFiberState" value="enabled"/>
+                </paramset>
+                <paramset name="ifu2">
+                  <param name="ra" value="4.423108333333346"/>
+                  <param name="dec" value="348.81815277777775"/>
+                </paramset>
+                <param name="tag" value="ghostTargetPlusSky"/>
+              </paramset>
+              <paramset name="guideEnv">
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoActiveTag"/>
+                  <param name="posAngle" value="0.0"/>
+                  <paramset name="guider">
+                    <param name="key" value="PWFS2"/>
+                    <param name="primary" value="0"/>
+                    <paramset name="spTarget">
+                      <paramset name="target">
+                        <param name="name" value="Gaia DR2 2424603635247995264"/>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.633876256076077"/>
+                          <param name="band" value="V"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.293584146793286"/>
+                          <param name="band" value="R"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.968376909683993"/>
+                          <param name="band" value="I"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.4838517478606"/>
+                          <param name="band" value="r"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.36244890570376"/>
+                          <param name="band" value="i"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.87175494000135"/>
+                          <param name="band" value="g"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.153477242505286"/>
+                          <param name="band" value="K"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.222237037468298"/>
+                          <param name="band" value="H"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.491788136526072"/>
+                          <param name="band" value="J"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="coordinates">
+                          <param name="ra" value="4.3382858653453695"/>
+                          <param name="dec" value="348.8563719107751"/>
+                        </paramset>
+                        <paramset name="proper-motion">
+                          <param name="delta-ra" value="-14.985691687370013"/>
+                          <param name="delta-dec" value="-6.722483282732992"/>
+                          <param name="epoch" value="2015.5"/>
+                        </paramset>
+                        <param name="tag" value="sidereal"/>
+                      </paramset>
+                    </paramset>
+                  </paramset>
+                </paramset>
+              </paramset>
+            </paramset>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="750d6980-8b3b-4af7-8a24-7acd5ba13faf" name="Observing Conditions">
+          <paramset name="Observing Conditions" kind="dataObj">
+            <param name="CloudCover" value="PERCENT_80"/>
+            <param name="ImageQuality" value="ANY"/>
+            <param name="SkyBackground" value="ANY"/>
+            <param name="WaterVapor" value="ANY"/>
+            <param name="ElevationConstraintType" value="NONE"/>
+            <param name="ElevationConstraintMin" value="0.0"/>
+            <param name="ElevationConstraintMax" value="0.0"/>
+            <paramset name="timing-window-list"/>
+          </paramset>
+        </container>
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e727993e-3e31-43ba-858a-057ca2c51b3a" name="Observing Log">
+          <paramset name="Observing Log" kind="dataObj">
+            <paramset name="obsQaRecord"/>
+          </paramset>
+        </container>
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="7394f7cf-2f01-47a1-8aff-39ea1d105b68" name="Observation Exec Log">
+          <paramset name="Observation Exec Log" kind="dataObj">
+            <paramset name="obsExecRecord">
+              <paramset name="datasets"/>
+              <paramset name="events"/>
+              <paramset name="configMap"/>
+            </paramset>
+          </paramset>
+        </container>
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="9ae6255a-2082-47a6-a084-0969ca5b00c2" name="Sequence">
+          <paramset name="Sequence" kind="dataObj"/>
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="d2403616-71fb-46d0-a741-eb82e4a31599" name="GHOST Sequence">
+            <paramset name="GHOST Sequence" kind="dataObj">
+              <param name="blueExposureCount" value="1"/>
+              <param name="blueExposureTime" value="600.0"/>
+              <param name="redExposureCount" value="1"/>
+              <param name="redExposureTime" value="600.0"/>
+            </paramset>
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="f288dd5d-5de1-4e65-a08e-1d4c31f22c16" name="Observe">
+              <paramset name="Observe" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="class" value="SCIENCE"/>
+              </paramset>
+            </container>
           </container>
         </container>
       </container>
     </container>
-    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="d83369a8-7fee-4c71-91f1-0b90ed5c74e8" name="">
-      <paramset name="Observation" kind="dataObj">
-        <param name="title" value="GHOST science - high resolution example"/>
+    <container kind="group" type="Group" version="2009A-1" subtype="group" key="5670c483-7d2b-4ff3-b7e2-100a4fe78c32" name="Group">
+      <paramset name="Group" kind="dataObj">
+        <param name="title" value="GHOST Dual-Target Blind Offset Example"/>
+        <param name="GroupType" value="TYPE_FOLDER"/>
         <param name="libraryId" value=""/>
-        <param name="priority" value="LOW"/>
-        <param name="tooOverrideRapid" value="false"/>
-        <param name="phase2Status" value="PI_TO_COMPLETE"/>
-        <paramset name="schedulingBlock">
-          <param name="start" value="1667237400000"/>
-          <paramset name="duration">
-            <param name="tag" value="unstated"/>
-          </paramset>
-        </paramset>
-        <param name="qaState" value="UNDEFINED"/>
-        <param name="overrideQaState" value="false"/>
-        <param name="setupTimeType" value="FULL"/>
       </paramset>
-      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="1dc5f526-e0d2-4fae-9f16-bfe3945c8b2d" name="GHOST">
-        <paramset name="GHOST" kind="dataObj">
-          <param name="posAngle" value="0"/>
-          <param name="issPort" value="UP_LOOKING"/>
-          <param name="enableFiberAgitator1" value="false"/>
-          <param name="enableFiberAgitator2" value="false"/>
-          <param name="redExposureTime" value="600.0"/>
-          <param name="redExposureCount" value="1"/>
-          <param name="redBinning" value="ONE_BY_ONE"/>
-          <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
-          <param name="blueExposureTime" value="600.0"/>
-          <param name="blueExposureCount" value="1"/>
-          <param name="blueBinning" value="ONE_BY_ONE"/>
-          <param name="blueReadNoiseGain" value="SLOW_LOW"/>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="4fdd9069-5642-4066-9595-3cc66697e098" name="Targets">
-        <paramset name="Targets" kind="dataObj">
-          <paramset name="targetEnv">
-            <paramset name="asterism">
-              <paramset name="ifu1">
-                <paramset name="target">
-                  <param name="name" value="HD1355"/>
-                  <param name="redshift" value="-5.0E-6"/>
-                  <param name="parallax" value="3.7153"/>
-                  <paramset name="magnitude">
-                    <param name="value" value="9.96"/>
-                    <param name="band" value="B"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.03"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="8.87"/>
-                    <param name="band" value="V"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.02"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="7.037"/>
-                    <param name="band" value="J"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.018"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="6.532"/>
-                    <param name="band" value="H"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.044"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="6.415"/>
-                    <param name="band" value="K"/>
-                    <param name="system" value="Vega"/>
-                    <param name="error" value="0.024"/>
-                  </paramset>
-                  <paramset name="coordinates">
-                    <param name="ra" value="4.423109895970015"/>
-                    <param name="dec" value="348.784820192"/>
-                  </paramset>
-                  <paramset name="proper-motion">
-                    <param name="delta-ra" value="7.57"/>
-                    <param name="delta-dec" value="-8.661"/>
-                    <param name="epoch" value="2000.0"/>
-                  </paramset>
-                  <param name="tag" value="sidereal"/>
-                </paramset>
-                <param name="guideFiberState" value="enabled"/>
-              </paramset>
-              <paramset name="ifu2">
-                <param name="ra" value="4.423108333333346"/>
-                <param name="dec" value="348.81815277777775"/>
-              </paramset>
-              <param name="tag" value="ghostTargetPlusSky"/>
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="b10cea79-520c-41ad-8317-2d2e153b62ee" name="">
+        <paramset name="Observation" kind="dataObj">
+          <param name="title" value="GHOST Blind Offset Acquistion"/>
+          <param name="libraryId" value=""/>
+          <param name="priority" value="LOW"/>
+          <param name="tooOverrideRapid" value="false"/>
+          <param name="phase2Status" value="PI_TO_COMPLETE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1667237400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
             </paramset>
-            <paramset name="guideEnv">
-              <param name="primary" value="0"/>
-              <paramset name="guideGroup">
-                <param name="tag" value="AutoActiveTag"/>
-                <param name="posAngle" value="0.0"/>
-                <paramset name="guider">
-                  <param name="key" value="PWFS2"/>
-                  <param name="primary" value="0"/>
-                  <paramset name="spTarget">
-                    <paramset name="target">
-                      <param name="name" value="Gaia DR2 2424603635247995264"/>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.633876256076077"/>
-                        <param name="band" value="V"/>
-                        <param name="system" value="Vega"/>
+          </paramset>
+          <param name="qaState" value="UNDEFINED"/>
+          <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
+        </paramset>
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="43c5cf6b-385d-4d6a-85a2-7b0f5f5376bb" name="Observing Conditions">
+          <paramset name="Observing Conditions" kind="dataObj">
+            <param name="CloudCover" value="PERCENT_80"/>
+            <param name="ImageQuality" value="PERCENT_85"/>
+            <param name="SkyBackground" value="ANY"/>
+            <param name="WaterVapor" value="ANY"/>
+            <param name="ElevationConstraintType" value="NONE"/>
+            <param name="ElevationConstraintMin" value="0.0"/>
+            <param name="ElevationConstraintMax" value="0.0"/>
+            <paramset name="timing-window-list"/>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="59be42f1-d10e-4bfe-95b4-dd5a8eb07911" name="Targets">
+          <paramset name="Targets" kind="dataObj">
+            <paramset name="targetEnv">
+              <paramset name="asterism">
+                <paramset name="ifu1">
+                  <paramset name="target">
+                    <param name="name" value="Blind offset star 1"/>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.540602126287425"/>
+                      <param name="band" value="V"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="12.60853803040833"/>
+                      <param name="band" value="R"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="11.73085535014483"/>
+                      <param name="band" value="I"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="12.965546527205884"/>
+                      <param name="band" value="r"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="12.254423417964805"/>
+                      <param name="band" value="i"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="14.425740567653925"/>
+                      <param name="band" value="g"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="9.431187484568328"/>
+                      <param name="band" value="K"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="9.642228680623004"/>
+                      <param name="band" value="H"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="10.419930317804981"/>
+                      <param name="band" value="J"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="coordinates">
+                      <param name="ra" value="138.10330141801182"/>
+                      <param name="dec" value="295.1471197885487"/>
+                    </paramset>
+                    <paramset name="proper-motion">
+                      <param name="delta-ra" value="1.0689751563270562"/>
+                      <param name="delta-dec" value="0.3855455842259491"/>
+                      <param name="epoch" value="2015.5"/>
+                    </paramset>
+                    <param name="tag" value="sidereal"/>
+                  </paramset>
+                  <param name="guideFiberState" value="enabled"/>
+                </paramset>
+                <paramset name="ifu2">
+                  <paramset name="target">
+                    <param name="name" value="Blind offset star 2"/>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.482837381156648"/>
+                      <param name="band" value="V"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.014116381900589"/>
+                      <param name="band" value="R"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="12.569532900143715"/>
+                      <param name="band" value="I"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.222772197594425"/>
+                      <param name="band" value="r"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="12.992566175573536"/>
+                      <param name="band" value="i"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.872616374866258"/>
+                      <param name="band" value="g"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="11.397964529870588"/>
+                      <param name="band" value="K"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="11.500404111686649"/>
+                      <param name="band" value="H"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="11.902407954909663"/>
+                      <param name="band" value="J"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="coordinates">
+                      <param name="ra" value="137.91709562221183"/>
+                      <param name="dec" value="295.1292838791403"/>
+                    </paramset>
+                    <paramset name="proper-motion">
+                      <param name="delta-ra" value="-60.315023745901705"/>
+                      <param name="delta-dec" value="36.41305473977431"/>
+                      <param name="epoch" value="2015.5"/>
+                    </paramset>
+                    <param name="tag" value="sidereal"/>
+                  </paramset>
+                  <param name="guideFiberState" value="enabled"/>
+                </paramset>
+                <paramset name="base">
+                  <param name="ra" value="138.01548333333335"/>
+                  <param name="dec" value="295.14828055555563"/>
+                </paramset>
+                <param name="tag" value="ghostDualTarget"/>
+              </paramset>
+              <paramset name="guideEnv">
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoActiveTag"/>
+                  <param name="posAngle" value="0.0"/>
+                  <paramset name="guider">
+                    <param name="key" value="PWFS2"/>
+                    <param name="primary" value="0"/>
+                    <paramset name="spTarget">
+                      <paramset name="target">
+                        <param name="name" value="Gaia DR2 5296798418142177408"/>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.515370309968736"/>
+                          <param name="band" value="V"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.88771329675027"/>
+                          <param name="band" value="R"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.294955395380397"/>
+                          <param name="band" value="I"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.128343999268465"/>
+                          <param name="band" value="r"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.753107551018305"/>
+                          <param name="band" value="i"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.085998587066612"/>
+                          <param name="band" value="g"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="8.71098703963027"/>
+                          <param name="band" value="K"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="8.852748444721636"/>
+                          <param name="band" value="H"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="9.400002347582701"/>
+                          <param name="band" value="J"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="coordinates">
+                          <param name="ra" value="137.79725956664652"/>
+                          <param name="dec" value="295.18436389367514"/>
+                        </paramset>
+                        <paramset name="proper-motion">
+                          <param name="delta-ra" value="-5.99068728278085"/>
+                          <param name="delta-dec" value="8.204049925407096"/>
+                          <param name="epoch" value="2015.5"/>
+                        </paramset>
+                        <param name="tag" value="sidereal"/>
                       </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.293584146793286"/>
-                        <param name="band" value="R"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.968376909683993"/>
-                        <param name="band" value="I"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.4838517478606"/>
-                        <param name="band" value="r"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.36244890570376"/>
-                        <param name="band" value="i"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="12.87175494000135"/>
-                        <param name="band" value="g"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.153477242505286"/>
-                        <param name="band" value="K"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.222237037468298"/>
-                        <param name="band" value="H"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.491788136526072"/>
-                        <param name="band" value="J"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="coordinates">
-                        <param name="ra" value="4.3382858653453695"/>
-                        <param name="dec" value="348.8563719107751"/>
-                      </paramset>
-                      <paramset name="proper-motion">
-                        <param name="delta-ra" value="-14.985691687370013"/>
-                        <param name="delta-dec" value="-6.722483282732992"/>
-                        <param name="epoch" value="2015.5"/>
-                      </paramset>
-                      <param name="tag" value="sidereal"/>
                     </paramset>
                   </paramset>
                 </paramset>
               </paramset>
             </paramset>
           </paramset>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="def819c0-3401-4a66-8bd3-ca1a7408fd60" name="Observing Conditions">
-        <paramset name="Observing Conditions" kind="dataObj">
-          <param name="CloudCover" value="PERCENT_80"/>
-          <param name="ImageQuality" value="ANY"/>
-          <param name="SkyBackground" value="ANY"/>
-          <param name="WaterVapor" value="ANY"/>
-          <param name="ElevationConstraintType" value="NONE"/>
-          <param name="ElevationConstraintMin" value="0.0"/>
-          <param name="ElevationConstraintMax" value="0.0"/>
-          <paramset name="timing-window-list"/>
-        </paramset>
-      </container>
-      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e55abc90-eeb9-4c1b-a568-3cae239308ed" name="Observing Log">
-        <paramset name="Observing Log" kind="dataObj">
-          <paramset name="obsQaRecord"/>
-        </paramset>
-      </container>
-      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c61f357c-7c17-4848-8346-a3f165f34e3b" name="Observation Exec Log">
-        <paramset name="Observation Exec Log" kind="dataObj">
-          <paramset name="obsExecRecord">
-            <paramset name="datasets"/>
-            <paramset name="events"/>
-            <paramset name="configMap"/>
-          </paramset>
-        </paramset>
-      </container>
-      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="a9792111-9f82-4c47-8d20-abe7d1c1e143" name="Sequence">
-        <paramset name="Sequence" kind="dataObj"/>
-        <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="179a698b-fb7c-44aa-b505-e318760e894a" name="GHOST Sequence">
-          <paramset name="GHOST Sequence" kind="dataObj">
-            <param name="blueExposureCount" value="1"/>
-            <param name="blueExposureTime" value="600.0"/>
+        </container>
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="c77db346-42d5-44ec-8439-af7cfb317320" name="GHOST">
+          <paramset name="GHOST" kind="dataObj">
+            <param name="posAngle" value="0"/>
+            <param name="issPort" value="UP_LOOKING"/>
+            <param name="enableFiberAgitator1" value="false"/>
+            <param name="enableFiberAgitator2" value="false"/>
+            <param name="redExposureTime" value="60.0"/>
             <param name="redExposureCount" value="1"/>
-            <param name="redExposureTime" value="600.0"/>
+            <param name="redBinning" value="ONE_BY_ONE"/>
+            <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
+            <param name="blueExposureTime" value="60.0"/>
+            <param name="blueExposureCount" value="1"/>
+            <param name="blueBinning" value="ONE_BY_ONE"/>
+            <param name="blueReadNoiseGain" value="SLOW_LOW"/>
           </paramset>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="50859f53-a112-4fe3-b679-fd574a3024cb" name="Observe">
-            <paramset name="Observe" kind="dataObj">
-              <param name="repeatCount" value="1"/>
-              <param name="class" value="SCIENCE"/>
+        </container>
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="7d387cf3-da0f-4550-80a4-a61e4fb49ae6" name="Note">
+          <paramset name="Note" kind="dataObj">
+            <param name="title" value="The acquisition must use the same Base position and PWFS2 guide star as the science"/>
+            <param name="NoteText" value=""/>
+          </paramset>
+        </container>
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="ae5a6751-efb0-4a83-98c8-7cbb7e2498fe" name="Observing Log">
+          <paramset name="Observing Log" kind="dataObj">
+            <paramset name="obsQaRecord"/>
+          </paramset>
+        </container>
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="63a66535-fd15-4413-8d07-1d47f2abdb11" name="Observation Exec Log">
+          <paramset name="Observation Exec Log" kind="dataObj">
+            <paramset name="obsExecRecord">
+              <paramset name="datasets"/>
+              <paramset name="events"/>
+              <paramset name="configMap"/>
             </paramset>
+          </paramset>
+        </container>
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="adad825e-2083-4120-b24a-4ba7a2515fa6" name="Sequence">
+          <paramset name="Sequence" kind="dataObj"/>
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="e0ac23a4-aabe-4ade-8a29-7aefe2a0deb1" name="GHOST Sequence">
+            <paramset name="GHOST Sequence" kind="dataObj">
+              <param name="blueExposureCount" value="1"/>
+              <param name="blueExposureTime" value="60.0"/>
+              <param name="redExposureCount" value="1"/>
+              <param name="redExposureTime" value="60.0"/>
+            </paramset>
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="ecd20cd8-03a3-4bfa-a2da-5b64b6ec0d85" name="Observe">
+              <paramset name="Observe" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="class" value="ACQ"/>
+              </paramset>
+            </container>
           </container>
         </container>
       </container>
-    </container>
-    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="de062e39-31e0-4295-b467-6d199416de8f" name="">
-      <paramset name="Observation" kind="dataObj">
-        <param name="title" value="GHOST science - dual target example"/>
-        <param name="libraryId" value=""/>
-        <param name="priority" value="LOW"/>
-        <param name="tooOverrideRapid" value="false"/>
-        <param name="phase2Status" value="PI_TO_COMPLETE"/>
-        <paramset name="schedulingBlock">
-          <param name="start" value="1667237400000"/>
-          <paramset name="duration">
-            <param name="tag" value="unstated"/>
-          </paramset>
-        </paramset>
-        <param name="qaState" value="UNDEFINED"/>
-        <param name="overrideQaState" value="false"/>
-        <param name="setupTimeType" value="FULL"/>
-      </paramset>
-      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="b21548a1-f66a-44e7-a851-4fc38b485ddc" name="Observing Conditions">
-        <paramset name="Observing Conditions" kind="dataObj">
-          <param name="CloudCover" value="PERCENT_80"/>
-          <param name="ImageQuality" value="ANY"/>
-          <param name="SkyBackground" value="ANY"/>
-          <param name="WaterVapor" value="ANY"/>
-          <param name="ElevationConstraintType" value="NONE"/>
-          <param name="ElevationConstraintMin" value="0.0"/>
-          <param name="ElevationConstraintMax" value="0.0"/>
-          <paramset name="timing-window-list"/>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="390bf25d-d650-4b0a-96a1-1f3373634566" name="GHOST">
-        <paramset name="GHOST" kind="dataObj">
-          <param name="posAngle" value="0"/>
-          <param name="issPort" value="UP_LOOKING"/>
-          <param name="enableFiberAgitator1" value="false"/>
-          <param name="enableFiberAgitator2" value="false"/>
-          <param name="redExposureTime" value="600.0"/>
-          <param name="redExposureCount" value="1"/>
-          <param name="redBinning" value="ONE_BY_ONE"/>
-          <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
-          <param name="blueExposureTime" value="600.0"/>
-          <param name="blueExposureCount" value="1"/>
-          <param name="blueBinning" value="ONE_BY_ONE"/>
-          <param name="blueReadNoiseGain" value="SLOW_LOW"/>
-        </paramset>
-      </container>
-      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e854a9d0-0ac6-4b3a-b738-99000d4469b5" name="Targets">
-        <paramset name="Targets" kind="dataObj">
-          <paramset name="targetEnv">
-            <paramset name="asterism">
-              <paramset name="ifu1">
-                <paramset name="target">
-                  <param name="name" value="NGC2808 star1 "/>
-                  <paramset name="magnitude">
-                    <param name="value" value="13.23072477955091"/>
-                    <param name="band" value="V"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="12.150290743698195"/>
-                    <param name="band" value="R"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="11.133283169636655"/>
-                    <param name="band" value="I"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="12.599432443541296"/>
-                    <param name="band" value="r"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="11.68799822472841"/>
-                    <param name="band" value="i"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="14.250653157785202"/>
-                    <param name="band" value="g"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="8.514383555398194"/>
-                    <param name="band" value="K"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="8.756784038894278"/>
-                    <param name="band" value="H"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="9.627747336078956"/>
-                    <param name="band" value="J"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="coordinates">
-                    <param name="ra" value="138.08428805253521"/>
-                    <param name="dec" value="295.12763567379943"/>
-                  </paramset>
-                  <paramset name="proper-motion">
-                    <param name="delta-ra" value="1.1413518814497048"/>
-                    <param name="delta-dec" value="0.3346264845685283"/>
-                    <param name="epoch" value="2015.5"/>
-                  </paramset>
-                  <param name="tag" value="sidereal"/>
-                </paramset>
-                <param name="guideFiberState" value="enabled"/>
-              </paramset>
-              <paramset name="ifu2">
-                <paramset name="target">
-                  <param name="name" value="NGC2808 star 2"/>
-                  <paramset name="magnitude">
-                    <param name="value" value="14.725969124078764"/>
-                    <param name="band" value="V"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="14.0201028644874"/>
-                    <param name="band" value="R"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="13.354272681502447"/>
-                    <param name="band" value="I"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="14.282613077124529"/>
-                    <param name="band" value="r"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="13.82944676779055"/>
-                    <param name="band" value="i"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="15.381803930363931"/>
-                    <param name="band" value="g"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="11.577787215047401"/>
-                    <param name="band" value="K"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="11.738050785399366"/>
-                    <param name="band" value="H"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="magnitude">
-                    <param name="value" value="12.350072896201958"/>
-                    <param name="band" value="J"/>
-                    <param name="system" value="Vega"/>
-                  </paramset>
-                  <paramset name="coordinates">
-                    <param name="ra" value="137.97067205480164"/>
-                    <param name="dec" value="295.15336877266816"/>
-                  </paramset>
-                  <paramset name="proper-motion">
-                    <param name="delta-ra" value="0.8458675442987402"/>
-                    <param name="delta-dec" value="0.2660131714228431"/>
-                    <param name="epoch" value="2015.5"/>
-                  </paramset>
-                  <param name="tag" value="sidereal"/>
-                </paramset>
-                <param name="guideFiberState" value="enabled"/>
-              </paramset>
-              <param name="tag" value="ghostDualTarget"/>
+      <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="31fc4496-7292-4ac8-bc03-0f8f531fc26f" name="">
+        <paramset name="Observation" kind="dataObj">
+          <param name="title" value="GHOST Science - dual target example"/>
+          <param name="libraryId" value=""/>
+          <param name="priority" value="LOW"/>
+          <param name="tooOverrideRapid" value="false"/>
+          <param name="phase2Status" value="PI_TO_COMPLETE"/>
+          <paramset name="schedulingBlock">
+            <param name="start" value="1667237400000"/>
+            <paramset name="duration">
+              <param name="tag" value="unstated"/>
             </paramset>
-            <paramset name="guideEnv">
-              <param name="primary" value="0"/>
-              <paramset name="guideGroup">
-                <param name="tag" value="AutoActiveTag"/>
-                <param name="posAngle" value="0.0"/>
-                <paramset name="guider">
-                  <param name="key" value="PWFS2"/>
-                  <param name="primary" value="0"/>
-                  <paramset name="spTarget">
-                    <paramset name="target">
-                      <param name="name" value="Gaia DR2 5248754909672194304"/>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.217195629875249"/>
-                        <param name="band" value="V"/>
-                        <param name="system" value="Vega"/>
+          </paramset>
+          <param name="qaState" value="UNDEFINED"/>
+          <param name="overrideQaState" value="false"/>
+          <param name="setupTimeType" value="FULL"/>
+        </paramset>
+        <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="8d9596fc-36ed-4414-8673-d72274b9ee36" name="Observing Conditions">
+          <paramset name="Observing Conditions" kind="dataObj">
+            <param name="CloudCover" value="PERCENT_80"/>
+            <param name="ImageQuality" value="PERCENT_85"/>
+            <param name="SkyBackground" value="ANY"/>
+            <param name="WaterVapor" value="ANY"/>
+            <param name="ElevationConstraintType" value="NONE"/>
+            <param name="ElevationConstraintMin" value="0.0"/>
+            <param name="ElevationConstraintMax" value="0.0"/>
+            <paramset name="timing-window-list"/>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="05be8153-db95-4b88-9312-d793120f67b9" name="GHOST">
+          <paramset name="GHOST" kind="dataObj">
+            <param name="posAngle" value="0"/>
+            <param name="issPort" value="UP_LOOKING"/>
+            <param name="enableFiberAgitator1" value="false"/>
+            <param name="enableFiberAgitator2" value="false"/>
+            <param name="redExposureTime" value="600.0"/>
+            <param name="redExposureCount" value="1"/>
+            <param name="redBinning" value="ONE_BY_ONE"/>
+            <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
+            <param name="blueExposureTime" value="600.0"/>
+            <param name="blueExposureCount" value="1"/>
+            <param name="blueBinning" value="ONE_BY_ONE"/>
+            <param name="blueReadNoiseGain" value="SLOW_LOW"/>
+          </paramset>
+        </container>
+        <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e263164f-5752-4ce2-b2db-2efbfb23912f" name="Targets">
+          <paramset name="Targets" kind="dataObj">
+            <paramset name="targetEnv">
+              <paramset name="asterism">
+                <paramset name="ifu1">
+                  <paramset name="target">
+                    <param name="name" value="NGC 2808 faint star 1"/>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.272973210794284"/>
+                      <param name="band" value="V"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="15.678643826864887"/>
+                      <param name="band" value="R"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="15.116994007208147"/>
+                      <param name="band" value="I"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="15.911326777387487"/>
+                      <param name="band" value="r"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="15.567842639776718"/>
+                      <param name="band" value="i"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.80648020046969"/>
+                      <param name="band" value="g"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.617067717094885"/>
+                      <param name="band" value="K"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="13.75078171150603"/>
+                      <param name="band" value="H"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="14.269145490776769"/>
+                      <param name="band" value="J"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="coordinates">
+                      <param name="ra" value="138.100190667685"/>
+                      <param name="dec" value="295.1655739283892"/>
+                    </paramset>
+                    <paramset name="proper-motion">
+                      <param name="delta-ra" value="0.8683509274050563"/>
+                      <param name="delta-dec" value="0.01392946979236137"/>
+                      <param name="epoch" value="2015.5"/>
+                    </paramset>
+                    <param name="tag" value="sidereal"/>
+                  </paramset>
+                  <param name="guideFiberState" value="disabled"/>
+                </paramset>
+                <paramset name="ifu2">
+                  <paramset name="target">
+                    <param name="name" value="NGC 2808 faint star 2"/>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.587159291374096"/>
+                      <param name="band" value="V"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.437130969820974"/>
+                      <param name="band" value="R"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.288077063777287"/>
+                      <param name="band" value="I"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.598449360536343"/>
+                      <param name="band" value="r"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.638100265973634"/>
+                      <param name="band" value="i"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.5957417400078"/>
+                      <param name="band" value="g"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.047495596950974"/>
+                      <param name="band" value="K"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.062624200172856"/>
+                      <param name="band" value="H"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="magnitude">
+                      <param name="value" value="16.106383922734544"/>
+                      <param name="band" value="J"/>
+                      <param name="system" value="Vega"/>
+                    </paramset>
+                    <paramset name="coordinates">
+                      <param name="ra" value="137.93066799836322"/>
+                      <param name="dec" value="295.13103334494247"/>
+                    </paramset>
+                    <paramset name="proper-motion">
+                      <param name="delta-ra" value="1.1563374284612635"/>
+                      <param name="delta-dec" value="-0.27641211765731244"/>
+                      <param name="epoch" value="2015.5"/>
+                    </paramset>
+                    <param name="tag" value="sidereal"/>
+                  </paramset>
+                  <param name="guideFiberState" value="disabled"/>
+                </paramset>
+                <param name="tag" value="ghostDualTarget"/>
+              </paramset>
+              <paramset name="guideEnv">
+                <param name="primary" value="0"/>
+                <paramset name="guideGroup">
+                  <param name="tag" value="AutoActiveTag"/>
+                  <param name="posAngle" value="0.0"/>
+                  <paramset name="guider">
+                    <param name="key" value="PWFS2"/>
+                    <param name="primary" value="0"/>
+                    <paramset name="spTarget">
+                      <paramset name="target">
+                        <param name="name" value="Gaia DR2 5296798418142177408"/>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.515370309968736"/>
+                          <param name="band" value="V"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.88771329675027"/>
+                          <param name="band" value="R"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.294955395380397"/>
+                          <param name="band" value="I"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="11.128343999268465"/>
+                          <param name="band" value="r"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="10.753107551018305"/>
+                          <param name="band" value="i"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="12.085998587066612"/>
+                          <param name="band" value="g"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="8.71098703963027"/>
+                          <param name="band" value="K"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="8.852748444721636"/>
+                          <param name="band" value="H"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="magnitude">
+                          <param name="value" value="9.400002347582701"/>
+                          <param name="band" value="J"/>
+                          <param name="system" value="Vega"/>
+                        </paramset>
+                        <paramset name="coordinates">
+                          <param name="ra" value="137.79725956664652"/>
+                          <param name="dec" value="295.18436389367514"/>
+                        </paramset>
+                        <paramset name="proper-motion">
+                          <param name="delta-ra" value="-5.99068728278085"/>
+                          <param name="delta-dec" value="8.204049925407096"/>
+                          <param name="epoch" value="2015.5"/>
+                        </paramset>
+                        <param name="tag" value="sidereal"/>
                       </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="10.707163258058326"/>
-                        <param name="band" value="R"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="10.22410985101349"/>
-                        <param name="band" value="I"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="10.92282703677957"/>
-                        <param name="band" value="r"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="10.656343741740354"/>
-                        <param name="band" value="i"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="11.654860415648425"/>
-                        <param name="band" value="g"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="8.942442674948325"/>
-                        <param name="band" value="K"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="9.055339339134704"/>
-                        <param name="band" value="H"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="magnitude">
-                        <param name="value" value="9.496968122250106"/>
-                        <param name="band" value="J"/>
-                        <param name="system" value="Vega"/>
-                      </paramset>
-                      <paramset name="coordinates">
-                        <param name="ra" value="138.2058987921505"/>
-                        <param name="dec" value="295.0557015649252"/>
-                      </paramset>
-                      <paramset name="proper-motion">
-                        <param name="delta-ra" value="36.64160021542454"/>
-                        <param name="delta-dec" value="-1.7399778064393452"/>
-                        <param name="epoch" value="2015.5"/>
-                      </paramset>
-                      <param name="tag" value="sidereal"/>
                     </paramset>
                   </paramset>
                 </paramset>
               </paramset>
             </paramset>
           </paramset>
-        </paramset>
-      </container>
-      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="b17e6907-f468-4e67-9ec6-383e49706947" name="Observing Log">
-        <paramset name="Observing Log" kind="dataObj">
-          <paramset name="obsQaRecord"/>
-        </paramset>
-      </container>
-      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="b6d12fa3-f63e-4ded-8a20-89704fad23e3" name="Observation Exec Log">
-        <paramset name="Observation Exec Log" kind="dataObj">
-          <paramset name="obsExecRecord">
-            <paramset name="datasets"/>
-            <paramset name="events"/>
-            <paramset name="configMap"/>
+        </container>
+        <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="13dec610-0561-4716-9d7e-834f16d6dba3" name="Note">
+          <paramset name="Note" kind="dataObj">
+            <param name="title" value="Faint targets, so GHOST guiding should be off"/>
+            <param name="NoteText" value=""/>
           </paramset>
-        </paramset>
-      </container>
-      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="cdb0232a-a726-4289-b548-b6c6f772469c" name="Sequence">
-        <paramset name="Sequence" kind="dataObj"/>
-        <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="caef6c68-7aef-4c4a-a84c-d7e1a95d7601" name="GHOST Sequence">
-          <paramset name="GHOST Sequence" kind="dataObj">
-            <param name="blueExposureCount" value="1"/>
-            <param name="blueExposureTime" value="600.0"/>
-            <param name="redExposureCount" value="1"/>
-            <param name="redExposureTime" value="600.0"/>
+        </container>
+        <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="2f332554-3ec6-4af9-9f1e-470677f3b70f" name="Observing Log">
+          <paramset name="Observing Log" kind="dataObj">
+            <paramset name="obsQaRecord"/>
           </paramset>
-          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="922bfd1a-28a3-4584-bd54-62ac347a0032" name="Observe">
-            <paramset name="Observe" kind="dataObj">
-              <param name="repeatCount" value="1"/>
-              <param name="class" value="SCIENCE"/>
+        </container>
+        <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="972d6351-c8a3-4cec-9e06-adc30b9cc1b3" name="Observation Exec Log">
+          <paramset name="Observation Exec Log" kind="dataObj">
+            <paramset name="obsExecRecord">
+              <paramset name="datasets"/>
+              <paramset name="events"/>
+              <paramset name="configMap"/>
             </paramset>
+          </paramset>
+        </container>
+        <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="0b76f7ea-57c6-4b27-90d6-f3d3c424518e" name="Sequence">
+          <paramset name="Sequence" kind="dataObj"/>
+          <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="ef45c9c4-3cbf-4e0d-8763-25bbd6a4e98e" name="GHOST Sequence">
+            <paramset name="GHOST Sequence" kind="dataObj">
+              <param name="blueExposureCount" value="1"/>
+              <param name="blueExposureTime" value="600.0"/>
+              <param name="redExposureCount" value="1"/>
+              <param name="redExposureTime" value="600.0"/>
+            </paramset>
+            <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="f4f94cf2-e621-4b04-9c35-5861f7375fda" name="Observe">
+              <paramset name="Observe" kind="dataObj">
+                <param name="repeatCount" value="1"/>
+                <param name="class" value="SCIENCE"/>
+              </paramset>
+            </container>
           </container>
         </container>
       </container>
@@ -813,13 +1402,33 @@
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="ae5a6751-efb0-4a83-98c8-7cbb7e2498fe"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ecd20cd8-03a3-4bfa-a2da-5b64b6ec0d85"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="2"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="8d9596fc-36ed-4414-8673-d72274b9ee36"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="2"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="a746d845-cffe-4ba3-8edf-abdb42c27801"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="43c5cf6b-385d-4d6a-85a2-7b0f5f5376bb"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="3"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="71e6a8d8-474d-4a01-b7ec-cb83d5f3359a"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="51"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e263164f-5752-4ce2-b2db-2efbfb23912f"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="66"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="9ae6255a-2082-47a6-a084-0969ca5b00c2"/>
@@ -832,14 +1441,24 @@
     <paramset name="node">
       <param name="key" value="668cc23e-f767-4279-94ff-7d06026703f7"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="12"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="4"/>
+      <param name="249f5e6b-b759-4893-8e81-bfe829073b99" value="9"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="e9a65dbe-e121-4022-8518-550b79bc1b1e"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="66"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="13dec610-0561-4716-9d7e-834f16d6dba3"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="52"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="d4e317bc-f38d-4bce-8dc5-2dc5a1ba13ef"/>
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="64"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ef45c9c4-3cbf-4e0d-8763-25bbd6a4e98e"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="aa14b2b0-07b7-4503-beff-856455c7529a"/>
@@ -852,6 +1471,10 @@
     <paramset name="node">
       <param name="key" value="e727993e-3e31-43ba-858a-057ca2c51b3a"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="59be42f1-d10e-4bfe-95b4-dd5a8eb07911"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="95"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="81fdf234-3253-4f2b-8c0f-a224f2310325"/>
@@ -880,8 +1503,17 @@
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="65"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="0b76f7ea-57c6-4b27-90d6-f3d3c424518e"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b10cea79-520c-41ad-8317-2d2e153b62ee"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="37"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="e854a9d0-0ac6-4b3a-b738-99000d4469b5"/>
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="21"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="c61f357c-7c17-4848-8346-a3f165f34e3b"/>
@@ -891,18 +1523,40 @@
       <param name="key" value="b1ebce10-d2be-4de1-93ee-7277da77dbef"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="9"/>
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="4"/>
+      <param name="249f5e6b-b759-4893-8e81-bfe829073b99" value="11"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="750d6980-8b3b-4af7-8a24-7acd5ba13faf"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="5"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="05be8153-db95-4b88-9312-d793120f67b9"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="5670c483-7d2b-4ff3-b7e2-100a4fe78c32"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="71"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="56e679b6-1740-47fe-855f-706f5071ff24"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="40"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="adad825e-2083-4120-b24a-4ba7a2515fa6"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="2"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b0e8d299-49a4-4736-984e-e22a8b9ff720"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="27"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="b17e6907-f468-4e67-9ec6-383e49706947"/>
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="63a66535-fd15-4413-8d07-1d47f2abdb11"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="7302de0a-99d8-47c4-92d3-b2d0bf4e96c5"/>
@@ -910,8 +1564,20 @@
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="2f332554-3ec6-4af9-9f1e-470677f3b70f"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c77db346-42d5-44ec-8439-af7cfb317320"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="4"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="cdb0232a-a726-4289-b548-b6c6f772469c"/>
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="972d6351-c8a3-4cec-9e06-adc30b9cc1b3"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="2"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="1ae16348-fc28-4ef7-826d-12dd96e35741"/>
@@ -922,13 +1588,22 @@
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="4"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="31fc4496-7292-4ac8-bc03-0f8f531fc26f"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="6"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="922bfd1a-28a3-4584-bd54-62ac347a0032"/>
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="f4f94cf2-e621-4b04-9c35-5861f7375fda"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="4fdd9069-5642-4066-9595-3cc66697e098"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="2"/>
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="2"/>
+      <param name="249f5e6b-b759-4893-8e81-bfe829073b99" value="1"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="7394f7cf-2f01-47a1-8aff-39ea1d105b68"/>
@@ -951,6 +1626,10 @@
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="7"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="e0ac23a4-aabe-4ade-8a29-7aefe2a0deb1"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="3"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="d2403616-71fb-46d0-a741-eb82e4a31599"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
     </paramset>
@@ -963,9 +1642,14 @@
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="2"/>
     </paramset>
     <paramset name="node">
+      <param name="key" value="7d387cf3-da0f-4550-80a4-a61e4fb49ae6"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="127"/>
+    </paramset>
+    <paramset name="node">
       <param name="key" value="51a43069-2f6c-4026-a201-f3e701892613"/>
       <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="55"/>
       <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+      <param name="746d55d9-9e08-4a74-ab1a-1f9745db28cf" value="5"/>
     </paramset>
     <paramset name="node">
       <param name="key" value="caef6c68-7aef-4c4a-a84c-d7e1a95d7601"/>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GHOST_BP.xml
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/resources/edu/gemini/phase2/template/factory/xml/GHOST_BP.xml
@@ -1,0 +1,975 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document PUBLIC "-//Gemini Observatory//DTD for Storage of P1 and P2 Documents//EN" "http://ftp.gemini.edu/Support/xml/dtds/SpXML2.dtd">
+
+<document>
+  <container kind="program" type="Program" version="2023A-1" subtype="basic" key="51a43069-2f6c-4026-a201-f3e701892613" name="">
+    <paramset name="Science Program" kind="dataObj">
+      <param name="title" value="GHOST PHASE I/II MAPPING BPS"/>
+      <param name="programMode" value="QUEUE"/>
+      <param name="tooType" value="none"/>
+      <param name="programStatus" value="PHASE2"/>
+      <param name="nextObsId" value="1"/>
+      <paramset name="piInfo">
+        <param name="firstName" value=""/>
+        <param name="lastName" value=""/>
+        <param name="email" value=""/>
+        <param name="phone" value=""/>
+      </paramset>
+      <param name="queueBand" value="1"/>
+      <param name="isLibrary" value="true"/>
+      <paramset name="timeAcct"/>
+      <param name="awardedTime" value="0.0" units="hours"/>
+      <param name="fetched" value="yes"/>
+      <param name="completed" value="false"/>
+      <param name="notifyPi" value="NO"/>
+      <param name="timingWindowNotification" value="false"/>
+    </paramset>
+    <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="6b205a5a-fa7d-4968-be0f-035b2a6a0e72" name="Note">
+      <paramset name="Note" kind="dataObj">
+        <param name="title" value="Next libID = 2"/>
+        <param name="NoteText" value=""/>
+      </paramset>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="e9a65dbe-e121-4022-8518-550b79bc1b1e" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="GHOST science"/>
+        <param name="libraryId" value="1"/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="INACTIVE"/>
+        <paramset name="schedulingBlock">
+          <param name="start" value="1667237400000"/>
+          <paramset name="duration">
+            <param name="tag" value="unstated"/>
+          </paramset>
+        </paramset>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+        <param name="setupTimeType" value="FULL"/>
+      </paramset>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="b1ebce10-d2be-4de1-93ee-7277da77dbef" name="GHOST">
+        <paramset name="GHOST" kind="dataObj">
+          <param name="posAngle" value="0"/>
+          <param name="issPort" value="UP_LOOKING"/>
+          <param name="enableFiberAgitator1" value="false"/>
+          <param name="enableFiberAgitator2" value="false"/>
+          <param name="redExposureTime" value="600.0"/>
+          <param name="redExposureCount" value="1"/>
+          <param name="redBinning" value="ONE_BY_ONE"/>
+          <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
+          <param name="blueExposureTime" value="600.0"/>
+          <param name="blueExposureCount" value="1"/>
+          <param name="blueBinning" value="ONE_BY_ONE"/>
+          <param name="blueReadNoiseGain" value="SLOW_LOW"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Info" version="2009A-1" subtype="note" key="56e679b6-1740-47fe-855f-706f5071ff24" name="Note">
+        <paramset name="Note" kind="dataObj">
+          <param name="title" value="Description"/>
+          <param name="NoteText" value="Describe this template"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="81fdf234-3253-4f2b-8c0f-a224f2310325" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="1ae16348-fc28-4ef7-826d-12dd96e35741" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="953a10d3-7da0-4746-af7b-0696ac287ee3" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+        <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="668cc23e-f767-4279-94ff-7d06026703f7" name="GHOST Sequence">
+          <paramset name="GHOST Sequence" kind="dataObj">
+            <param name="blueExposureCount" value="1"/>
+            <param name="blueExposureTime" value="600.0"/>
+            <param name="redExposureCount" value="1"/>
+            <param name="redExposureTime" value="600.0"/>
+          </paramset>
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="aa14b2b0-07b7-4503-beff-856455c7529a" name="Observe">
+            <paramset name="Observe" kind="dataObj">
+              <param name="repeatCount" value="1"/>
+              <param name="class" value="SCIENCE"/>
+            </paramset>
+          </container>
+        </container>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="7302de0a-99d8-47c4-92d3-b2d0bf4e96c5" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="GHOST science - SRIFU1 + sky example"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <paramset name="schedulingBlock">
+          <param name="start" value="1667237400000"/>
+          <paramset name="duration">
+            <param name="tag" value="unstated"/>
+          </paramset>
+        </paramset>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+        <param name="setupTimeType" value="FULL"/>
+      </paramset>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="a746d845-cffe-4ba3-8edf-abdb42c27801" name="GHOST">
+        <paramset name="GHOST" kind="dataObj">
+          <param name="posAngle" value="0"/>
+          <param name="issPort" value="UP_LOOKING"/>
+          <param name="enableFiberAgitator1" value="false"/>
+          <param name="enableFiberAgitator2" value="false"/>
+          <param name="redExposureTime" value="600.0"/>
+          <param name="redExposureCount" value="1"/>
+          <param name="redBinning" value="ONE_BY_ONE"/>
+          <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
+          <param name="blueExposureTime" value="600.0"/>
+          <param name="blueExposureCount" value="1"/>
+          <param name="blueBinning" value="ONE_BY_ONE"/>
+          <param name="blueReadNoiseGain" value="SLOW_LOW"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="71e6a8d8-474d-4a01-b7ec-cb83d5f3359a" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="asterism">
+              <paramset name="ifu1">
+                <paramset name="target">
+                  <param name="name" value="HD1355"/>
+                  <param name="redshift" value="-5.0E-6"/>
+                  <param name="parallax" value="3.7153"/>
+                  <paramset name="magnitude">
+                    <param name="value" value="9.96"/>
+                    <param name="band" value="B"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.03"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="8.87"/>
+                    <param name="band" value="V"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.02"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="7.037"/>
+                    <param name="band" value="J"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.018"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="6.532"/>
+                    <param name="band" value="H"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.044"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="6.415"/>
+                    <param name="band" value="K"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.024"/>
+                  </paramset>
+                  <paramset name="coordinates">
+                    <param name="ra" value="4.423109895970015"/>
+                    <param name="dec" value="348.784820192"/>
+                  </paramset>
+                  <paramset name="proper-motion">
+                    <param name="delta-ra" value="7.57"/>
+                    <param name="delta-dec" value="-8.661"/>
+                    <param name="epoch" value="2000.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
+                <param name="guideFiberState" value="enabled"/>
+              </paramset>
+              <paramset name="ifu2">
+                <param name="ra" value="4.423108333333346"/>
+                <param name="dec" value="348.81815277777775"/>
+              </paramset>
+              <param name="tag" value="ghostTargetPlusSky"/>
+            </paramset>
+            <paramset name="guideEnv">
+              <param name="primary" value="0"/>
+              <paramset name="guideGroup">
+                <param name="tag" value="AutoActiveTag"/>
+                <param name="posAngle" value="0.0"/>
+                <paramset name="guider">
+                  <param name="key" value="PWFS2"/>
+                  <param name="primary" value="0"/>
+                  <paramset name="spTarget">
+                    <paramset name="target">
+                      <param name="name" value="Gaia DR2 2424603635247995264"/>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.633876256076077"/>
+                        <param name="band" value="V"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.293584146793286"/>
+                        <param name="band" value="R"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.968376909683993"/>
+                        <param name="band" value="I"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.4838517478606"/>
+                        <param name="band" value="r"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.36244890570376"/>
+                        <param name="band" value="i"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.87175494000135"/>
+                        <param name="band" value="g"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.153477242505286"/>
+                        <param name="band" value="K"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.222237037468298"/>
+                        <param name="band" value="H"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.491788136526072"/>
+                        <param name="band" value="J"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="coordinates">
+                        <param name="ra" value="4.3382858653453695"/>
+                        <param name="dec" value="348.8563719107751"/>
+                      </paramset>
+                      <paramset name="proper-motion">
+                        <param name="delta-ra" value="-14.985691687370013"/>
+                        <param name="delta-dec" value="-6.722483282732992"/>
+                        <param name="epoch" value="2015.5"/>
+                      </paramset>
+                      <param name="tag" value="sidereal"/>
+                    </paramset>
+                  </paramset>
+                </paramset>
+              </paramset>
+            </paramset>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="750d6980-8b3b-4af7-8a24-7acd5ba13faf" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="PERCENT_80"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e727993e-3e31-43ba-858a-057ca2c51b3a" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="7394f7cf-2f01-47a1-8aff-39ea1d105b68" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="9ae6255a-2082-47a6-a084-0969ca5b00c2" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+        <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="d2403616-71fb-46d0-a741-eb82e4a31599" name="GHOST Sequence">
+          <paramset name="GHOST Sequence" kind="dataObj">
+            <param name="blueExposureCount" value="1"/>
+            <param name="blueExposureTime" value="600.0"/>
+            <param name="redExposureCount" value="1"/>
+            <param name="redExposureTime" value="600.0"/>
+          </paramset>
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="f288dd5d-5de1-4e65-a08e-1d4c31f22c16" name="Observe">
+            <paramset name="Observe" kind="dataObj">
+              <param name="repeatCount" value="1"/>
+              <param name="class" value="SCIENCE"/>
+            </paramset>
+          </container>
+        </container>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="d83369a8-7fee-4c71-91f1-0b90ed5c74e8" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="GHOST science - high resolution example"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <paramset name="schedulingBlock">
+          <param name="start" value="1667237400000"/>
+          <paramset name="duration">
+            <param name="tag" value="unstated"/>
+          </paramset>
+        </paramset>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+        <param name="setupTimeType" value="FULL"/>
+      </paramset>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="1dc5f526-e0d2-4fae-9f16-bfe3945c8b2d" name="GHOST">
+        <paramset name="GHOST" kind="dataObj">
+          <param name="posAngle" value="0"/>
+          <param name="issPort" value="UP_LOOKING"/>
+          <param name="enableFiberAgitator1" value="false"/>
+          <param name="enableFiberAgitator2" value="false"/>
+          <param name="redExposureTime" value="600.0"/>
+          <param name="redExposureCount" value="1"/>
+          <param name="redBinning" value="ONE_BY_ONE"/>
+          <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
+          <param name="blueExposureTime" value="600.0"/>
+          <param name="blueExposureCount" value="1"/>
+          <param name="blueBinning" value="ONE_BY_ONE"/>
+          <param name="blueReadNoiseGain" value="SLOW_LOW"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="4fdd9069-5642-4066-9595-3cc66697e098" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="asterism">
+              <paramset name="ifu1">
+                <paramset name="target">
+                  <param name="name" value="HD1355"/>
+                  <param name="redshift" value="-5.0E-6"/>
+                  <param name="parallax" value="3.7153"/>
+                  <paramset name="magnitude">
+                    <param name="value" value="9.96"/>
+                    <param name="band" value="B"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.03"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="8.87"/>
+                    <param name="band" value="V"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.02"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="7.037"/>
+                    <param name="band" value="J"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.018"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="6.532"/>
+                    <param name="band" value="H"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.044"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="6.415"/>
+                    <param name="band" value="K"/>
+                    <param name="system" value="Vega"/>
+                    <param name="error" value="0.024"/>
+                  </paramset>
+                  <paramset name="coordinates">
+                    <param name="ra" value="4.423109895970015"/>
+                    <param name="dec" value="348.784820192"/>
+                  </paramset>
+                  <paramset name="proper-motion">
+                    <param name="delta-ra" value="7.57"/>
+                    <param name="delta-dec" value="-8.661"/>
+                    <param name="epoch" value="2000.0"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
+                <param name="guideFiberState" value="enabled"/>
+              </paramset>
+              <paramset name="ifu2">
+                <param name="ra" value="4.423108333333346"/>
+                <param name="dec" value="348.81815277777775"/>
+              </paramset>
+              <param name="tag" value="ghostTargetPlusSky"/>
+            </paramset>
+            <paramset name="guideEnv">
+              <param name="primary" value="0"/>
+              <paramset name="guideGroup">
+                <param name="tag" value="AutoActiveTag"/>
+                <param name="posAngle" value="0.0"/>
+                <paramset name="guider">
+                  <param name="key" value="PWFS2"/>
+                  <param name="primary" value="0"/>
+                  <paramset name="spTarget">
+                    <paramset name="target">
+                      <param name="name" value="Gaia DR2 2424603635247995264"/>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.633876256076077"/>
+                        <param name="band" value="V"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.293584146793286"/>
+                        <param name="band" value="R"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.968376909683993"/>
+                        <param name="band" value="I"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.4838517478606"/>
+                        <param name="band" value="r"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.36244890570376"/>
+                        <param name="band" value="i"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="12.87175494000135"/>
+                        <param name="band" value="g"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.153477242505286"/>
+                        <param name="band" value="K"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.222237037468298"/>
+                        <param name="band" value="H"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.491788136526072"/>
+                        <param name="band" value="J"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="coordinates">
+                        <param name="ra" value="4.3382858653453695"/>
+                        <param name="dec" value="348.8563719107751"/>
+                      </paramset>
+                      <paramset name="proper-motion">
+                        <param name="delta-ra" value="-14.985691687370013"/>
+                        <param name="delta-dec" value="-6.722483282732992"/>
+                        <param name="epoch" value="2015.5"/>
+                      </paramset>
+                      <param name="tag" value="sidereal"/>
+                    </paramset>
+                  </paramset>
+                </paramset>
+              </paramset>
+            </paramset>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="def819c0-3401-4a66-8bd3-ca1a7408fd60" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="PERCENT_80"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="e55abc90-eeb9-4c1b-a568-3cae239308ed" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="c61f357c-7c17-4848-8346-a3f165f34e3b" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="a9792111-9f82-4c47-8d20-abe7d1c1e143" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+        <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="179a698b-fb7c-44aa-b505-e318760e894a" name="GHOST Sequence">
+          <paramset name="GHOST Sequence" kind="dataObj">
+            <param name="blueExposureCount" value="1"/>
+            <param name="blueExposureTime" value="600.0"/>
+            <param name="redExposureCount" value="1"/>
+            <param name="redExposureTime" value="600.0"/>
+          </paramset>
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="50859f53-a112-4fe3-b679-fd574a3024cb" name="Observe">
+            <paramset name="Observe" kind="dataObj">
+              <param name="repeatCount" value="1"/>
+              <param name="class" value="SCIENCE"/>
+            </paramset>
+          </container>
+        </container>
+      </container>
+    </container>
+    <container kind="observation" type="Observation" version="2014A-1" subtype="basic" key="de062e39-31e0-4295-b467-6d199416de8f" name="">
+      <paramset name="Observation" kind="dataObj">
+        <param name="title" value="GHOST science - dual target example"/>
+        <param name="libraryId" value=""/>
+        <param name="priority" value="LOW"/>
+        <param name="tooOverrideRapid" value="false"/>
+        <param name="phase2Status" value="PI_TO_COMPLETE"/>
+        <paramset name="schedulingBlock">
+          <param name="start" value="1667237400000"/>
+          <paramset name="duration">
+            <param name="tag" value="unstated"/>
+          </paramset>
+        </paramset>
+        <param name="qaState" value="UNDEFINED"/>
+        <param name="overrideQaState" value="false"/>
+        <param name="setupTimeType" value="FULL"/>
+      </paramset>
+      <container kind="obsComp" type="Scheduling" version="2009A-1" subtype="conditions" key="b21548a1-f66a-44e7-a851-4fc38b485ddc" name="Observing Conditions">
+        <paramset name="Observing Conditions" kind="dataObj">
+          <param name="CloudCover" value="PERCENT_80"/>
+          <param name="ImageQuality" value="ANY"/>
+          <param name="SkyBackground" value="ANY"/>
+          <param name="WaterVapor" value="ANY"/>
+          <param name="ElevationConstraintType" value="NONE"/>
+          <param name="ElevationConstraintMin" value="0.0"/>
+          <param name="ElevationConstraintMax" value="0.0"/>
+          <paramset name="timing-window-list"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Instrument" version="2009A-1" subtype="GHOST" key="390bf25d-d650-4b0a-96a1-1f3373634566" name="GHOST">
+        <paramset name="GHOST" kind="dataObj">
+          <param name="posAngle" value="0"/>
+          <param name="issPort" value="UP_LOOKING"/>
+          <param name="enableFiberAgitator1" value="false"/>
+          <param name="enableFiberAgitator2" value="false"/>
+          <param name="redExposureTime" value="600.0"/>
+          <param name="redExposureCount" value="1"/>
+          <param name="redBinning" value="ONE_BY_ONE"/>
+          <param name="redReadNoiseGain" value="MEDIUM_LOW"/>
+          <param name="blueExposureTime" value="600.0"/>
+          <param name="blueExposureCount" value="1"/>
+          <param name="blueBinning" value="ONE_BY_ONE"/>
+          <param name="blueReadNoiseGain" value="SLOW_LOW"/>
+        </paramset>
+      </container>
+      <container kind="obsComp" type="Telescope" version="2009B-1" subtype="targetEnv" key="e854a9d0-0ac6-4b3a-b738-99000d4469b5" name="Targets">
+        <paramset name="Targets" kind="dataObj">
+          <paramset name="targetEnv">
+            <paramset name="asterism">
+              <paramset name="ifu1">
+                <paramset name="target">
+                  <param name="name" value="NGC2808 star1 "/>
+                  <paramset name="magnitude">
+                    <param name="value" value="13.23072477955091"/>
+                    <param name="band" value="V"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="12.150290743698195"/>
+                    <param name="band" value="R"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="11.133283169636655"/>
+                    <param name="band" value="I"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="12.599432443541296"/>
+                    <param name="band" value="r"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="11.68799822472841"/>
+                    <param name="band" value="i"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="14.250653157785202"/>
+                    <param name="band" value="g"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="8.514383555398194"/>
+                    <param name="band" value="K"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="8.756784038894278"/>
+                    <param name="band" value="H"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="9.627747336078956"/>
+                    <param name="band" value="J"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="coordinates">
+                    <param name="ra" value="138.08428805253521"/>
+                    <param name="dec" value="295.12763567379943"/>
+                  </paramset>
+                  <paramset name="proper-motion">
+                    <param name="delta-ra" value="1.1413518814497048"/>
+                    <param name="delta-dec" value="0.3346264845685283"/>
+                    <param name="epoch" value="2015.5"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
+                <param name="guideFiberState" value="enabled"/>
+              </paramset>
+              <paramset name="ifu2">
+                <paramset name="target">
+                  <param name="name" value="NGC2808 star 2"/>
+                  <paramset name="magnitude">
+                    <param name="value" value="14.725969124078764"/>
+                    <param name="band" value="V"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="14.0201028644874"/>
+                    <param name="band" value="R"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="13.354272681502447"/>
+                    <param name="band" value="I"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="14.282613077124529"/>
+                    <param name="band" value="r"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="13.82944676779055"/>
+                    <param name="band" value="i"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="15.381803930363931"/>
+                    <param name="band" value="g"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="11.577787215047401"/>
+                    <param name="band" value="K"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="11.738050785399366"/>
+                    <param name="band" value="H"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="magnitude">
+                    <param name="value" value="12.350072896201958"/>
+                    <param name="band" value="J"/>
+                    <param name="system" value="Vega"/>
+                  </paramset>
+                  <paramset name="coordinates">
+                    <param name="ra" value="137.97067205480164"/>
+                    <param name="dec" value="295.15336877266816"/>
+                  </paramset>
+                  <paramset name="proper-motion">
+                    <param name="delta-ra" value="0.8458675442987402"/>
+                    <param name="delta-dec" value="0.2660131714228431"/>
+                    <param name="epoch" value="2015.5"/>
+                  </paramset>
+                  <param name="tag" value="sidereal"/>
+                </paramset>
+                <param name="guideFiberState" value="enabled"/>
+              </paramset>
+              <param name="tag" value="ghostDualTarget"/>
+            </paramset>
+            <paramset name="guideEnv">
+              <param name="primary" value="0"/>
+              <paramset name="guideGroup">
+                <param name="tag" value="AutoActiveTag"/>
+                <param name="posAngle" value="0.0"/>
+                <paramset name="guider">
+                  <param name="key" value="PWFS2"/>
+                  <param name="primary" value="0"/>
+                  <paramset name="spTarget">
+                    <paramset name="target">
+                      <param name="name" value="Gaia DR2 5248754909672194304"/>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.217195629875249"/>
+                        <param name="band" value="V"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="10.707163258058326"/>
+                        <param name="band" value="R"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="10.22410985101349"/>
+                        <param name="band" value="I"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="10.92282703677957"/>
+                        <param name="band" value="r"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="10.656343741740354"/>
+                        <param name="band" value="i"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="11.654860415648425"/>
+                        <param name="band" value="g"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="8.942442674948325"/>
+                        <param name="band" value="K"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="9.055339339134704"/>
+                        <param name="band" value="H"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="magnitude">
+                        <param name="value" value="9.496968122250106"/>
+                        <param name="band" value="J"/>
+                        <param name="system" value="Vega"/>
+                      </paramset>
+                      <paramset name="coordinates">
+                        <param name="ra" value="138.2058987921505"/>
+                        <param name="dec" value="295.0557015649252"/>
+                      </paramset>
+                      <paramset name="proper-motion">
+                        <param name="delta-ra" value="36.64160021542454"/>
+                        <param name="delta-dec" value="-1.7399778064393452"/>
+                        <param name="epoch" value="2015.5"/>
+                      </paramset>
+                      <param name="tag" value="sidereal"/>
+                    </paramset>
+                  </paramset>
+                </paramset>
+              </paramset>
+            </paramset>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="obsQaLog" type="ObsLog" version="2009A-1" subtype="qa" key="b17e6907-f468-4e67-9ec6-383e49706947" name="Observing Log">
+        <paramset name="Observing Log" kind="dataObj">
+          <paramset name="obsQaRecord"/>
+        </paramset>
+      </container>
+      <container kind="obsExecLog" type="ObsLog" version="2009A-1" subtype="exec" key="b6d12fa3-f63e-4ded-8a20-89704fad23e3" name="Observation Exec Log">
+        <paramset name="Observation Exec Log" kind="dataObj">
+          <paramset name="obsExecRecord">
+            <paramset name="datasets"/>
+            <paramset name="events"/>
+            <paramset name="configMap"/>
+          </paramset>
+        </paramset>
+      </container>
+      <container kind="seqComp" type="Iterator" version="2012A-1" subtype="base" key="cdb0232a-a726-4289-b548-b6c6f772469c" name="Sequence">
+        <paramset name="Sequence" kind="dataObj"/>
+        <container kind="seqComp" type="Iterator" version="2009A-1" subtype="GHOST" key="caef6c68-7aef-4c4a-a84c-d7e1a95d7601" name="GHOST Sequence">
+          <paramset name="GHOST Sequence" kind="dataObj">
+            <param name="blueExposureCount" value="1"/>
+            <param name="blueExposureTime" value="600.0"/>
+            <param name="redExposureCount" value="1"/>
+            <param name="redExposureTime" value="600.0"/>
+          </paramset>
+          <container kind="seqComp" type="Observer" version="2009A-1" subtype="observe" key="922bfd1a-28a3-4584-bd54-62ac347a0032" name="Observe">
+            <paramset name="Observe" kind="dataObj">
+              <param name="repeatCount" value="1"/>
+              <param name="class" value="SCIENCE"/>
+            </paramset>
+          </container>
+        </container>
+      </container>
+    </container>
+  </container>
+  <container kind="versions" type="versions" version="1.0">
+    <paramset name="node">
+      <param name="key" value="8136caf3-0ef6-461a-b3ba-bfa6ed78176e"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="50859f53-a112-4fe3-b679-fd574a3024cb"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="a9792111-9f82-4c47-8d20-abe7d1c1e143"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="a746d845-cffe-4ba3-8edf-abdb42c27801"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="71e6a8d8-474d-4a01-b7ec-cb83d5f3359a"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="51"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="9ae6255a-2082-47a6-a084-0969ca5b00c2"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="179a698b-fb7c-44aa-b505-e318760e894a"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="668cc23e-f767-4279-94ff-7d06026703f7"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="12"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e9a65dbe-e121-4022-8518-550b79bc1b1e"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="66"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="d4e317bc-f38d-4bce-8dc5-2dc5a1ba13ef"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="64"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="aa14b2b0-07b7-4503-beff-856455c7529a"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="ba3070ca-269b-408a-94da-819b304f68dc"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e727993e-3e31-43ba-858a-057ca2c51b3a"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="81fdf234-3253-4f2b-8c0f-a224f2310325"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="d83369a8-7fee-4c71-91f1-0b90ed5c74e8"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="25"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b21548a1-f66a-44e7-a851-4fc38b485ddc"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="2"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="1dc5f526-e0d2-4fae-9f16-bfe3945c8b2d"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="5"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e55abc90-eeb9-4c1b-a568-3cae239308ed"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="de062e39-31e0-4295-b467-6d199416de8f"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="65"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="e854a9d0-0ac6-4b3a-b738-99000d4469b5"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="21"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="c61f357c-7c17-4848-8346-a3f165f34e3b"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b1ebce10-d2be-4de1-93ee-7277da77dbef"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="9"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="750d6980-8b3b-4af7-8a24-7acd5ba13faf"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="5"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="56e679b6-1740-47fe-855f-706f5071ff24"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="40"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b17e6907-f468-4e67-9ec6-383e49706947"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="7302de0a-99d8-47c4-92d3-b2d0bf4e96c5"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="78"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="cdb0232a-a726-4289-b548-b6c6f772469c"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="1ae16348-fc28-4ef7-826d-12dd96e35741"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="953a10d3-7da0-4746-af7b-0696ac287ee3"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="4"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="922bfd1a-28a3-4584-bd54-62ac347a0032"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="4fdd9069-5642-4066-9595-3cc66697e098"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="2"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="2"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="7394f7cf-2f01-47a1-8aff-39ea1d105b68"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="b6d12fa3-f63e-4ded-8a20-89704fad23e3"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="de0eba24-fe64-4e40-b894-dc1e4e0cada4"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="f288dd5d-5de1-4e65-a08e-1d4c31f22c16"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="6b205a5a-fa7d-4968-be0f-035b2a6a0e72"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="7"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="d2403616-71fb-46d0-a741-eb82e4a31599"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="def819c0-3401-4a66-8bd3-ca1a7408fd60"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="390bf25d-d650-4b0a-96a1-1f3373634566"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="2"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="51a43069-2f6c-4026-a201-f3e701892613"/>
+      <param name="12de28ac-e8ab-4adb-8d7d-00157b19dfbc" value="55"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+    <paramset name="node">
+      <param name="key" value="caef6c68-7aef-4c4a-a84c-d7e1a95d7601"/>
+      <param name="1ce96c21-0dc9-48c4-bb14-9f0de248fa5c" value="1"/>
+    </paramset>
+  </container>
+</document>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpBlueprintFactory.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/skeleton/factory/SpBlueprintFactory.scala
@@ -44,7 +44,7 @@ object SpBlueprintFactory {
       case b: Flamingos2BlueprintImaging    => F2.imaging(b)
       case b: Flamingos2BlueprintLongslit   => F2.longslit(b)
       case b: Flamingos2BlueprintMos        => F2.mos(b)
-      case b: GhostBlueprint                => Ghost(b)
+      case b: GhostBlueprint                => GhostHandler(b)
       case b: GmosNBlueprintIfu             => GmosN.ifu(b)
       case b: GmosNBlueprintImaging         => GmosN.imaging(b)
       case b: GmosNBlueprintLongslit        => GmosN.longslit(b)
@@ -113,7 +113,7 @@ object SpBlueprintFactory {
     }
   }
 
-  object Ghost {
+  object GhostHandler {
 
     private def asterismType(
       r: GhostResolutionMode,

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateDb.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateDb.scala
@@ -29,6 +29,7 @@ object TemplateDb {
   // URLs of xml files, filtered by name
   def xmls(f: String => Boolean) = List(
     "F2_BP.xml",
+    "GHOST_BP.xml",
     "GMOS_N_BP.xml",
     "GMOS_S_BP.xml",
     "GNIRS_BP.xml",

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateFactoryImpl.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateFactoryImpl.scala
@@ -1,29 +1,29 @@
 package edu.gemini.phase2.template.factory.impl
 
-import edu.gemini.phase2.core.model.{ObsComponentShell, ObservationShell, GroupShell}
+import edu.gemini.phase2.core.model.{GroupShell, ObsComponentShell, ObservationShell}
 import edu.gemini.phase2.template.factory.api.{BlueprintExpansion, TemplateFactory}
 import edu.gemini.phase2.template.factory.impl.phoenix.Phoenix
 import edu.gemini.spModel.gemini.gmos.blueprint._
 import edu.gemini.spModel.gemini.phoenix.blueprint.SpPhoenixBlueprint
 import edu.gemini.spModel.rich.pot.sp._
 import edu.gemini.spModel.template.{Phase1Group, SpBlueprint}
-
-import flamingos2.{Flamingos2Mos, Flamingos2Longslit, Flamingos2Imaging}
+import flamingos2.{Flamingos2Imaging, Flamingos2Longslit, Flamingos2Mos}
 import gmos._
-import gnirs.{GnirsSpectroscopy, GnirsImaging}
+import gnirs.{GnirsImaging, GnirsSpectroscopy}
 import gsaoi.Gsaoi
-import michelle.{MichelleSpectroscopy, MichelleImaging}
-import nici.{NiciStandard, NiciCoronographic}
+import michelle.{MichelleImaging, MichelleSpectroscopy}
+import nici.{NiciCoronographic, NiciStandard}
 import nifs.{Nifs, NifsAo}
 import niri.Niri
+
 import scala.collection.JavaConverters._
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.gemini.gmos.GmosCommonType.UseNS
-import edu.gemini.spModel.gemini.flamingos2.blueprint.{SpFlamingos2BlueprintMos, SpFlamingos2BlueprintLongslit, SpFlamingos2BlueprintImaging}
-import edu.gemini.spModel.gemini.gnirs.blueprint.{SpGnirsBlueprintSpectroscopy, SpGnirsBlueprintImaging}
-import edu.gemini.spModel.gemini.gnirs.GNIRSParams.SlitWidth
-import edu.gemini.spModel.gemini.michelle.blueprint.{SpMichelleBlueprintSpectroscopy, SpMichelleBlueprintImaging}
-import edu.gemini.spModel.gemini.nici.blueprint.{SpNiciBlueprintStandard, SpNiciBlueprintCoronagraphic}
+import edu.gemini.spModel.gemini.flamingos2.blueprint.{SpFlamingos2BlueprintImaging, SpFlamingos2BlueprintLongslit, SpFlamingos2BlueprintMos}
+import edu.gemini.phase2.template.factory.impl.ghost.Ghost
+import edu.gemini.spModel.gemini.gnirs.blueprint.{SpGnirsBlueprintImaging, SpGnirsBlueprintSpectroscopy}
+import edu.gemini.spModel.gemini.michelle.blueprint.{SpMichelleBlueprintImaging, SpMichelleBlueprintSpectroscopy}
+import edu.gemini.spModel.gemini.nici.blueprint.{SpNiciBlueprintCoronagraphic, SpNiciBlueprintStandard}
 import edu.gemini.spModel.gemini.nifs.blueprint.{SpNifsBlueprint, SpNifsBlueprintAo}
 import edu.gemini.spModel.gemini.niri.blueprint.SpNiriBlueprint
 import edu.gemini.spModel.obs.ObsPhase2Status
@@ -40,6 +40,7 @@ import edu.gemini.spModel.gemini.graces.blueprint.SpGracesBlueprint
 import edu.gemini.phase2.template.factory.impl.graces.Graces
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.phase2.template.factory.impl.gnirs.GnirsSpectroscopyIfu
+import edu.gemini.spModel.gemini.ghost.blueprint.SpGhostBlueprint
 
 case class TemplateFactoryImpl(db: TemplateDb) extends TemplateFactory {
 
@@ -67,6 +68,9 @@ case class TemplateFactoryImpl(db: TemplateDb) extends TemplateFactory {
       case b: SpFlamingos2BlueprintImaging => Right(Flamingos2Imaging(b))
       case b: SpFlamingos2BlueprintLongslit => Right(Flamingos2Longslit(b, sampleTarget))
       case b: SpFlamingos2BlueprintMos => Right(Flamingos2Mos(b))
+
+      // GHOST
+      case b: SpGhostBlueprint => Right(Ghost(b))
 
       // GMOS-N
       case b: SpGmosNBlueprintIfu => Right(GmosNIfu(b))

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateFactoryImpl.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateFactoryImpl.scala
@@ -160,7 +160,7 @@ case class TemplateFactoryImpl(db: TemplateDb) extends TemplateFactory {
     }
 
     // Convert to shells.
-    val templateGroup = new GroupShell(grp).toTemplateGroupShell(pig)
+    val templateGroup = new GroupShell(grp).toTemplateGroupShell(pig, blue.asterismType)
 
     // Create the baseline calibration group
     val baselineDataObj = new SPGroup("Baseline: " + blue.toString)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateFactoryImpl.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/TemplateFactoryImpl.scala
@@ -164,7 +164,7 @@ case class TemplateFactoryImpl(db: TemplateDb) extends TemplateFactory {
     }
 
     // Convert to shells.
-    val templateGroup = new GroupShell(grp).toTemplateGroupShell(pig, blue.asterismType)
+    val templateGroup = new GroupShell(grp).toTemplateGroupShell(pig)
 
     // Create the baseline calibration group
     val baselineDataObj = new SPGroup("Baseline: " + blue.toString)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/Ghost.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/Ghost.scala
@@ -1,0 +1,54 @@
+package edu.gemini.phase2.template.factory.impl.ghost
+
+import edu.gemini.phase2.template.factory.impl.Maybe
+import edu.gemini.phase2.template.factory.impl.TemplateDb
+import edu.gemini.pot.sp.ISPGroup
+import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.gemini.ghost.blueprint.SpGhostBlueprint
+
+case class Ghost(blueprint: SpGhostBlueprint) extends GhostBase[SpGhostBlueprint] {
+
+//  INCLUDE {1}     # Science
+//
+//  SET RESOLUTION MODE FROM PI  # Possible w/o a target component?
+//
+//  SET TARGET MODE FROM PI      # Possible w/o a target component?
+//
+//  ON TEMPATE INSTANTIATION (adding the target(s))
+//    IF RESOLUTION MODE == STANDARD
+//        IF TARGET MODE == 'Single'
+//          Add target from PI to SRIFU1
+//        IF TARGET MODE == 'Dual'  # Position from PI is the Base position
+//          Add target1 from PI with RA + 1 arcmin to SRIFU1
+//          Add target2 from PI with RA - 1 arcmin to SRIFU2
+//
+//      IF TARGET MODE ==  'SRIFU1 Sky + SRIFU2 Target'
+//        Add target from PI to SRIFU2
+//        Add target from PI with ra + 2 arcmin to SRIFU1
+//      ELSE
+//        Add target from PI to SRIFU1
+//        IF TARGET MODE ==  'SRIFU1 Target + SRIFU2 Sky'
+//          Add target from PI with ra - 2 arcmin to SRIFU2
+//
+//    IF RESOLUTION MODE == HIGH or PRECISION RADIAL VELOCITY
+//      Add target from PI to HRIFU
+//      Add target from PI with ra - 2 arcmin to HRSKY
+
+// N.B.
+// The resolution mode and target mode "from PI" are kept in the template group.
+// The template instantiation rules are not used here.  When a template is
+// expanded the asterism type in the template group is consulted.
+
+  override def targetGroup: Seq[Int] =
+    List(1)
+
+    override def baselineFolder: Seq[Int] =
+    List.empty
+
+  override def notes: Seq[String] =
+    List.empty
+
+  override def initialize(group: ISPGroup, db: TemplateDb, pid: SPProgramID): Maybe[Unit] =
+    forObservations(group, targetGroup, _ => Right(()))
+
+}

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/Ghost.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/Ghost.scala
@@ -9,31 +9,28 @@ import edu.gemini.spModel.gemini.ghost.blueprint.SpGhostBlueprint
 
 case class Ghost(blueprint: SpGhostBlueprint) extends GhostBase[SpGhostBlueprint] {
 
-//  INCLUDE {1}     # Science
+//INCLUDE {1}     # Science
 //
-//  SET RESOLUTION MODE FROM PI  # Possible w/o a target component?
+//SET RESOLUTION MODE FROM PI
 //
-//  SET TARGET MODE FROM PI      # Possible w/o a target component?
+//SET TARGET MODE FROM PI
 //
-//  ON TEMPATE INSTANTIATION (adding the target(s))
-//    IF RESOLUTION MODE == STANDARD
-//        IF TARGET MODE == 'Single'
-//          Add target from PI to SRIFU1
-//        IF TARGET MODE == 'Dual'  # Position from PI is the Base position
-//          Add target1 from PI with RA + 1 arcmin to SRIFU1
-//          Add target2 from PI with RA - 1 arcmin to SRIFU2
+//ON TEMPATE INSTANTIATION (adding the target(s))
+//	IF RESOLUTION MODE == STANDARD
+//	    IF TARGET MODE == 'Single'
+//	    	Add target from PI to SRIFU1
 //
-//      IF TARGET MODE ==  'SRIFU1 Sky + SRIFU2 Target'
-//        Add target from PI to SRIFU2
-//        Add target from PI with ra + 2 arcmin to SRIFU1
-//      ELSE
-//        Add target from PI to SRIFU1
-//        IF TARGET MODE ==  'SRIFU1 Target + SRIFU2 Sky'
-//          Add target from PI with ra - 2 arcmin to SRIFU2
+//	    IF TARGET MODE == 'Dual'  # Position from PI is the fainter target
+//	    	Add target from PI to SRIFU1
+//	    	Add target from PI with RA - 2 arcmin to SRIFU2, set target name to 'Target 2'
 //
-//    IF RESOLUTION MODE == HIGH or PRECISION RADIAL VELOCITY
-//      Add target from PI to HRIFU
-//      Add target from PI with ra - 2 arcmin to HRSKY
+//		IF TARGET MODE ==  'SRIFU + Sky'
+//			Add target from PI to SRIFU1
+//			Add target from PI with ra - 2 arcmin to SRIFU2, set target name to 'Sky'
+//
+//	IF RESOLUTION MODE == HIGH or PRECISION RADIAL VELOCITY
+//		Add target from PI to HRIFU
+//		Add target from PI with ra - 2 arcmin to HRSKY, the target name should be 'Sky'
 
   override def targetGroup: Seq[Int] =
     List(1)

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/Ghost.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/Ghost.scala
@@ -3,6 +3,7 @@ package edu.gemini.phase2.template.factory.impl.ghost
 import edu.gemini.phase2.template.factory.impl.Maybe
 import edu.gemini.phase2.template.factory.impl.TemplateDb
 import edu.gemini.pot.sp.ISPGroup
+import edu.gemini.pot.sp.ISPObservation
 import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.gemini.ghost.blueprint.SpGhostBlueprint
 
@@ -34,21 +35,21 @@ case class Ghost(blueprint: SpGhostBlueprint) extends GhostBase[SpGhostBlueprint
 //      Add target from PI to HRIFU
 //      Add target from PI with ra - 2 arcmin to HRSKY
 
-// N.B.
-// The resolution mode and target mode "from PI" are kept in the template group.
-// The template instantiation rules are not used here.  When a template is
-// expanded the asterism type in the template group is consulted.
-
   override def targetGroup: Seq[Int] =
     List(1)
 
-    override def baselineFolder: Seq[Int] =
+  override def baselineFolder: Seq[Int] =
     List.empty
 
   override def notes: Seq[String] =
     List.empty
 
+  // Records the preferred asterism type from the PI in the GHOST component.
+  // This is then used on instantiation to create corresponding GHOST asterism.
+  private def setAsterismType(o: ISPObservation): Maybe[Unit] =
+    o.setAsterismType(blueprint.asterismType)
+
   override def initialize(group: ISPGroup, db: TemplateDb, pid: SPProgramID): Maybe[Unit] =
-    forObservations(group, targetGroup, _ => Right(()))
+    forObservations(group, targetGroup, setAsterismType)
 
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/GhostBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/GhostBase.scala
@@ -1,0 +1,13 @@
+package edu.gemini.phase2.template.factory.impl.ghost
+
+import edu.gemini.spModel.gemini.ghost.blueprint.SpGhostBlueprintBase
+import edu.gemini.phase2.template.factory.impl.GroupInitializer
+
+trait GhostBase[B <: SpGhostBlueprintBase] extends GroupInitializer[B] {
+
+  override val program: String =
+    "GHOST PHASE I/II MAPPING BPS"
+
+
+
+}

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/GhostBase.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/main/scala/edu/gemini/phase2/template/factory/impl/ghost/GhostBase.scala
@@ -1,13 +1,21 @@
 package edu.gemini.phase2.template.factory.impl.ghost
 
 import edu.gemini.spModel.gemini.ghost.blueprint.SpGhostBlueprintBase
-import edu.gemini.phase2.template.factory.impl.GroupInitializer
+import edu.gemini.phase2.template.factory.impl.{GroupInitializer, StaticObservationEditor}
+import edu.gemini.pot.sp.ISPObservation
+import edu.gemini.spModel.target.env.AsterismType
 
 trait GhostBase[B <: SpGhostBlueprintBase] extends GroupInitializer[B] {
 
   override val program: String =
     "GHOST PHASE I/II MAPPING BPS"
 
+  implicit def GhostObsOps(obs: ISPObservation) = new {
+    val ed = StaticObservationEditor[edu.gemini.spModel.gemini.ghost.Ghost](obs, instrumentType)
 
+    def setAsterismType(a: AsterismType): Either[String, Unit] =
+      ed.updateInstrument(_.setPreferredAsterismType(a))
+
+  }
 
 }

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GhostBlueprintTest.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GhostBlueprintTest.scala
@@ -38,11 +38,11 @@ class GhostBlueprintTest extends TemplateSpec("GHOST_BP.xml") with Specification
       }
     }
 
-    "put the asterism type in the template group" in {
+    "put the asterism type in the GHOST component" in {
       forAll { (b: GhostBlueprint) =>
         expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
-          groups(sp).forall { tg =>
-            tg.getDataObject.asInstanceOf[TemplateGroup].getAsterismType match {
+          templateObservations(sp).forall { o =>
+            AsterismType.forObservation(o) match {
               case AsterismType.Single                              =>
                 false
               case AsterismType.GhostSingleTarget                   =>

--- a/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GhostBlueprintTest.scala
+++ b/bundle/edu.gemini.phase2.skeleton.servlet/src/test/scala/edu/gemini/phase2/skeleton/factory/GhostBlueprintTest.scala
@@ -1,0 +1,67 @@
+package edu.gemini.phase2.skeleton.factory
+
+import edu.gemini.model.p1.immutable._
+import edu.gemini.spModel.core.MagnitudeBand
+import edu.gemini.spModel.target.env.AsterismType
+import edu.gemini.spModel.template.TemplateGroup
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.SpecificationLike
+
+class GhostBlueprintTest extends TemplateSpec("GHOST_BP.xml") with SpecificationLike with ScalaCheck {
+
+  implicit val ArbitraryGhostResolutionMode: Arbitrary[GhostResolutionMode] =
+    Arbitrary(Gen.oneOf(GhostResolutionMode.values))
+
+  implicit val ArbitraryGhostTargetMode: Arbitrary[GhostTargetMode] =
+    Arbitrary(Gen.oneOf(GhostTargetMode.values))
+
+  implicit val ArbitraryGhostBlueprint: Arbitrary[GhostBlueprint] =
+    Arbitrary {
+      for {
+        r <- arbitrary[GhostResolutionMode]
+        t <- arbitrary[GhostTargetMode]
+      } yield GhostBlueprint(r, t)
+    }
+
+  "Ghost" should {
+
+    "include the science observation" in {
+      forAll { (b: GhostBlueprint) =>
+        expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
+          groups(sp).forall { tg =>
+            libs(tg) == Set(1)
+          }
+        }
+      }
+    }
+
+    "put the asterism type in the template group" in {
+      forAll { (b: GhostBlueprint) =>
+        expand(proposal(b, Nil, MagnitudeBand.R)) { (_, sp) =>
+          groups(sp).forall { tg =>
+            tg.getDataObject.asInstanceOf[TemplateGroup].getAsterismType match {
+              case AsterismType.Single                              =>
+                false
+              case AsterismType.GhostSingleTarget                   =>
+                b.resolutionMode == GhostResolutionMode.Standard && b.targetMode == GhostTargetMode.Single
+              case AsterismType.GhostDualTarget                     =>
+                b.resolutionMode == GhostResolutionMode.Standard && b.targetMode == GhostTargetMode.Dual
+              case AsterismType.GhostTargetPlusSky                  =>
+                b.resolutionMode == GhostResolutionMode.Standard && b.targetMode == GhostTargetMode.TargetAndSky
+              case AsterismType.GhostSkyPlusTarget                  =>
+                b.resolutionMode == GhostResolutionMode.Standard && b.targetMode == GhostTargetMode.SkyAndTarget
+              case AsterismType.GhostHighResolutionTargetPlusSky    =>
+                b.resolutionMode == GhostResolutionMode.High
+              case AsterismType.GhostHighResolutionTargetPlusSkyPrv =>
+                b.resolutionMode == GhostResolutionMode.PrecisionRadialVelocity
+            }
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/bundle/edu.gemini.pot/build.sbt
+++ b/bundle/edu.gemini.pot/build.sbt
@@ -76,6 +76,7 @@ OsgiKeys.exportPackage := Seq(
   "edu.gemini.spModel.gemini.flamingos2.test",
   "edu.gemini.spModel.gemini.gems",
   "edu.gemini.spModel.gemini.ghost",
+  "edu.gemini.spModel.gemini.ghost.blueprint",
   "edu.gemini.spModel.gemini.gmos",
   "edu.gemini.spModel.gemini.gmos.blueprint",
   "edu.gemini.spModel.gemini.gmos.test",

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/blueprint/SpGhostBlueprint.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/blueprint/SpGhostBlueprint.java
@@ -25,7 +25,7 @@ public final class SpGhostBlueprint extends SpGhostBlueprintBase {
     }
 
     public String toString() {
-        return String.format("Ghost %s", asterismType().tag);
+        return String.format("Ghost %s", asterismType().displayName);
     }
 
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/blueprint/SpGhostBlueprint.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/blueprint/SpGhostBlueprint.java
@@ -1,0 +1,31 @@
+package edu.gemini.spModel.gemini.ghost.blueprint;
+
+import edu.gemini.pot.sp.Instrument;
+import edu.gemini.shared.util.immutable.ImOption;
+import edu.gemini.shared.util.immutable.Option;
+import edu.gemini.spModel.target.env.AsterismType;
+
+public final class SpGhostBlueprint extends SpGhostBlueprintBase {
+
+    public static final String PARAM_SET_NAME = "ghost";
+
+    private SpGhostBlueprint(AsterismType asterismType) {
+        super(asterismType);
+    }
+
+    public static Option<SpGhostBlueprint> fromAsterismType(AsterismType asterismType) {
+        return ImOption.when(
+            AsterismType.supportedTypesForInstrument(Instrument.Ghost).contains(asterismType),
+            () -> new SpGhostBlueprint(asterismType)
+        );
+    }
+
+    @Override public String paramSetName() {
+        return PARAM_SET_NAME;
+    }
+
+    public String toString() {
+        return String.format("Ghost %s", asterismType().tag);
+    }
+
+}

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/blueprint/SpGhostBlueprintBase.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/blueprint/SpGhostBlueprintBase.java
@@ -1,0 +1,53 @@
+package edu.gemini.spModel.gemini.ghost.blueprint;
+
+import edu.gemini.pot.sp.Instrument;
+import edu.gemini.pot.sp.SPComponentType;
+import edu.gemini.spModel.pio.ParamSet;
+import edu.gemini.spModel.pio.Pio;
+import edu.gemini.spModel.pio.PioFactory;
+import edu.gemini.spModel.target.env.AsterismType;
+import edu.gemini.spModel.template.SpBlueprint;
+
+import java.util.Objects;
+
+
+public abstract class SpGhostBlueprintBase extends SpBlueprint {
+
+    public static final String ASTERISM_TYPE_PARAM_NAME = "asterismType";
+
+    private final AsterismType asterismType;
+
+    protected SpGhostBlueprintBase(AsterismType asterismType) {
+        assert AsterismType.supportedTypesForInstrument(Instrument.Ghost).contains(asterismType) :
+                "Ghost blueprints must be created with a GHOST asterism type, not " + asterismType.tag;
+
+        this.asterismType = asterismType;
+    }
+
+    @Override public SPComponentType instrumentType() {
+        return SPComponentType.INSTRUMENT_GHOST;
+    }
+
+    @Override public AsterismType asterismType() {
+       return asterismType;
+    }
+
+    @Override public ParamSet toParamSet(PioFactory factory) {
+        final ParamSet paramSet = factory.createParamSet(paramSetName());
+        Pio.addEnumParam(factory, paramSet, ASTERISM_TYPE_PARAM_NAME, asterismType);
+        return paramSet;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SpGhostBlueprintBase that = (SpGhostBlueprintBase) o;
+        return asterismType == that.asterismType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(asterismType);
+    }
+}

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obscomp/SPInstObsComp.java
@@ -13,6 +13,7 @@ import edu.gemini.spModel.obs.plannedtime.PlannedTime;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
+import edu.gemini.spModel.target.env.AsterismType;
 import edu.gemini.spModel.util.Angle;
 
 import java.beans.PropertyDescriptor;
@@ -335,34 +336,6 @@ public abstract class SPInstObsComp extends AbstractDataObject {
         }
     }
 
-    /**
-     * Are two SPInstObsComp objects are equal.
-     */
-    /*  equals / hashCode for mutable objects is not well defined and this
-        is problematic anyway because it is not defined in the subclasses
-    public boolean equals(Object obj) {
-        if (obj == null || (!(obj instanceof SPInstObsComp))) {
-            return false;
-        }
-        SPInstObsComp oc = (SPInstObsComp) obj;
-
-		// RCN: this had not been serialization-safe.
-		String v1 = getVersion(), v2 = oc.getVersion();
-		if (v1 == null && v2 == null) {
-			// this is apparently ok, if it ever happens.
-		} else {
-			if (v1 == null || !v1.equals(v2))
-				return false;
-		}
-
-	    if (_exposureTime != oc._exposureTime)
-            return false;
-        if (_positionAngle != oc._positionAngle)
-            return false;
-        return _coadds == oc._coadds;
-    }
-    */
-
     /** Return true if this instrument has an OIWFS */
     public boolean hasOIWFS() {
         return true;  //  redefine in a derived class if not
@@ -430,6 +403,10 @@ public abstract class SPInstObsComp extends AbstractDataObject {
      */
     public Instrument getInstrument() {
         return Instrument.fromComponentType(getType()).getValue();
+    }
+
+    public AsterismType getPreferredAsterismType() {
+        return AsterismType.Single;
     }
 
     // REL-1678: 7 seconds DHS write overhead

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
@@ -1,16 +1,14 @@
 package edu.gemini.spModel.target.env;
 
 import edu.gemini.pot.sp.Instrument;
+import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.gemini.ghost.AsterismConverters;
-import edu.gemini.spModel.gemini.ghost.GhostAsterism$;
 import edu.gemini.spModel.type.DisplayableSpType;
 
 import java.util.Collections;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.function.Supplier;
 
 public enum AsterismType implements DisplayableSpType {
 
@@ -91,24 +89,36 @@ public enum AsterismType implements DisplayableSpType {
         return displayName;
     }
 
+    public static final SortedSet<AsterismType> DEFAULT_SET;
+
+    static {
+        final SortedSet<AsterismType> s = new TreeSet<>();
+        s.add(Single);
+        DEFAULT_SET = Collections.unmodifiableSortedSet(s);
+    }
+
+    public static final SortedSet<AsterismType> GHOST_SET;
+
+    static {
+        final SortedSet<AsterismType> s = new TreeSet<>();
+        s.add(GhostSingleTarget);
+        s.add(GhostDualTarget);
+        s.add(GhostTargetPlusSky);
+        s.add(GhostSkyPlusTarget);
+        s.add(GhostHighResolutionTargetPlusSky);
+        s.add(GhostHighResolutionTargetPlusSkyPrv);
+        GHOST_SET = Collections.unmodifiableSortedSet(s);
+    }
+
     // Return the asterism types supported by the different instruments.
     // We need to do this here because we want these statically accessible.
     public static SortedSet<AsterismType> supportedTypesForInstrument(final Instrument instType) {
-        final SortedSet<AsterismType> result;
-        if (instType == Instrument.Ghost) {
-            final SortedSet<AsterismType> s = new TreeSet<>();
-            s.add(GhostSingleTarget);
-            s.add(GhostDualTarget);
-            s.add(GhostTargetPlusSky);
-            s.add(GhostSkyPlusTarget);
-            s.add(GhostHighResolutionTargetPlusSky);
-            s.add(GhostHighResolutionTargetPlusSkyPrv);
-            result = Collections.unmodifiableSortedSet(s);
-        } else {
-            final SortedSet<AsterismType> s = new TreeSet<>();
-            s.add(Single);
-            result = Collections.unmodifiableSortedSet(s);
-        }
-        return result;
+        return (instType == Instrument.Ghost) ? GHOST_SET : DEFAULT_SET;
+    }
+
+    public static Option<SortedSet<AsterismType>> supportedTypesForComponent(final SPComponentType compType) {
+        return Instrument
+                .fromComponentType(compType)
+                .map(AsterismType::supportedTypesForInstrument);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/env/AsterismType.java
@@ -1,10 +1,14 @@
 package edu.gemini.spModel.target.env;
 
+import edu.gemini.pot.sp.ISPObservation;
 import edu.gemini.pot.sp.Instrument;
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.shared.util.immutable.*;
 import edu.gemini.spModel.gemini.ghost.AsterismConverters;
+import edu.gemini.spModel.obscomp.SPInstObsComp;
+import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.type.DisplayableSpType;
+import edu.gemini.spModel.util.SPTreeUtil;
 
 import java.util.Collections;
 import java.util.SortedSet;
@@ -120,5 +124,20 @@ public enum AsterismType implements DisplayableSpType {
         return Instrument
                 .fromComponentType(compType)
                 .map(AsterismType::supportedTypesForInstrument);
+    }
+
+    public static AsterismType forTargetEnvironment(TargetEnvironment env) {
+        return env.getAsterism().asterismType();
+    }
+
+    public static AsterismType forObservation(ISPObservation obs) {
+        return ImOption
+            .apply(SPTreeUtil.findTargetEnvNode(obs))
+            .map(n -> forTargetEnvironment(((TargetObsComp) n.getDataObject()).getTargetEnvironment()))
+            .orElse(ImOption
+                .apply(SPTreeUtil.findInstrument(obs))
+                .filter(n -> n.getDataObject() instanceof SPInstObsComp)
+                .map(n -> ((SPInstObsComp) n.getDataObject()).getPreferredAsterismType())
+            ).getOrElse(AsterismType.Single);
     }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/FunctorHelpers.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/FunctorHelpers.java
@@ -1,9 +1,6 @@
 package edu.gemini.spModel.template;
 
 import edu.gemini.pot.sp.*;
-
-
-import java.util.List;
 import java.util.logging.Logger;
 
 class FunctorHelpers {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
@@ -14,6 +14,7 @@ import edu.gemini.spModel.target.env.Asterism;
 import edu.gemini.spModel.target.env.Asterism$;
 import edu.gemini.spModel.target.env.AsterismType;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
+import edu.gemini.spModel.util.AsterismEditUtil;
 import edu.gemini.spModel.util.DefaultSchedulingBlock;
 
 
@@ -126,6 +127,7 @@ public class InstantiationFunctor extends DBAbstractFunctor {
         toc.setTargetEnvironment(toc.getTargetEnvironment().setAsterism(ast));
         comp.setDataObject(toc);
         addIfNotPresent(newObs, comp);
+        AsterismEditUtil.matchAsterismToInstrument(newObs);
     }
 
     // Copy the specified site quality into the specified observation

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
@@ -10,6 +10,9 @@ import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obscomp.SPGroup;
 import edu.gemini.spModel.target.SPTarget;
+import edu.gemini.spModel.target.env.Asterism;
+import edu.gemini.spModel.target.env.Asterism$;
+import edu.gemini.spModel.target.env.AsterismType;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.spModel.util.DefaultSchedulingBlock;
 
@@ -84,6 +87,8 @@ public class InstantiationFunctor extends DBAbstractFunctor {
 
     // Copy observations from the template group into the destination group
     private static void copyObservations(ISPFactory fact, ISPProgram prog, ISPTemplateGroup templateGroup, SPSiteQuality siteQualityData, SPTarget targetData, ISPGroup group) throws Exception {
+        final AsterismType astType = ((TemplateGroup) templateGroup.getDataObject()).getAsterismType();
+
         for (ISPObservation templateObs: templateGroup.getAllObservations()) {
 
             // Clone the template obs
@@ -105,20 +110,20 @@ public class InstantiationFunctor extends DBAbstractFunctor {
                 copySiteQuality(fact, prog, siteQualityData, newObs);
             }
             if (newObsClass == ObsClass.SCIENCE || newObsClass == ObsClass.ACQ) {
-                copyTarget(fact, prog, targetData, newObs);
+                copyTarget(fact, prog, astType, targetData, newObs);
             }
 
             // Done
             group.addObservation(newObs);
-
         }
     }
 
     // Copy the specified target into the specified observation
-    private static void copyTarget(ISPFactory fact, ISPProgram prog, SPTarget targetData, ISPObservation newObs) throws SPUnknownIDException, SPNodeNotLocalException, SPTreeStateException {
+    private static void copyTarget(ISPFactory fact, ISPProgram prog, AsterismType astType, SPTarget targetData, ISPObservation newObs) throws SPUnknownIDException, SPNodeNotLocalException, SPTreeStateException {
         final ISPObsComponent comp = fact.createObsComponent(prog, TargetObsComp.SP_TYPE, null);
-        final TargetObsComp toc = (TargetObsComp) comp.getDataObject();
-        toc.setTargetEnvironment(toc.getTargetEnvironment().setBasePosition(targetData));
+        final TargetObsComp    toc = (TargetObsComp) comp.getDataObject();
+        final Asterism         ast = Asterism$.MODULE$.fromTypeAndTemplateTarget(astType, targetData);
+        toc.setTargetEnvironment(toc.getTargetEnvironment().setAsterism(ast));
         comp.setDataObject(toc);
         addIfNotPresent(newObs, comp);
     }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/InstantiationFunctor.java
@@ -88,8 +88,6 @@ public class InstantiationFunctor extends DBAbstractFunctor {
 
     // Copy observations from the template group into the destination group
     private static void copyObservations(ISPFactory fact, ISPProgram prog, ISPTemplateGroup templateGroup, SPSiteQuality siteQualityData, SPTarget targetData, ISPGroup group) throws Exception {
-        final AsterismType astType = ((TemplateGroup) templateGroup.getDataObject()).getAsterismType();
-
         for (ISPObservation templateObs: templateGroup.getAllObservations()) {
 
             // Clone the template obs
@@ -111,7 +109,7 @@ public class InstantiationFunctor extends DBAbstractFunctor {
                 copySiteQuality(fact, prog, siteQualityData, newObs);
             }
             if (newObsClass == ObsClass.SCIENCE || newObsClass == ObsClass.ACQ) {
-                copyTarget(fact, prog, astType, targetData, newObs);
+                copyTarget(fact, prog, targetData, newObs);
             }
 
             // Done
@@ -120,9 +118,10 @@ public class InstantiationFunctor extends DBAbstractFunctor {
     }
 
     // Copy the specified target into the specified observation
-    private static void copyTarget(ISPFactory fact, ISPProgram prog, AsterismType astType, SPTarget targetData, ISPObservation newObs) throws SPUnknownIDException, SPNodeNotLocalException, SPTreeStateException {
+    private static void copyTarget(ISPFactory fact, ISPProgram prog, SPTarget targetData, ISPObservation newObs) throws SPUnknownIDException, SPNodeNotLocalException, SPTreeStateException {
         final ISPObsComponent comp = fact.createObsComponent(prog, TargetObsComp.SP_TYPE, null);
         final TargetObsComp    toc = (TargetObsComp) comp.getDataObject();
+        final AsterismType astType = AsterismType.forObservation(newObs);
         final Asterism         ast = Asterism$.MODULE$.fromTypeAndTemplateTarget(astType, targetData);
         toc.setTargetEnvironment(toc.getTargetEnvironment().setAsterism(ast));
         comp.setDataObject(toc);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/ReapplicationFunctor.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/ReapplicationFunctor.java
@@ -11,6 +11,7 @@ import edu.gemini.spModel.obs.SPObservation;
 import edu.gemini.spModel.obsclass.ObsClass;
 import edu.gemini.spModel.obscomp.SPInstObsComp;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
+import edu.gemini.spModel.util.AsterismEditUtil;
 
 import java.security.Principal;
 import java.util.*;
@@ -121,6 +122,7 @@ public final class ReapplicationFunctor extends DBAbstractFunctor {
 
         // Restore old target and conditions if not already present
         addIfNotPresent(obs, oldTarget);
+        AsterismEditUtil.matchAsterismToInstrument(obs);
         addIfNotPresent(obs, oldConditions);
 
         // Restore the position angle, if any

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/SpBlueprint.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/SpBlueprint.java
@@ -3,6 +3,7 @@ package edu.gemini.spModel.template;
 import edu.gemini.pot.sp.SPComponentType;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.PioFactory;
+import edu.gemini.spModel.target.env.AsterismType;
 
 import java.io.Serializable;
 
@@ -13,4 +14,8 @@ public abstract class SpBlueprint implements Serializable {
     public abstract SPComponentType instrumentType();
     public abstract String paramSetName();
     public abstract ParamSet toParamSet(PioFactory factory);
+
+    public AsterismType asterismType() {
+        return AsterismType.Single;
+    }
 }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
@@ -19,7 +19,7 @@ public final class TemplateGroup extends AbstractDataObject {
     public static final SPComponentType SP_TYPE = SPComponentType.TEMPLATE_GROUP;
 
     public static final ISPNodeInitializer<ISPTemplateGroup, TemplateGroup> NI =
-        new SimpleNodeInitializer<>(SP_TYPE, () -> new TemplateGroup());
+        new SimpleNodeInitializer<>(SP_TYPE, TemplateGroup::new);
 
     // Private PIO parameters
     private static final String PARAM_BLUEPRINT = "blueprint";
@@ -36,7 +36,7 @@ public final class TemplateGroup extends AbstractDataObject {
     /**
      * Observation status values.
      */
-    public static enum Status implements DisplayableSpType, DescribableSpType {
+    public enum Status implements DisplayableSpType, DescribableSpType {
 
         PHASE2("Phase 2", "In Phase 2"),
         FOR_REVIEW("For Review", "Ready for review by contact scientist"),
@@ -47,8 +47,8 @@ public final class TemplateGroup extends AbstractDataObject {
         /** The default ObservationStatus value **/
         public static Status DEFAULT = PHASE2;
 
-        private String displayValue;
-        private String description;
+        private final String displayValue;
+        private final String description;
 
         private Status(String displayVal, String description) {
             displayValue = displayVal;
@@ -144,8 +144,8 @@ public final class TemplateGroup extends AbstractDataObject {
         blueprintId = Pio.getValue(paramSet, PARAM_BLUEPRINT);
         status = Status.valueOf(Pio.getValue(paramSet, PARAM_STATUS));
         groupType = Pio.getEnumValue(paramSet, PROP_GROUP_TYPE, GroupType.DEFAULT);
-        int[] segments = VersionToken.segments(Pio.getValue(paramSet, PARAM_VERSION_TOKEN, versionToken.toString()));
-        int next = Pio.getIntValue(paramSet, PARAM_VERSION_TOKEN_NEXT, 1);
+        final int[] segments = VersionToken.segments(Pio.getValue(paramSet, PARAM_VERSION_TOKEN, versionToken.toString()));
+        final int next = Pio.getIntValue(paramSet, PARAM_VERSION_TOKEN_NEXT, 1);
         versionToken = VersionToken.apply(segments, next);
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
@@ -9,8 +9,6 @@ import edu.gemini.spModel.obscomp.SPGroup.GroupType;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
-import edu.gemini.spModel.type.DescribableSpType;
-import edu.gemini.spModel.type.DisplayableSpType;
 import edu.gemini.spModel.util.VersionToken;
 
 public final class TemplateGroup extends AbstractDataObject {
@@ -29,51 +27,13 @@ public final class TemplateGroup extends AbstractDataObject {
     private static final String PARAM_GROUP_TYPE = "groupType";
 
     // Public property identifiers (for truly mutable stuff only)
-    public static final String PROP_STATUS = PARAM_STATUS;
     public static final String PROP_SPLIT_TOKEN = PARAM_VERSION_TOKEN;
     public static final String PROP_GROUP_TYPE = PARAM_GROUP_TYPE;
-
-    /**
-     * Observation status values.
-     */
-    public enum Status implements DisplayableSpType, DescribableSpType {
-
-        PHASE2("Phase 2", "In Phase 2"),
-        FOR_REVIEW("For Review", "Ready for review by contact scientist"),
-        IN_REVIEW("In Review", "Under review by NGO staff"),
-        READY("Ready", "Ready to execute or schedule"),
-        ;
-
-        /** The default ObservationStatus value **/
-        public static Status DEFAULT = PHASE2;
-
-        private final String displayValue;
-        private final String description;
-
-        private Status(String displayVal, String description) {
-            displayValue = displayVal;
-            this.description = description;
-        }
-
-        public String displayValue() {
-            return displayValue;
-        }
-
-        public String description() {
-            return description;
-        }
-
-        public String toString() {
-            return displayValue;
-        }
-
-    }
 
     // Each template group is derived from a single blueprint, and has a list of (Target, Conditions) refs to
     // which it can apply. These args can be moved between templates, but only if the templates share the same
     // blueprint (this allows forking).
     private String blueprintId;
-    private Status status = Status.DEFAULT;
     private VersionToken versionToken = new VersionToken(1);
     private GroupType groupType = GroupType.DEFAULT;
 
@@ -103,18 +63,6 @@ public final class TemplateGroup extends AbstractDataObject {
         this.groupType = groupType;
     }
 
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        if (this.status != status) {
-            final Status prev = this.status;
-            this.status = status;
-            firePropertyChange(PROP_STATUS, prev, status);
-        }
-    }
-
     public VersionToken getVersionToken() {
         return versionToken;
     }
@@ -131,7 +79,6 @@ public final class TemplateGroup extends AbstractDataObject {
     public ParamSet getParamSet(PioFactory factory) {
         final ParamSet ps = super.getParamSet(factory);
         Pio.addParam(factory, ps, PARAM_BLUEPRINT, blueprintId);
-        Pio.addParam(factory, ps, PARAM_STATUS, status.name());
         Pio.addParam(factory, ps, PARAM_VERSION_TOKEN, versionToken.toString());
         Pio.addIntParam(factory, ps, PARAM_VERSION_TOKEN_NEXT, versionToken.nextSegment());
         Pio.addEnumParam(factory, ps, PARAM_GROUP_TYPE, groupType);
@@ -142,7 +89,6 @@ public final class TemplateGroup extends AbstractDataObject {
     public void setParamSet(ParamSet paramSet) {
         super.setParamSet(paramSet);
         blueprintId = Pio.getValue(paramSet, PARAM_BLUEPRINT);
-        status = Status.valueOf(Pio.getValue(paramSet, PARAM_STATUS));
         groupType = Pio.getEnumValue(paramSet, PROP_GROUP_TYPE, GroupType.DEFAULT);
         final int[] segments = VersionToken.segments(Pio.getValue(paramSet, PARAM_VERSION_TOKEN, versionToken.toString()));
         final int next = Pio.getIntValue(paramSet, PARAM_VERSION_TOKEN_NEXT, 1);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
@@ -9,11 +9,12 @@ import edu.gemini.spModel.obscomp.SPGroup.GroupType;
 import edu.gemini.spModel.pio.ParamSet;
 import edu.gemini.spModel.pio.Pio;
 import edu.gemini.spModel.pio.PioFactory;
+import edu.gemini.spModel.target.env.AsterismType;
 import edu.gemini.spModel.util.VersionToken;
 
 public final class TemplateGroup extends AbstractDataObject {
 
-    public static final String VERSION = "2021A-1";
+    public static final String VERSION = "2023A-1";
     public static final SPComponentType SP_TYPE = SPComponentType.TEMPLATE_GROUP;
 
     public static final ISPNodeInitializer<ISPTemplateGroup, TemplateGroup> NI =
@@ -21,14 +22,17 @@ public final class TemplateGroup extends AbstractDataObject {
 
     // Private PIO parameters
     private static final String PARAM_BLUEPRINT = "blueprint";
-    private static final String PARAM_STATUS = "status";
     private static final String PARAM_VERSION_TOKEN = "versionToken";
     private static final String PARAM_VERSION_TOKEN_NEXT = "versionTokenNext";
     private static final String PARAM_GROUP_TYPE = "groupType";
 
-    // Public property identifiers (for truly mutable stuff only)
+    private static final String PARAM_ASTERISM_TYPE = "asterismType";
+
+// Public property identifiers (for truly mutable stuff only)
     public static final String PROP_SPLIT_TOKEN = PARAM_VERSION_TOKEN;
     public static final String PROP_GROUP_TYPE = PARAM_GROUP_TYPE;
+
+    public static final String PROP_ASTERISM_TYPE = PARAM_ASTERISM_TYPE;
 
     // Each template group is derived from a single blueprint, and has a list of (Target, Conditions) refs to
     // which it can apply. These args can be moved between templates, but only if the templates share the same
@@ -36,6 +40,8 @@ public final class TemplateGroup extends AbstractDataObject {
     private String blueprintId;
     private VersionToken versionToken = new VersionToken(1);
     private GroupType groupType = GroupType.DEFAULT;
+
+    private AsterismType asterismType = AsterismType.Single;
 
     public TemplateGroup() {
         setTitle("Untitled");
@@ -75,6 +81,18 @@ public final class TemplateGroup extends AbstractDataObject {
         }
     }
 
+    public AsterismType getAsterismType() {
+        return asterismType;
+    }
+
+    public void setAsterismType(AsterismType astType) {
+        if (!this.asterismType.equals(astType)) {
+            final AsterismType prev = this.asterismType;
+            this.asterismType = astType;
+            firePropertyChange(PROP_ASTERISM_TYPE, prev, astType);
+        }
+    }
+
     @Override
     public ParamSet getParamSet(PioFactory factory) {
         final ParamSet ps = super.getParamSet(factory);
@@ -82,6 +100,7 @@ public final class TemplateGroup extends AbstractDataObject {
         Pio.addParam(factory, ps, PARAM_VERSION_TOKEN, versionToken.toString());
         Pio.addIntParam(factory, ps, PARAM_VERSION_TOKEN_NEXT, versionToken.nextSegment());
         Pio.addEnumParam(factory, ps, PARAM_GROUP_TYPE, groupType);
+        Pio.addEnumParam(factory, ps, PARAM_ASTERISM_TYPE, asterismType);
         return ps;
     }
 
@@ -89,7 +108,8 @@ public final class TemplateGroup extends AbstractDataObject {
     public void setParamSet(ParamSet paramSet) {
         super.setParamSet(paramSet);
         blueprintId = Pio.getValue(paramSet, PARAM_BLUEPRINT);
-        groupType = Pio.getEnumValue(paramSet, PROP_GROUP_TYPE, GroupType.DEFAULT);
+        asterismType = Pio.getEnumValue(paramSet, PARAM_ASTERISM_TYPE, AsterismType.Single);
+        groupType = Pio.getEnumValue(paramSet, PARAM_GROUP_TYPE, GroupType.DEFAULT);
         final int[] segments = VersionToken.segments(Pio.getValue(paramSet, PARAM_VERSION_TOKEN, versionToken.toString()));
         final int next = Pio.getIntValue(paramSet, PARAM_VERSION_TOKEN_NEXT, 1);
         versionToken = VersionToken.apply(segments, next);

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/template/TemplateGroup.java
@@ -26,13 +26,9 @@ public final class TemplateGroup extends AbstractDataObject {
     private static final String PARAM_VERSION_TOKEN_NEXT = "versionTokenNext";
     private static final String PARAM_GROUP_TYPE = "groupType";
 
-    private static final String PARAM_ASTERISM_TYPE = "asterismType";
-
-// Public property identifiers (for truly mutable stuff only)
+    // Public property identifiers (for truly mutable stuff only)
     public static final String PROP_SPLIT_TOKEN = PARAM_VERSION_TOKEN;
     public static final String PROP_GROUP_TYPE = PARAM_GROUP_TYPE;
-
-    public static final String PROP_ASTERISM_TYPE = PARAM_ASTERISM_TYPE;
 
     // Each template group is derived from a single blueprint, and has a list of (Target, Conditions) refs to
     // which it can apply. These args can be moved between templates, but only if the templates share the same
@@ -40,8 +36,6 @@ public final class TemplateGroup extends AbstractDataObject {
     private String blueprintId;
     private VersionToken versionToken = new VersionToken(1);
     private GroupType groupType = GroupType.DEFAULT;
-
-    private AsterismType asterismType = AsterismType.Single;
 
     public TemplateGroup() {
         setTitle("Untitled");
@@ -81,18 +75,6 @@ public final class TemplateGroup extends AbstractDataObject {
         }
     }
 
-    public AsterismType getAsterismType() {
-        return asterismType;
-    }
-
-    public void setAsterismType(AsterismType astType) {
-        if (!this.asterismType.equals(astType)) {
-            final AsterismType prev = this.asterismType;
-            this.asterismType = astType;
-            firePropertyChange(PROP_ASTERISM_TYPE, prev, astType);
-        }
-    }
-
     @Override
     public ParamSet getParamSet(PioFactory factory) {
         final ParamSet ps = super.getParamSet(factory);
@@ -100,7 +82,6 @@ public final class TemplateGroup extends AbstractDataObject {
         Pio.addParam(factory, ps, PARAM_VERSION_TOKEN, versionToken.toString());
         Pio.addIntParam(factory, ps, PARAM_VERSION_TOKEN_NEXT, versionToken.nextSegment());
         Pio.addEnumParam(factory, ps, PARAM_GROUP_TYPE, groupType);
-        Pio.addEnumParam(factory, ps, PARAM_ASTERISM_TYPE, asterismType);
         return ps;
     }
 
@@ -108,7 +89,6 @@ public final class TemplateGroup extends AbstractDataObject {
     public void setParamSet(ParamSet paramSet) {
         super.setParamSet(paramSet);
         blueprintId = Pio.getValue(paramSet, PARAM_BLUEPRINT);
-        asterismType = Pio.getEnumValue(paramSet, PARAM_ASTERISM_TYPE, AsterismType.Single);
         groupType = Pio.getEnumValue(paramSet, PARAM_GROUP_TYPE, GroupType.DEFAULT);
         final int[] segments = VersionToken.segments(Pio.getValue(paramSet, PARAM_VERSION_TOKEN, versionToken.toString()));
         final int next = Pio.getIntValue(paramSet, PARAM_VERSION_TOKEN_NEXT, 1);

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/Ghost.scala
@@ -173,6 +173,22 @@ final class Ghost
   }
 
   /**
+   * Preferred Asterism type
+   */
+  private var asterismType: AsterismType = AsterismType.GhostSingleTarget
+
+  override def getPreferredAsterismType(): AsterismType =
+    asterismType
+
+  def setPreferredAsterismType(newValue: AsterismType): Unit = {
+    val oldValue = getPreferredAsterismType
+    if (oldValue != newValue) {
+      asterismType = newValue
+      firePropertyChange(Ghost.PREFERRED_ASTERISM_TYPE_PROP, oldValue, newValue)
+    }
+  }
+
+  /**
    * ISS Port
    */
   private var port: IssPort = IssPort.UP_LOOKING
@@ -509,6 +525,8 @@ object Ghost {
   // The name of the Ghost instrument configuration.
   val INSTRUMENT_NAME_PROP: String = "GHOST"
 
+  val PREFERRED_ASTERISM_TYPE: String = "preferredAsterismType"
+
   // GHOST-specific exposure times.
   val EXPOSURE_TIME_RED_PROP = "redExposureTime"
   val COUNT_RED = "redExposureCount"
@@ -578,6 +596,7 @@ object Ghost {
   private val iter_no   = false
 
   val POS_ANGLE_PROP: PropertyDescriptor = initProp(InstConstants.POS_ANGLE_PROP, query = query_no, iter = iter_no)
+  val PREFERRED_ASTERISM_TYPE_PROP: PropertyDescriptor = initProp(PREFERRED_ASTERISM_TYPE, query = query_no, iter = iter_no)
   val PORT_PROP: PropertyDescriptor = initProp(IssPortProvider.PORT_PROPERTY_NAME, query = query_no, iter = iter_no)
   val ENABLE_FIBER_AGITATOR_1_PROP: PropertyDescriptor = initProp(FIBER_AGITATOR_1, query = query_no, iter = iter_no)
   val ENABLE_FIBER_AGITATOR_2_PROP: PropertyDescriptor = initProp(FIBER_AGITATOR_2, query = query_no, iter = iter_no)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostAsterism.scala
@@ -299,6 +299,16 @@ object GhostAsterism {
     StandardResolution.emptySingleTarget.copyWithClonedTargets
   }
 
+  def createEmptyAsterism(t: AsterismType): Asterism =
+    (t match {
+      case AsterismType.GhostDualTarget                     => StandardResolution.emptyDualTarget
+      case AsterismType.GhostTargetPlusSky                  => StandardResolution.emptyTargetPlusSky
+      case AsterismType.GhostSkyPlusTarget                  => StandardResolution.emptySkyPlusTarget
+      case AsterismType.GhostHighResolutionTargetPlusSky    => HighResolution.emptyHRTargetPlusSky(PrvMode.PrvOff)
+      case AsterismType.GhostHighResolutionTargetPlusSkyPrv => HighResolution.emptyHRTargetPlusSky(PrvMode.PrvOn)
+      case _                                                => StandardResolution.emptySingleTarget
+    }).copyWithClonedTargets
+
   // Names of the IFUs.
   val SRIFU1: String = "SRIFU1"
   val SRIFU2: String = "SRIFU2"

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -9,10 +9,14 @@ import edu.gemini.spModel.target.{SPCoordinates, SPTarget, TargetParamSetCodecs}
 import edu.gemini.spModel.pio.{ParamSet, Pio}
 import edu.gemini.spModel.pio.codec.{MissingKey, ParamSetCodec, PioError, UnknownTag}
 import edu.gemini.spModel.pio.xml.PioXmlFactory
-import java.time.Instant
 
+import java.time.Instant
 import scalaz._
 import Scalaz._
+import edu.gemini.spModel.core.Angle
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostTarget
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.GuideFiberState
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.PrvMode
 
 
 /** Collection of stars that make up the science target(s) for an observation,
@@ -189,5 +193,72 @@ object Asterism {
   // classes results cannot be resolved.
   def createSingleAsterism: Single = {
     Single(new SPTarget())
+  }
+
+  def fromTypeAndTemplateTarget(
+    asterismType: AsterismType,
+    target:       SPTarget
+  ): Asterism = {
+
+    def targetPlus(am: Int): SPTarget = {
+      val res = new SPTarget()
+      res.setTarget(
+        Target.ra.mod(_.offset(Angle.fromArcmin(am.toDouble)), target.getTarget)
+      )
+      res
+    }
+
+    def coordinatesPlus(am: Int): SPCoordinates =
+      target.getCoordinates(None).fold(new SPCoordinates()) { c =>
+        new SPCoordinates(c.offset(Angle.fromArcmin(am.toDouble), Angle.zero))
+      }
+
+    def ghostTarget(sp: SPTarget): GhostTarget =
+      GhostTarget(sp, GuideFiberState.Enabled)
+
+    asterismType match {
+      case AsterismType.Single                              =>
+        Single(target)
+
+      case AsterismType.GhostSingleTarget                   =>
+        GhostAsterism.SingleTarget(ghostTarget(target), None)
+
+      case AsterismType.GhostDualTarget                     =>
+        GhostAsterism.DualTarget(
+          ghostTarget(targetPlus(1)),
+          ghostTarget(targetPlus(-1)),
+          target.getCoordinates(None).map(new SPCoordinates(_))
+        )
+
+      case AsterismType.GhostTargetPlusSky                  =>
+        GhostAsterism.TargetPlusSky(
+          ghostTarget(target),
+          coordinatesPlus(-2),
+          None
+        )
+
+      case AsterismType.GhostSkyPlusTarget                  =>
+        GhostAsterism.SkyPlusTarget(
+          coordinatesPlus(2),
+          ghostTarget(target),
+          None
+        )
+
+      case AsterismType.GhostHighResolutionTargetPlusSky    =>
+        GhostAsterism.HighResolutionTargetPlusSky(
+          ghostTarget(target),
+          coordinatesPlus(-2),
+          PrvMode.PrvOff,
+          None
+        )
+
+      case AsterismType.GhostHighResolutionTargetPlusSkyPrv =>
+        GhostAsterism.HighResolutionTargetPlusSky(
+          ghostTarget(target),
+          coordinatesPlus(-2),
+          PrvMode.PrvOn,
+          None
+        )
+    }
   }
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -203,7 +203,8 @@ object Asterism {
     def targetPlus(am: Int): SPTarget = {
       val res = new SPTarget()
       res.setTarget(
-        Target.ra.mod(_.offset(Angle.fromArcmin(am.toDouble)), target.getTarget)
+        // We offset in p, which increases to the left.
+        Target.ra.mod(_.offset(Angle.fromArcmin(-am.toDouble)), target.getTarget)
       )
       res
     }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -203,8 +203,7 @@ object Asterism {
     def targetPlus(am: Int): SPTarget = {
       val res = new SPTarget()
       res.setTarget(
-        // We offset in p, which increases to the left.
-        Target.ra.mod(_.offset(Angle.fromArcmin(-am.toDouble)), target.getTarget)
+        Target.ra.mod(_.offset(Angle.fromArcmin(am.toDouble)), target.getTarget)
       )
       res
     }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/env/Asterism.scala
@@ -200,11 +200,12 @@ object Asterism {
     target:       SPTarget
   ): Asterism = {
 
-    def targetPlus(am: Int): SPTarget = {
+    def targetPlus(am: Int, name: String): SPTarget = {
       val res = new SPTarget()
       res.setTarget(
         Target.ra.mod(_.offset(Angle.fromArcmin(am.toDouble)), target.getTarget)
       )
+      res.setName(name)
       res
     }
 
@@ -225,9 +226,9 @@ object Asterism {
 
       case AsterismType.GhostDualTarget                     =>
         GhostAsterism.DualTarget(
-          ghostTarget(targetPlus(1)),
-          ghostTarget(targetPlus(-1)),
-          target.getCoordinates(None).map(new SPCoordinates(_))
+          ghostTarget(target),
+          ghostTarget(targetPlus(-2, "Target 2")),
+          None
         )
 
       case AsterismType.GhostTargetPlusSky                  =>

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/AsterismEditUtil.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/AsterismEditUtil.scala
@@ -1,20 +1,19 @@
 // Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package jsky.app.ot.nsp
+package edu.gemini.spModel.util
 
 import edu.gemini.pot.sp.ISPObsComponent
 import edu.gemini.pot.sp.ISPObservation
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.shared.util.immutable.ScalaConverters._
 import edu.gemini.spModel.gemini.ghost.GhostAsterism
-import edu.gemini.spModel.gemini.ghost.GhostAsterism.GuideFiberState.Enabled
 import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostTarget
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.GuideFiberState.Enabled
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env.Asterism
 import edu.gemini.spModel.target.env.UserTarget
 import edu.gemini.spModel.target.obsComp.TargetObsComp
-import edu.gemini.spModel.util.SPTreeUtil
 
 object AsterismEditUtil {
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/AsterismEditUtil.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/AsterismEditUtil.scala
@@ -7,11 +7,14 @@ import edu.gemini.pot.sp.ISPObsComponent
 import edu.gemini.pot.sp.ISPObservation
 import edu.gemini.pot.sp.SPComponentType
 import edu.gemini.shared.util.immutable.ScalaConverters._
+import edu.gemini.spModel.gemini.ghost.Ghost
 import edu.gemini.spModel.gemini.ghost.GhostAsterism
 import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostTarget
 import edu.gemini.spModel.gemini.ghost.GhostAsterism.GuideFiberState.Enabled
+import edu.gemini.spModel.target.SPCoordinates
 import edu.gemini.spModel.target.SPTarget
 import edu.gemini.spModel.target.env.Asterism
+import edu.gemini.spModel.target.env.AsterismType
 import edu.gemini.spModel.target.env.UserTarget
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 
@@ -49,13 +52,30 @@ object AsterismEditUtil {
   private def switchToGhostAsterism(
     tn:  ISPObsComponent,
     toc: TargetObsComp,
-    ast: Asterism
+    ast: Asterism,
+    newType: AsterismType
   ): Unit =
     switchAsterism(
       tn,
       toc,
       ast,
-      t => GhostAsterism.SingleTarget(GhostTarget(t, Enabled), None)
+      t => {
+        val ghostTarget = GhostTarget(t, Enabled)
+        newType match {
+          case AsterismType.GhostDualTarget                     =>
+            GhostAsterism.DualTarget(ghostTarget, GhostTarget.empty, None)
+          case AsterismType.GhostTargetPlusSky                  =>
+            GhostAsterism.TargetPlusSky(ghostTarget, new SPCoordinates, None)
+          case AsterismType.GhostSkyPlusTarget                  =>
+            GhostAsterism.SkyPlusTarget(new SPCoordinates, ghostTarget, None)
+          case AsterismType.GhostHighResolutionTargetPlusSky    =>
+            GhostAsterism.HighResolutionTargetPlusSky(ghostTarget, new SPCoordinates, GhostAsterism.PrvMode.PrvOff, None)
+          case AsterismType.GhostHighResolutionTargetPlusSkyPrv =>
+            GhostAsterism.HighResolutionTargetPlusSky(ghostTarget, new SPCoordinates, GhostAsterism.PrvMode.PrvOn, None)
+          case _ =>
+            GhostAsterism.SingleTarget(ghostTarget, None)
+        }
+      }
     )
 
   private def switchToDefaultAsterism(
@@ -70,17 +90,32 @@ object AsterismEditUtil {
       Asterism.Single(_)
     )
 
-  def matchAsterismToInstrument(obs: ISPObservation): Unit =
+  def matchAsterismToInstrument(obs: ISPObservation): Unit = {
+    println("\n\n\n\nmatchAsterismToInstrument\n")
+    new RuntimeException().printStackTrace(System.out)
+
     for {
       tn <- Option(SPTreeUtil.findTargetEnvNode(obs))
       toc = tn.getDataObject.asInstanceOf[TargetObsComp]
       a   = toc.getAsterism
-      i  <- Option(SPTreeUtil.findInstrument(obs)).map(_.getType)
-    } (i, a) match {
-      case (SPComponentType.INSTRUMENT_GHOST, _: GhostAsterism) => // do nothing
-      case (SPComponentType.INSTRUMENT_GHOST, a)                => switchToGhostAsterism(tn, toc, a)
-      case (_, g: GhostAsterism)                                => switchToDefaultAsterism(tn, toc, g)
-      case _                                                    => // do nothing
+      i  <- Option(SPTreeUtil.findInstrument(obs))
+    } (i.getType, a) match {
+
+      case (SPComponentType.INSTRUMENT_GHOST, _: GhostAsterism) =>
+        println(s"do nothing: $a")
+        // do nothing
+
+      case (SPComponentType.INSTRUMENT_GHOST, a)                =>
+        val astType = i.getDataObject.asInstanceOf[Ghost].getPreferredAsterismType
+        println(s"preferredAsterismType: $astType")
+        switchToGhostAsterism(tn, toc, a, astType)
+
+      case (_, g: GhostAsterism)                                =>
+        switchToDefaultAsterism(tn, toc, g)
+
+      case _                                                    =>
+        // do nothing
     }
+  }
 
 }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/AsterismEditUtil.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/util/AsterismEditUtil.scala
@@ -90,10 +90,7 @@ object AsterismEditUtil {
       Asterism.Single(_)
     )
 
-  def matchAsterismToInstrument(obs: ISPObservation): Unit = {
-    println("\n\n\n\nmatchAsterismToInstrument\n")
-    new RuntimeException().printStackTrace(System.out)
-
+  def matchAsterismToInstrument(obs: ISPObservation): Unit =
     for {
       tn <- Option(SPTreeUtil.findTargetEnvNode(obs))
       toc = tn.getDataObject.asInstanceOf[TargetObsComp]
@@ -102,12 +99,10 @@ object AsterismEditUtil {
     } (i.getType, a) match {
 
       case (SPComponentType.INSTRUMENT_GHOST, _: GhostAsterism) =>
-        println(s"do nothing: $a")
         // do nothing
 
       case (SPComponentType.INSTRUMENT_GHOST, a)                =>
         val astType = i.getDataObject.asInstanceOf[Ghost].getPreferredAsterismType
-        println(s"preferredAsterismType: $astType")
         switchToGhostAsterism(tn, toc, a, astType)
 
       case (_, g: GhostAsterism)                                =>
@@ -116,6 +111,5 @@ object AsterismEditUtil {
       case _                                                    =>
         // do nothing
     }
-  }
 
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
@@ -38,7 +38,6 @@ class GhostInstantiationTest extends TestBase {
     val tgNode = fact.createTemplateGroup(prog, WithSomeNewKey)
     val tg     = new TemplateGroup()
     tg.setBlueprintId("blueprint-0")
-//    tg.setAsterismType(astType)
     tgNode.setDataObject(tg)
     os.foreach { o =>
       setAsterismType(o, astType)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
@@ -3,11 +3,14 @@ package edu.gemini.spModel.template
 import edu.gemini.pot.sp.ISPObservation
 import edu.gemini.pot.sp.Instrument
 import edu.gemini.spModel.core.Coordinates
+import edu.gemini.spModel.gemini.ghost.Ghost
 import edu.gemini.spModel.gemini.ghost.GhostAsterism
 import edu.gemini.spModel.gemini.ghost.blueprint.SpGhostBlueprint
+import edu.gemini.spModel.obsclass.ObsClass
 import edu.gemini.spModel.target.env.AsterismType
 import edu.gemini.spModel.obsclass.ObsClass.SCIENCE
 import edu.gemini.spModel.target.env.Asterism
+import edu.gemini.spModel.util.SPTreeUtil
 import org.junit.Test
 import org.junit.Assert._
 
@@ -35,9 +38,12 @@ class GhostInstantiationTest extends TestBase {
     val tgNode = fact.createTemplateGroup(prog, WithSomeNewKey)
     val tg     = new TemplateGroup()
     tg.setBlueprintId("blueprint-0")
-    tg.setAsterismType(astType)
+//    tg.setAsterismType(astType)
     tgNode.setDataObject(tg)
-    os.foreach(tgNode.addObservation)
+    os.foreach { o =>
+      setAsterismType(o, astType)
+      tgNode.addObservation(o)
+    }
 
     val tpNode = fact.createTemplateParameters(prog, WithSomeNewKey)
     val tp     = newParameters(ScienceTargetName, ScienceTargetCC)
@@ -84,6 +90,13 @@ class GhostInstantiationTest extends TestBase {
         fail(s"Expected a Ghost Dual Target asterism, not $a")
     }
 
+  }
+
+  private def setAsterismType(o: ISPObservation, asterismType: AsterismType): Unit = {
+    val shell = SPTreeUtil.findInstrument(o)
+    val ghost = shell.getDataObject.asInstanceOf[Ghost]
+    ghost.setPreferredAsterismType(asterismType)
+    shell.setDataObject(ghost)
   }
 
   @Test def testInstantiationHasProperAsterism(): Unit = {

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
@@ -1,0 +1,68 @@
+package edu.gemini.spModel.template
+
+import edu.gemini.pot.sp.ISPObservation
+import edu.gemini.pot.sp.Instrument
+import edu.gemini.spModel.gemini.ghost.blueprint.SpGhostBlueprint
+import edu.gemini.spModel.target.env.AsterismType
+import edu.gemini.spModel.obsclass.ObsClass.SCIENCE
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.collection.JavaConverters._
+
+
+class GhostInstantiationTest extends TestBase {
+
+  def instantiate(astType: AsterismType, os: ISPObservation*): List[ISPObservation] = {
+
+    val fact = getFactory
+    val prog = getProgram
+
+    // Remove existing observations
+    prog.setObservations(java.util.Collections.emptyList())
+    prog.setGroups(java.util.Collections.emptyList())
+
+    // Add the template folder with a single GHOST blueprint
+    val tfNode = fact.createTemplateFolder(prog, WithSomeNewKey)
+    val bp: SpBlueprint = SpGhostBlueprint.fromAsterismType(astType).getValue
+    val bpMap = Map("blueprint-0" -> bp)
+    val tf    = new TemplateFolder(bpMap.asJava)
+    tfNode.setDataObject(tf)
+
+    val tgNode = fact.createTemplateGroup(prog, WithSomeNewKey)
+    val tg     = new TemplateGroup()
+    tg.setBlueprintId("blueprint-0")
+    tg.setAsterismType(astType)
+    tgNode.setDataObject(tg)
+    os.foreach(tgNode.addObservation)
+
+    val tpNode = fact.createTemplateParameters(prog, WithSomeNewKey)
+    val tp     = newParameters(ScienceTargetName, ScienceTargetCC)
+    tpNode.setDataObject(tp)
+
+    tgNode.addTemplateParameters(tpNode)
+    tfNode.addTemplateGroup(tgNode)
+    prog.setTemplateFolder(tfNode)
+
+    // Instantiate observations
+    val func = new InstantiationFunctor
+    func.add(tgNode, tpNode)
+    func.execute(getOdb, getProgram, null)
+
+    val grp = getProgram.getGroups.get(0)
+    grp.getObservations.asScala.toList
+  }
+
+  @Test def testInstantiationHasProperAsterism(): Unit = {
+    val obsList = instantiate(AsterismType.GhostDualTarget, newObs(SCIENCE, Instrument.Ghost))
+
+    obsList match {
+      case o :: Nil =>
+        target(o).map(_.getAsterism.asterismType).contains(AsterismType.GhostDualTarget)
+
+      case _        =>
+        fail("Expected a single observation")
+
+    }
+  }
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
@@ -77,13 +77,13 @@ class GhostInstantiationTest extends TestBase {
     a match {
       case GhostAsterism.DualTarget(ifu1, ifu2, base) =>
         // Overridden base at the template target coordinates
-         checkDiff(base.get.coordinates, ct, 0, 0)
+         checkDiff(base.get.coordinates, ct,0,0)
 
         // IFU1 at 1 arcmin (in p) from base
-        checkDiff(ifu1.coordinates(None).get, ct, 1, 0)
+        checkDiff(ct, ifu1.coordinates(None).get,1,0)
 
         // IFU2 at -1 arcmin (in p) from base
-        checkDiff(ifu2.coordinates(None).get, ct, -1, 0)
+        checkDiff(ct, ifu2.coordinates(None).get,-1,0)
 
       case _ =>
         fail(s"Expected a Ghost Dual Target asterism, not $a")

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
@@ -76,7 +76,7 @@ class GhostInstantiationTest extends TestBase {
     assertEquals(AsterismType.GhostDualTarget, a.asterismType)
     a match {
       case GhostAsterism.DualTarget(ifu1, ifu2, None) =>
-        
+
         // IFU1 at 1 arcmin (in p) from base
         checkDiff(ct, ifu1.coordinates(None).get,1,0)
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/GhostInstantiationTest.scala
@@ -71,14 +71,12 @@ class GhostInstantiationTest extends TestBase {
   }
 
   private def checkDualTarget(a: Asterism): Unit = {
-    val ct = newTarget(ScienceTargetName).getCoordinates(None).get
+    val ct = a.basePosition(None).get
 
     assertEquals(AsterismType.GhostDualTarget, a.asterismType)
     a match {
-      case GhostAsterism.DualTarget(ifu1, ifu2, base) =>
-        // Overridden base at the template target coordinates
-         checkDiff(base.get.coordinates, ct,0,0)
-
+      case GhostAsterism.DualTarget(ifu1, ifu2, None) =>
+        
         // IFU1 at 1 arcmin (in p) from base
         checkDiff(ct, ifu1.coordinates(None).get,1,0)
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
@@ -48,7 +48,7 @@ class InstantiationFunctorTest extends TestBase {
     tfNode.addTemplateGroup(tgNode)
     prog.setTemplateFolder(tfNode)
 
-    // Add an observation for each of the specified obs clsses
+    // Add an observation for each of the specified obs classes
     os.foreach(tgNode.addObservation)
 
     // Instantiate observations

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/TestBase.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/TestBase.scala
@@ -1,0 +1,58 @@
+package edu.gemini.spModel.template
+
+import edu.gemini.pot.sp.ISPObsComponent
+import edu.gemini.pot.sp.ISPObservation
+import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.pot.sp.SPComponentType.{OBSERVER_OBSERVE, SCHEDULING_CONDITIONS, TELESCOPE_TARGETENV}
+import edu.gemini.spModel.data.ISPDataObject
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover
+import edu.gemini.spModel.test.SpModelTestBase
+
+import scala.collection.JavaConverters._
+import scalaz._
+import Scalaz._
+import edu.gemini.pot.sp.Instrument
+import edu.gemini.spModel.obsclass.ObsClass
+import edu.gemini.spModel.seqcomp.SeqRepeatObserve
+
+abstract class TestBase extends SpModelTestBase with TestHelp {
+  def newObsComp(cType: SPComponentType, dob: ISPDataObject): ISPObsComponent =
+    getFactory.createObsComponent(getProgram, cType, WithSomeNewKey) <| (_.setDataObject(dob))
+
+  def newSiteQualityComponent(cc: CloudCover): ISPObsComponent =
+    newObsComp(SCHEDULING_CONDITIONS, newSiteQuality(cc))
+
+  def newTargetComponent(n: String): ISPObsComponent =
+    newObsComp(TELESCOPE_TARGETENV, newTargetObsComp(n))
+
+  def editObservation(o: ISPObservation): Unit = {
+    def editObsComponent(o: ISPObservation, ct: SPComponentType, noc: ISPObsComponent): Unit =
+      o.getObsComponents.asScala.find { _.getType == ct }.fold(o.addObsComponent(noc)) { oc =>
+        oc.setDataObject(noc.getDataObject)
+      }
+
+    // Set conditions, target, and PA.
+    editObsComponent(o, SCHEDULING_CONDITIONS, newSiteQualityComponent(EditTargetCC))
+    editObsComponent(o, TELESCOPE_TARGETENV, newTargetComponent(EditTargetName))
+  }
+
+  def newObs(clazz: ObsClass, inst: Instrument): ISPObservation = {
+    val obsNode     = getFactory.createObservation(getProgram, inst.some, WithSomeNewKey)
+
+    val filteredChildren = obsNode.getObsComponents.asScala.filter { n =>
+      n.getDataObject.getType match {
+        case TELESCOPE_TARGETENV | SCHEDULING_CONDITIONS => false
+        case _                                           => true
+      }
+    }
+    obsNode.setObsComponents(filteredChildren.asJava)
+
+    val observeNode = getFactory.createSeqComponent(getProgram, OBSERVER_OBSERVE, WithSomeNewKey)
+    val observe     = new SeqRepeatObserve() <| (_.setObsClass(clazz))
+    observeNode.setDataObject(observe)
+
+    obsNode.getSeqComponent.addSeqComponent(observeNode)
+    obsNode
+  }
+
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/TestHelp.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/TestHelp.scala
@@ -1,0 +1,57 @@
+package edu.gemini.spModel.template
+
+
+import edu.gemini.pot.sp.ISPObsComponent
+import edu.gemini.pot.sp.ISPObservation
+import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.pot.sp.SPComponentType.{SCHEDULING_CONDITIONS, TELESCOPE_TARGETENV}
+import edu.gemini.pot.sp.SPNodeKey
+import edu.gemini.shared.util.TimeValue
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover.{PERCENT_50 => CC50, PERCENT_80 => CC80}
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.env.TargetEnvironment
+import edu.gemini.spModel.target.obsComp.TargetObsComp
+
+import scala.collection.JavaConverters._
+import scalaz._
+import Scalaz._
+
+trait TestHelp {
+  // The program factory interprets a null key as a request to create a new key
+  val WithSomeNewKey: SPNodeKey = null
+
+  val ScienceTargetName = "Biff"
+  val EditTargetName    = "Henderson"
+  val ScienceTargetCC   = CC50
+  val EditTargetCC      = CC80
+  val EditPA            = 42.0
+
+  def newTarget(name: String): SPTarget =
+    new SPTarget() <| (_.setName(name))
+
+  def newTargetObsComp(name: String): TargetObsComp =
+    new TargetObsComp <| (_.setTargetEnvironment(TargetEnvironment.create(newTarget(name))))
+
+  def newSiteQuality(cc: CloudCover): SPSiteQuality =
+    new SPSiteQuality() <| (_.setCloudCover(cc))
+
+  def newParameters(targetName: String, cc: CloudCover): TemplateParameters =
+    TemplateParameters.newInstance(newTarget(targetName), newSiteQuality(cc), new TimeValue(1, TimeValue.Units.hours))
+
+  def siteQuality(o: ISPObservation): Option[SPSiteQuality] =
+    dataObject[SPSiteQuality](o, SCHEDULING_CONDITIONS)
+
+  def target(o: ISPObservation): Option[TargetObsComp] =
+    dataObject[TargetObsComp](o, TELESCOPE_TARGETENV)
+
+  def dataObject[D: Manifest](o: ISPObservation, ct: SPComponentType): Option[D] =
+    obsComp[D](o, ct).map(_._2)
+
+  def obsComp[D: Manifest](o: ISPObservation, ct: SPComponentType): Option[(ISPObsComponent, D)] =
+    o.getObsComponents.asScala.find { _.getType == ct }.map(oc => (oc, oc.getDataObject)).collect {
+      case (oc, d: D) => (oc, d)
+    }
+
+}

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/PublishAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/PublishAction.java
@@ -230,7 +230,7 @@ public class PublishAction extends AbstractAsyncAction implements PropertyChange
         final String httpRoot;
 
         public Destination(String host, String user, String root, String httpRoot) {
-            this(new DefaultSshConfig(host, user, "", SshConfig$.MODULE$.DEFAULT_TIMEOUT()), root, httpRoot);
+            this(new DefaultSshConfig(host, user, "", SshConfig$.MODULE$.DEFAULT_TIMEOUT(), true), root, httpRoot);
         }
 
         private Destination(SshConfig config, String root, String httpRoot) {
@@ -240,7 +240,7 @@ public class PublishAction extends AbstractAsyncAction implements PropertyChange
         }
 
         public Destination withPassword(String password) {
-            final SshConfig c = new DefaultSshConfig(config.getHost(), config.getUser(), password, config.getTimeout());
+            final SshConfig c = new DefaultSshConfig(config.getHost(), config.getUser(), password, config.getTimeout(), true);
             return new Destination(c, root, httpRoot);
         }
     }

--- a/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
+++ b/bundle/edu.gemini.shared.util/src/main/java/edu/gemini/shared/util/immutable/ImOption.java
@@ -4,6 +4,7 @@ import scala.None$;
 import scala.Option$;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public final class ImOption {
     private ImOption() { }
@@ -34,5 +35,9 @@ public final class ImOption {
 
     public static <T> scala.Option<T> scalaNone() {
         return toScalaOpt(None.instance());
+    }
+
+    public static <T> Option<T> when(final boolean condition, Supplier<T> value) {
+        return condition ? new Some<>(value.get()) : None.instance();
     }
 }

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/html/FtpProps.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/dbTools/html/FtpProps.java
@@ -52,7 +52,7 @@ final public class FtpProps extends Props {
         String user     = getString(FTP_USER_PROP);
         String password = getString(FTP_PASSWORD_PROP);
         int timeout     = getInt(FTP_TIMEOUT_PROP, SshConfig$.MODULE$.DEFAULT_TIMEOUT());
-        sshConfig = new DefaultSshConfig(host, user, password, timeout);
+        sshConfig = new DefaultSshConfig(host, user, password, timeout, true);
         dir = getString(FTP_DEST_DIR_PROP);
     }
 

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/collection/table/TemplateSummaryTable.java
@@ -22,11 +22,10 @@ public class TemplateSummaryTable extends AbstractTable {
 	@SuppressWarnings("unused")
 	private static final Logger LOGGER = Logger.getLogger(TemplateSummaryTable.class.getName());
 	private static final long serialVersionUID = 1L;
-	private static final float MS_PER_HOUR = 1000 * 60 * 60;
 	private static final String DESC = "Templates";
 	private static final String CAPTION = "Template Summary";
 
-	public static enum Columns implements IColumn {
+	public enum Columns implements IColumn {
         // REL-775: The information that must be extracted for each target is:
         // Progid
         // Band

--- a/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/impl/BatchReportsTask.java
+++ b/bundle/edu.gemini.spdb.reports.collection/src/main/java/edu/gemini/spdb/reports/impl/BatchReportsTask.java
@@ -133,7 +133,7 @@ public class BatchReportsTask implements CronJob {
      * @throws IOException if anything goes wrong during the copy(i.e. file not found, wrong password, etc...)
      */
     private static void sftp(final Logger log, final File f, final String username, final String password, final String host, final String remoteDirectory) throws Exception {
-        DefaultSshConfig config = new DefaultSshConfig(host, username, password, SshConfig$.MODULE$.DEFAULT_TIMEOUT());
+        DefaultSshConfig config = new DefaultSshConfig(host, username, password, SshConfig$.MODULE$.DEFAULT_TIMEOUT(), true);
         log.info(String.format("sftp %s starting", config.toString()));
         long startTime = System.currentTimeMillis();
         Try<SftpSession> sftpSessionTry = SftpSession$.MODULE$.connect(config);

--- a/bundle/edu.gemini.util.ssh/src/main/scala/edu/gemini/util/ssh/DefaultSshConfig.scala
+++ b/bundle/edu.gemini.util.ssh/src/main/scala/edu/gemini/util/ssh/DefaultSshConfig.scala
@@ -8,10 +8,11 @@ package edu.gemini.util.ssh
  * @param password The password for the user on the host.
  * @param timeout  A timeout for establishing connections and executing commands, in milliseconds.
  */
-class DefaultSshConfig(host: String, user: String, password: String, timeout: Int = SshConfig.DEFAULT_TIMEOUT) extends SshConfig {
+class DefaultSshConfig(host: String, user: String, password: String, timeout: Int = SshConfig.DEFAULT_TIMEOUT, enabled: Boolean = true) extends SshConfig {
   val getHost = host
   val getUser = user
   val getPassword = password
   val getTimeout = timeout
+  val isEnabled = enabled
   override def toString = "%s@%s".format(user, host)
 }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
@@ -170,7 +170,7 @@ class ParamsListTableModel extends AbstractTableModel {
 
     // We keep a List of Pair (shell, data object), for efficiency
     private final java.util.List<Pair<ISPTemplateParameters, TemplateParameters>> data =
-            new ArrayList<Pair<ISPTemplateParameters, TemplateParameters>>();
+            new ArrayList<>();
 
     public void setTemplateGroupNode(ISPTemplateGroup tgn) {
         if (templateGroupNode != null) {
@@ -193,7 +193,7 @@ class ParamsListTableModel extends AbstractTableModel {
     }
 
     private static Pair<ISPTemplateParameters, TemplateParameters> pair(ISPTemplateParameters tp) {
-        return new Pair<ISPTemplateParameters, TemplateParameters>(tp, (TemplateParameters) tp.getDataObject());
+        return new Pair<>(tp, (TemplateParameters) tp.getDataObject());
     }
 
     private void refreshList() {
@@ -324,11 +324,7 @@ final class EdTemplateParameters extends JPanel {
         }};
         setLayout(new BorderLayout());
 
-        StaffBean.addPropertyChangeListener(new PropertyChangeListener() {
-            @Override public void propertyChange(PropertyChangeEvent evt) {
-                updateLayout();
-            }
-        });
+        StaffBean.addPropertyChangeListener(evt -> updateLayout());
     }
 
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/editor/template/EdTemplateGroup.java
@@ -22,7 +22,6 @@ import jsky.app.ot.viewer.SPDragDropObject;
 import jsky.app.ot.viewer.SPTree;
 import jsky.app.ot.viewer.SPViewer;
 import jsky.util.gui.DialogUtil;
-import jsky.util.gui.SingleSelectComboBox;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
@@ -442,8 +441,8 @@ final class EdTemplateParameters extends JPanel {
 
         private void addTargets(final ImList<SPTarget> ts) {
             addNewParameters(o -> {
-                final SPSiteQuality sq = o.map(tp -> tp.getSiteQuality()).getOrElse(new SPSiteQuality());
-                final TimeValue     tv = o.map(tp -> tp.getTime()).getOrElse(TimeValue.ZERO_HOURS);
+                final SPSiteQuality sq = o.map(TemplateParameters::getSiteQuality).getOrElse(new SPSiteQuality());
+                final TimeValue     tv = o.map(TemplateParameters::getTime).getOrElse(TimeValue.ZERO_HOURS);
                 return ts.map(t -> TemplateParameters.newInstance(t, sq, tv));
             });
         }
@@ -453,7 +452,7 @@ final class EdTemplateParameters extends JPanel {
 
             TargetImport.promptAndReadAsJava(c, program).biForEach(
               msg -> JOptionPane.showMessageDialog(c, msg, "Error", JOptionPane.ERROR_MESSAGE),
-              ts  -> addTargets(ts)
+              this::addTargets
             );
         }
     };
@@ -555,10 +554,6 @@ class EdTemplateGroupHeader extends JPanel {
     private TemplateGroup templateGroup;
 
     private final JLabel resource = new JLabel();
-    private final JComboBox status = new SingleSelectComboBox() {{
-        setChoices(TemplateGroup.Status.values());
-        setMaximumRowCount(TemplateGroup.Status.values().length);
-    }};
 
     private final JTextField title = new JTextField() {{
         getDocument().addDocumentListener(new AbstractDocumentListener() {
@@ -600,7 +595,6 @@ class EdTemplateGroupHeader extends JPanel {
         // Update our UI
         resource.setText(blueprint.toString());
         title.setText(templateGroup.getTitle());
-        status.setSelectedItem(templateGroup.getStatus());
     }
 }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/nsp/SPTreeEditUtil.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/nsp/SPTreeEditUtil.java
@@ -18,6 +18,7 @@ import edu.gemini.shared.util.immutable.ImOption;
 import edu.gemini.spModel.data.ISPDataObject;
 import edu.gemini.spModel.obscomp.SPNote;
 import edu.gemini.spModel.seqcomp.SeqBase;
+import edu.gemini.spModel.util.AsterismEditUtil;
 import edu.gemini.spModel.util.DBCopyService;
 import edu.gemini.spModel.util.SPTreeUtil;
 import jsky.app.ot.OTOptions;

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerActions.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/viewer/SPViewerActions.java
@@ -8,6 +8,7 @@ import edu.gemini.spModel.gemini.init.ComponentNodeInitializer;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.obscomp.SPGroup;
 import edu.gemini.spModel.seqcomp.SeqBase;
+import edu.gemini.spModel.target.env.AsterismType;
 import edu.gemini.spModel.target.obsComp.TargetObsComp;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.None;
@@ -211,7 +212,7 @@ public final class SPViewerActions {
                 ISPObsComponentContainer container
             ) {
                 return Ghost$.MODULE$.isGhostObservation(container) ?
-                         ImOption.apply(Ghost$.MODULE$.TARGET_NI()) :
+                         ImOption.apply(Ghost$.MODULE$.TargetNi(scala.Option.apply((ISPObservation) container))) :
                          ImOption.empty();
             }
         };

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/nsp/AsterismEditUtil.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/nsp/AsterismEditUtil.scala
@@ -15,7 +15,6 @@ import edu.gemini.spModel.target.env.Asterism
 import edu.gemini.spModel.target.env.UserTarget
 import edu.gemini.spModel.target.obsComp.TargetObsComp
 import edu.gemini.spModel.util.SPTreeUtil
-import scalaz.NonEmptyList
 
 object AsterismEditUtil {
 


### PR DESCRIPTION
Adds support for GHOST templates, according to the rules in `GHOST_BP.txt`.  The challenge with this template is that the resolution mode and target mode (taken together, the asterism type) is set at Phase 1 and we want to preserve this through instantiation.  Unfortunately this information is kept in the selected asterism in the target node, but there is no target node in the template group.  To compensate, a `preferredAsterismType` is added to the instrument component and overridden by GHOST in particular.  When there is no target node the instrument node's preferred asterism type is consulted instead.

