### PR TITLE
REL-4282 - ITC calculation of exposure time & number of exposures to achieve S/N

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ConfigCreator.java
+++ b/bundle/edu.gemini.itc.shared/src/main/java/edu/gemini/itc/shared/ConfigCreator.java
@@ -95,8 +95,12 @@ public final class ConfigCreator {
         this.obsDetailParams = p.observation();
     }
 
-    // create part of config common for all instruments
     private ConfigCreatorResult createCommonConfig(final int numberExposures) {
+        return createCommonConfig(numberExposures, obsDetailParams.exposureTime());
+    }
+
+    // create part of config common for all instruments
+    private ConfigCreatorResult createCommonConfig(final int numberExposures, final double exposureTime) {
         if (numberExposures <= 0) {
             throw new IllegalArgumentException("The number of exposures must be at least 1.");
         }
@@ -124,7 +128,7 @@ public final class ConfigCreator {
         for (int i = 0; i < numberExposures; i++) {
             final Config step = new DefaultConfig();
 
-            step.putItem(ExposureTimeKey, obsDetailParams.exposureTime());
+            step.putItem(ExposureTimeKey, exposureTime);
             step.putItem(ObserveTypeKey, InstConstants.SCIENCE_OBSERVE_TYPE);
             step.putItem(ObserveClassKey, ObsClass.SCIENCE);
             step.putItem(CoaddsKey, numberCoadds);
@@ -186,8 +190,8 @@ public final class ConfigCreator {
         return result;
     }
 
-    public final ConfigCreatorResult createGmosConfig(final GmosParameters gmosParams, final int numExp) {
-        final ConfigCreatorResult result = createCommonConfig(numExp);
+    public final ConfigCreatorResult createGmosConfig(final GmosParameters gmosParams, final int numExp, final int exposureTime) {
+        final ConfigCreatorResult result = createCommonConfig(numExp, exposureTime);
 
         for (final Config step : result.getConfig()) {
             if (gmosParams.site().equals(Site.GN)) {

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
@@ -111,6 +111,11 @@ sealed trait IntMethod extends CalculationMethod {
   def sigma: Double
 }
 
+sealed trait ExpMethod extends CalculationMethod {
+  def sigma: Double
+}
+
+// Return the Signal-to-Noise given the number of exposures, exposure time, etc.
 final case class ImagingS2N(
                     exposures: Int,
                     coadds: Option[Int],
@@ -118,12 +123,21 @@ final case class ImagingS2N(
                     sourceFraction: Double,
                     offset: Double) extends Imaging with S2NMethod
 
+// Return the number of exposures (Integration Time) given the exposure time, desired S/N, etc.
 final case class ImagingInt(
                     sigma: Double,
                     exposureTime: Double,
                     coadds: Option[Int],
                     sourceFraction: Double,
                     offset: Double) extends Imaging with IntMethod
+
+// Return the exposure time given the desired S/N
+final case class ImagingExp(
+                    sigma: Double,
+                    exposureTime: Double,
+                    coadds: Option[Int],
+                    sourceFraction: Double,
+                    offset: Double) extends Imaging with ExpMethod
 
 final case class SpectroscopyS2N(
                     exposures: Int,

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
@@ -115,6 +115,11 @@ sealed trait ExpMethod extends CalculationMethod {
   def sigma: Double
 }
 
+sealed trait SpecIntMethod extends CalculationMethod {
+  def sigma: Double
+  def wavelength: Double
+}
+
 // Return the Signal-to-Noise given the number of exposures, exposure time, etc.
 final case class ImagingS2N(
                     exposures: Int,
@@ -131,7 +136,7 @@ final case class ImagingInt(
                     sourceFraction: Double,
                     offset: Double) extends Imaging with IntMethod
 
-// Return the exposure time given the desired S/N
+// Return the exposure time and number of exposures given the desired S/N
 final case class ImagingExp(
                     sigma: Double,
                     exposureTime: Double,
@@ -145,6 +150,16 @@ final case class SpectroscopyS2N(
                     exposureTime: Double,
                     sourceFraction: Double,
                     offset: Double) extends Spectroscopy with S2NMethod
+
+// Return the spectroscopic integration time (exposure time & number of exposures) given the desired S/N
+final case class SpectroscopyInt(
+                    sigma: Double,
+                    wavelength: Double,
+                    coadds: Option[Int],
+                    exposureTime: Double,
+                    exposures: Int,
+                    sourceFraction: Double,
+                    offset: Double) extends Spectroscopy with SpecIntMethod
 
 
 // ==== Analysis method

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/CalculatablePrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/CalculatablePrinter.java
@@ -5,7 +5,6 @@ import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.S2NMethod;
 import edu.gemini.shared.util.immutable.*;
 import java.util.logging.Logger;
-
 /*
  * A helper class that collects some printing methods that used to be defined on the calculatable objects directly
  * but had to be moved somewhere else in order to be able to separate the calculation from the presentation logic.
@@ -89,11 +88,12 @@ public final class CalculatablePrinter {
 
     private static String getTextResult(final ObservationDetails obs, final ImagingMethodExptime s2n) {
         final StringBuilder sb = new StringBuilder(CalculatablePrinter.getTextResult(s2n));
-        sb.append(String.format("Derived exposure time = %.2f seconds", s2n.getExposureTime()));
+        sb.append(String.format("Derived integration time = %.2f seconds (%d x %.2f seconds)",
+                s2n.numberSourceExposures() * s2n.getExposureTime(), s2n.numberSourceExposures(), s2n.getExposureTime()));
         if (obs.calculationMethod().coaddsOrElse(1) > 1) {
             sb.append(String.format(" each having %d coadds", obs.calculationMethod().coaddsOrElse(1)));
         }
-        sb.append(String.format(".\nThe resulting S/N is %.2f\n\n", s2n.singleSNRatio()));
+        sb.append(String.format(".\n\nThe resulting S/N is %.2f\n", s2n.totalSNRatio()));
         return sb.toString();
     }
 
@@ -110,6 +110,7 @@ public final class CalculatablePrinter {
             throw new Error("Unsupported calculation method");
         }
     }
+
 
     private static String getTextResult(final ImagingS2NCalculation s2n) {
         return

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
@@ -12,13 +12,14 @@ import edu.gemini.spModel.obs.plannedtime.PlannedTime;
 import edu.gemini.spModel.obscomp.ItcOverheadProvider;
 
 import java.io.PrintWriter;
+import java.util.logging.Logger;
 import java.util.*;
 
 /**
  * Helper class for printing GMOS calculation results to an output stream.
  */
 public final class GmosPrinter extends PrinterBase implements OverheadTablePrinter.PrinterWithOverhead {
-
+    private static final Logger Log = Logger.getLogger(GmosPrinter.class.getName());
     private final GmosRecipe recipe;
     private final PlottingDetails pdp;
     private final boolean isImaging;
@@ -158,6 +159,7 @@ public final class GmosPrinter extends PrinterBase implements OverheadTablePrint
         _println("Read noise: " + instrument.getReadNoise());
 
         final Gmos[] ccdArray = instrument.getDetectorCcdInstruments();
+        Log.fine("ccdArray.length = " + ccdArray.length);
 
         for (final Gmos ccd : ccdArray) {
 

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
@@ -19,7 +19,7 @@ import java.util.*;
  */
 public final class GmosPrinter extends PrinterBase implements OverheadTablePrinter.PrinterWithOverhead {
 
-    private final GmosRecipe recipe;
+    final GmosRecipe recipe;
     private final PlottingDetails pdp;
     private final boolean isImaging;
     private final ItcParameters p;
@@ -260,7 +260,7 @@ public final class GmosPrinter extends PrinterBase implements OverheadTablePrint
 
     public ConfigCreator.ConfigCreatorResult createInstConfig(int numberExposures) {
         ConfigCreator cc = new ConfigCreator(p);
-        return cc.createGmosConfig(instr, numberExposures);
+        return cc.createGmosConfig(instr, numberExposures, recipe.getExposureTime());
     }
 
     public ItcOverheadProvider getInst() {

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
@@ -143,18 +143,24 @@ public final class HtmlPrinter {
         sb.append("<LI>Mode: ");
         sb.append((odp.calculationMethod() instanceof Imaging ? "imaging" : "spectroscopy"));
         sb.append("\n");
+
         sb.append("<LI>Calculation of ");
         if (odp.calculationMethod() instanceof S2NMethod) {
             sb.append(String.format("S/N ratio with %d", ((S2NMethod) odp.calculationMethod()).exposures()));
-        } else {
+        } else if (odp.calculationMethod() instanceof IntMethod) {
             sb.append(String.format("integration time from a S/N ratio of %.2f for", ((ImagingInt) odp.calculationMethod()).sigma()));
+        } else if (odp.calculationMethod() instanceof ExpMethod) {
+            sb.append(String.format("exposure time for a S/N ratio of %.2f.", ((ImagingExp) odp.calculationMethod()).sigma()));
+        } else {
+            throw new Error("Unsupported calculation method");
         }
-        sb.append(String.format(" exposures of %.2f secs", odp.exposureTime()));
-        if (odp.calculationMethod().coaddsOrElse(1) > 1) {
-            sb.append(String.format(" and %d coadds", odp.calculationMethod().coaddsOrElse(1)));
+        if (! (odp.calculationMethod() instanceof ExpMethod)) {
+            sb.append(String.format(" exposures of %.2f secs", odp.exposureTime()));
+            if (odp.calculationMethod().coaddsOrElse(1) > 1) {
+                sb.append(String.format(" and %d coadds", odp.calculationMethod().coaddsOrElse(1)));
+            }
+            sb.append(String.format(", and %.2f%% of them on source.\n", odp.sourceFraction() * 100));
         }
-        sb.append(String.format(", and %.2f%% of them on source.\n", odp.sourceFraction() * 100));
-
 
         sb.append("<LI>Analysis performed for aperture ");
         if (odp.analysisMethod() instanceof AutoAperture) {

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/HtmlPrinter.java
@@ -143,7 +143,6 @@ public final class HtmlPrinter {
         sb.append("<LI>Mode: ");
         sb.append((odp.calculationMethod() instanceof Imaging ? "imaging" : "spectroscopy"));
         sb.append("\n");
-
         sb.append("<LI>Calculation of ");
         if (odp.calculationMethod() instanceof S2NMethod) {
             sb.append(String.format("S/N ratio with %d", ((S2NMethod) odp.calculationMethod()).exposures()));
@@ -151,10 +150,13 @@ public final class HtmlPrinter {
             sb.append(String.format("integration time from a S/N ratio of %.2f for", ((ImagingInt) odp.calculationMethod()).sigma()));
         } else if (odp.calculationMethod() instanceof ExpMethod) {
             sb.append(String.format("exposure time for a S/N ratio of %.2f.", ((ImagingExp) odp.calculationMethod()).sigma()));
+        } else if (odp.calculationMethod() instanceof SpectroscopyInt) {
+            sb.append(String.format("exposure time and number of exposures for a S/N ratio of %.1f at wavelength %.2f nm.",
+                    ((SpectroscopyInt) odp.calculationMethod()).sigma(), ((SpectroscopyInt) odp.calculationMethod()).wavelength()));
         } else {
             throw new Error("Unsupported calculation method");
         }
-        if (! (odp.calculationMethod() instanceof ExpMethod)) {
+        if ( (odp.calculationMethod() instanceof S2NMethod) || (odp.calculationMethod() instanceof IntMethod)) {
             sb.append(String.format(" exposures of %.2f secs", odp.exposureTime()));
             if (odp.calculationMethod().coaddsOrElse(1) > 1) {
                 sb.append(String.format(" and %d coadds", odp.calculationMethod().coaddsOrElse(1)));

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
@@ -76,13 +76,17 @@ public class OverheadTablePrinter {
         final ObservationDetails obs = result.observation();
         final CalculationMethod calcMethod = obs.calculationMethod();
 
-
         if (calcMethod instanceof ImagingInt) {
             this.numOfExposures = (int)(((ImagingResult) result).is2nCalc().numberSourceExposures() / obs.sourceFraction());
         } else if (calcMethod instanceof ImagingS2N) {
             this.numOfExposures = ((ImagingS2N) calcMethod).exposures();
         } else if (calcMethod instanceof SpectroscopyS2N) {
             this.numOfExposures = ((SpectroscopyS2N) calcMethod).exposures();
+        } else if (calcMethod instanceof ImagingExp) {
+            this.numOfExposures = ((GmosPrinter) printer).recipe.getNumberExposures();
+        } else if (calcMethod instanceof SpectroscopyInt) {
+            this.numOfExposures = ((GmosPrinter) printer).recipe.getNumberExposures();
+
         } else {
             this.numOfExposures = 1;
         }

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -100,6 +100,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2023-Feb-18</footer>
+<footer>Last updated 2023-Feb-24</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -100,6 +100,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2022-Dec-01</footer>
+<footer>Last updated 2023-Feb-18</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -525,12 +525,26 @@
 			<tr>
 				<td><input value="s2n" name="calcMethod" checked="checked" type="radio" /></td>
 				<td>Total S/N ratio resulting from <input name="numExpA" size="5" value="1" type="text" />
-				exposures each having an exposure time of <input name="expTimeA" size="5" value="900" type="text" /> secs and with a fraction <input name="fracOnSourceA" size="4" value="1.0" type="text" /> of exposures that observe the source </td>
+					exposures each having an exposure time of <input name="expTimeA" size="5" value="900" type="text" />
+					secs and with a fraction <input name="fracOnSourceA" size="4" value="1.0" type="text" />
+					of exposures that observe the source </td>
 			</tr>
 			<tr>
 				<td><input value="intTime" name="calcMethod" type="radio" /></td>
-				<td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" /> using an exposure time for each exposure of <input name="expTimeC" size="5" value="900" type="text" /> secs and with a fraction <input name="fracOnSourceC" size="4" value="1.0" type="text" /> of exposures that observe the source </td>
+				<td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
+					using an exposure time for each exposure of<input name="expTimeC" size="5" value="900" type="text" />
+					secs and with a fraction <input name="fracOnSourceC" size="4" value="1.0" type="text" />
+					of exposures that observe the source </td>
 			</tr>
+			<tr>
+				<td><input value="expTime" name="calcMethod" type="radio" /></td>
+				<td>Single-image exposure time to achieve a S/N ratio of
+					<input name="sigmaD" size="3" value="5" type="text" />
+					<input name="expTimeD" value="60" type="hidden"/>
+					<input name="fracOnSourceD" value="1" type="hidden"/>
+				</td>
+			</tr>
+
 			<tr>
 				<td colspan="2" height="40" valign="bottom"><b>Telescope offset:</b><i><span>(<a href="#" onclick="window.open('https://www.gemini.edu/sciops/instruments/gmos','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>
 			</tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -538,10 +538,23 @@
 			</tr>
 			<tr>
 				<td><input value="expTime" name="calcMethod" type="radio" /></td>
-				<td>Single-image exposure time to achieve a S/N ratio of
+				<td>Imaging integration time to achieve a S/N ratio of
 					<input name="sigmaD" size="3" value="5" type="text" />
 					<input name="expTimeD" value="60" type="hidden"/>
+					<input name="coaddsD" value="1" type="hidden"/>
 					<input name="fracOnSourceD" value="1" type="hidden"/>
+					<input name="numExpD" value="1" type="hidden" />
+				</td>
+			</tr>
+			<tr>
+				<td><input value="intTimeSpec" name="calcMethod" type="radio" /></td>
+				<td>Spectroscopy integration time to achieve a S/N ratio of
+					<input name="sigmaE" size="3" value="5" type="text" />
+					measured at <input name="wavelengthE" size="3" value="600" type="text" /> nm.
+					<input name="expTimeE" value="1200" type="hidden"/>
+					<input name="coaddsE" value="1" type="hidden"/>
+					<input name="fracOnSourceE" value="1" type="hidden"/>
+					<input name="numExpE" value="1" type="hidden" />
 				</td>
 			</tr>
 
@@ -562,7 +575,6 @@
 			<tr>
 				<td><input value="userAper" name="analysisMethod" type="radio" /></td>
 				<td>Software aperture of diameter (or slit length) <input name="userAperDiam" size="4" value="2" type="text" /> arcsec and with a sky aperture <input name="userSkyAper" size="4" value="5" type="text" /> times the target aperture</td>
-
 			</tr>
 			<tr>
 				<td colspan="2" height="50" valign="bottom"><b>Analysis Method for Integral Field Unit (IFU) spectroscopy:</b><br />

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -531,7 +531,7 @@
 			</tr>
 			<tr>
 				<td><input value="intTime" name="calcMethod" type="radio" /></td>
-				<td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
+				<td>Imaging integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
 					using an exposure time for each exposure of<input name="expTimeC" size="5" value="900" type="text" />
 					secs and with a fraction <input name="fracOnSourceC" size="4" value="1.0" type="text" />
 					of exposures that observe the source </td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -532,7 +532,7 @@
             </tr>
             <tr>
                 <td><input value="intTime" name="calcMethod" type="radio" /></td>
-                <td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
+                <td>Imaging integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
                 using an exposure time for each exposure of <input name="expTimeC" size="5" value="900" type="text" />
                 secs and with a fraction <input name="fracOnSourceC" size="4" value="1.0" type="text" />
                 of exposures that observe the source </td>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -526,14 +526,39 @@
             <tr>
                 <td><input value="s2n" name="calcMethod" checked="checked" type="radio" /></td>
                 <td>Total S/N ratio resulting from <input name="numExpA" size="5" value="1" type="text" />
-                exposures each having an exposure time of <input name="expTimeA" size="5" value="900" type="text" /> secs and with a fraction <input name="fracOnSourceA" size="4" value="1.0" type="text" /> of exposures that observe the source </td>
-
+                exposures each having an exposure time of <input name="expTimeA" size="5" value="900" type="text" />
+                secs and with a fraction <input name="fracOnSourceA" size="4" value="1.0" type="text" />
+                of exposures that observe the source </td>
             </tr>
             <tr>
                 <td><input value="intTime" name="calcMethod" type="radio" /></td>
-                <td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" /> using an exposure time for each exposure of <input name="expTimeC" size="5" value="900" type="text" /> secs and with a fraction <input name="fracOnSourceC" size="4" value="1.0" type="text" /> of exposures that observe the source </td>
-
+                <td>Total integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
+                using an exposure time for each exposure of <input name="expTimeC" size="5" value="900" type="text" />
+                secs and with a fraction <input name="fracOnSourceC" size="4" value="1.0" type="text" />
+                of exposures that observe the source </td>
             </tr>
+			<tr>
+				<td><input value="expTime" name="calcMethod" type="radio" /></td>
+				<td>Imaging integration time to achieve a S/N ratio of
+					<input name="sigmaD" size="3" value="5" type="text" />
+					<input name="expTimeD" value="60" type="hidden"/>
+					<input name="coaddsD" value="1" type="hidden"/>
+					<input name="fracOnSourceD" value="1" type="hidden"/>
+					<input name="numExpD" value="1" type="hidden" />
+				</td>
+			</tr>
+			<tr>
+				<td><input value="intTimeSpec" name="calcMethod" type="radio" /></td>
+				<td>Spectroscopy integration time to achieve a S/N ratio of
+					<input name="sigmaE" size="3" value="5" type="text" />
+					measured at <input name="wavelengthE" size="3" value="600" type="text" /> nm.
+					<input name="expTimeE" value="1200" type="hidden"/>
+					<input name="coaddsE" value="1" type="hidden"/>
+					<input name="fracOnSourceE" value="1" type="hidden"/>
+					<input name="numExpE" value="1" type="hidden" />
+				</td>
+			</tr>
+
             <tr>
                 <td colspan="2" height="40" valign="bottom"><b>Telescope offset:</b><i><span>(<a href="#" onclick="window.open('https://www.gemini.edu/sciops/instruments/gmos-0','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false">more info</a>)</span></i></td>
             </tr>
@@ -545,15 +570,13 @@
                 <td colspan="2" height="50" valign="bottom"><b>Analysis method (non IFU):</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10256#analysis','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
             </tr>
             <tr>
-
-                <td colspan="2"><input value="autoAper" name="analysisMethod" checked="checked" type="radio" /> Software
-                aperture that gives 'optimum' S/N ratio and with a sky aperture <input name="autoSkyAper" size="4" value="5" type="text" /> times the target aperture</td>
+                <td><input value="autoAper" name="analysisMethod" checked="checked" type="radio" /> </td>
+                <td>Software aperture that gives 'optimum' S/N ratio and with a sky aperture <input name="autoSkyAper" size="4" value="5" type="text" /> times the target aperture</td>
             </tr>
             <tr>
-                <td colspan="2"><input value="userAper" name="analysisMethod" type="radio" /> Software aperture of
-                diameter (or slit length) <input name="userAperDiam" size="4" value="2" type="text" />
+                <td><input value="userAper" name="analysisMethod" type="radio" /></td>
+                <td>Software aperture of diameter (or slit length) <input name="userAperDiam" size="4" value="2" type="text" />
                 arcsec and with a sky aperture <input name="userSkyAper" size="4" value="5" type="text" /> times the target aperture</td>
-
             </tr>
             <tr>
                 <td colspan="2" height="50" valign="bottom"><b>Analysis Method for Integral Field Unit (IFU) spectroscopy:</b><br />

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -337,6 +337,7 @@ object ITCRequest {
 
   def observationParameters(r: ITCRequest, i: InstrumentDetails): ObservationDetails = {
     val calcMethod = r.parameter("calcMethod")
+    Log.fine("calcMethod = " + calcMethod)
     val calculationMethod = calcMethod match {
       case "intTime"  if InstrumentDetails.isImaging(i)     =>
         ImagingInt(
@@ -344,6 +345,14 @@ object ITCRequest {
           r.doubleParameter("expTimeC"),
           coadds(r, CoaddsC),
           r.doubleParameter("fracOnSourceC"),
+          r.doubleParameter("offset")
+        )
+      case "expTime"  if InstrumentDetails.isImaging(i)     =>
+        ImagingExp(
+          r.doubleParameter("sigmaD"),
+          r.doubleParameter("expTimeD"),        // not used
+          coadds(r, CoaddsC),                   // not used
+          r.doubleParameter("fracOnSourceD"),   // not used
           r.doubleParameter("offset")
         )
       case "s2n"      if InstrumentDetails.isImaging(i)     =>

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -385,7 +385,10 @@ object ITCRequest {
           r.doubleParameter("offset")
         )
 
-      case _ => throw new IllegalArgumentException("Unsupported analysis mode.")
+      case _ => throw new IllegalArgumentException(
+        "An incompatible calculation method is selected.\n" +
+        "Please select a spectroscopic calculation method for\n" +
+        "spectroscopy or an imaging calculation method for imaging.")
     }
 
     ObservationDetails(calculationMethod, analysisMethod(r))

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcquisitionCamera.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/acqcam/AcquisitionCamera.java
@@ -69,6 +69,9 @@ public class AcquisitionCamera extends Instrument {
         return INSTR_PREFIX;
     }
 
+    public double maxFlux() {
+        return WellDepth;
+    }
 
     @Override public double wellDepth() {
         return WellDepth;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Instrument.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/Instrument.java
@@ -1,6 +1,5 @@
 package edu.gemini.itc.base;
 
-import edu.gemini.itc.niri.GrismOptics;
 import edu.gemini.itc.shared.ItcWarning;
 import edu.gemini.spModel.core.Site;
 import scala.Option;
@@ -13,7 +12,7 @@ import java.util.List;
 
 /**
  * The Instrument class is the class that any instrument should extend.
- * It defines the common properties of any given Instrumnet.
+ * It defines the common properties of any given Instrument.
  * <p/>
  * The important piece of data is the _list. This is a linked list
  * that contains all of the Components that make up the instrument.
@@ -241,6 +240,7 @@ public abstract class Instrument {
     // to deal with one instrument that has several CCDs, if I may say so.
     public abstract double wellDepth();
     public abstract double gain();
+    public abstract double maxFlux();
 
     // === Warnings
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2.java
@@ -161,6 +161,10 @@ public final class Flamingos2 extends Instrument implements SpectroscopyInstrume
         return _grismOptics.get();
     }
 
+    public double maxFlux() {
+        return LinearityLimit;
+    }
+
     @Override public double wellDepth() {
         return WellDepth;
     }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -99,7 +99,6 @@ public abstract class Gmos extends Instrument implements BinningProvider, Spectr
                 String name = getCcdNames()[detectorCcdIndex];
                 _detector = new Detector(getDirectory() + "/", getPrefix(), fileName, "Hamamatsu array", name);
                 _detector.setDetectorPixels(detectorPixels());
-                Log.fine("detectorCcdIndex = " + detectorCcdIndex);
                 if (detectorCcdIndex == 0)
                     _instruments = createCcdArray();
                 break;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/Gmos.java
@@ -10,11 +10,13 @@ import scala.Option;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * Gmos specification class
  */
 public abstract class Gmos extends Instrument implements BinningProvider, SpectroscopyInstrument {
+    private static final Logger Log = Logger.getLogger(Gmos.class.getName());
 
     //Plate scales for original and Hamamatsu CCD's (temporary)
     public static final double ORIG_PLATE_SCALE = 0.0727;
@@ -97,6 +99,7 @@ public abstract class Gmos extends Instrument implements BinningProvider, Spectr
                 String name = getCcdNames()[detectorCcdIndex];
                 _detector = new Detector(getDirectory() + "/", getPrefix(), fileName, "Hamamatsu array", name);
                 _detector.setDetectorPixels(detectorPixels());
+                Log.fine("detectorCcdIndex = " + detectorCcdIndex);
                 if (detectorCcdIndex == 0)
                     _instruments = createCcdArray();
                 break;
@@ -279,6 +282,13 @@ public abstract class Gmos extends Instrument implements BinningProvider, Spectr
         } else {
             return getObservingEnd();
         }
+    }
+
+    // The maximum useful flux in a (binned) pixel: the minimum of the (binned) well-depth or ADC saturation value.
+    public double maxFlux() {
+        double wellSatLimit = wellDepth() * getSpatialBinning() * getSpectralBinning();
+        double adcSatLimit = AD_SATURATION * gain();
+        return Math.min(wellSatLimit, adcSatLimit);
     }
 
     //Abstract class for Detector Pixel Transmission  (i.e.  Create Detector gaps)

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
@@ -1,19 +1,15 @@
 package edu.gemini.itc.gmos;
 
 import edu.gemini.itc.shared.GmosParameters;
-import edu.gemini.itc.shared.ImagingExp;
 import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.gemini.gmos.GmosNorthType;
 
-import java.util.logging.Logger;
 
 /**
  * Gmos specification class
  */
 public final class GmosNorth extends Gmos {
-
-    private static final Logger Log = Logger.getLogger(GmosNorth.class.getName());
 
     // value taken from instrument's web documentation
     private static final double WellDepth = 105000;
@@ -51,14 +47,7 @@ public final class GmosNorth extends Gmos {
 
     @Override
     protected Gmos[] createCcdArray() {
-        if (odp.calculationMethod() instanceof ImagingExp) {  // Only use the central CCD to speed up calculations
-            Log.fine("Returning CCD1 only");                  // This should return CCD2 only.
-            return new Gmos[]{this};                          // This line is not correct,
-            //return new Gmos[]{new GmosNorth(gp, odp, 1)};   // but this line does not work.
-        } else {
-            Log.fine("Returning array of all 3 CCDs");
-            return new Gmos[]{this, new GmosNorth(gp, odp, 1), new GmosNorth(gp, odp, 2)};
-        }
+        return new Gmos[]{this, new GmosNorth(gp, odp, 1), new GmosNorth(gp, odp, 2)};
     }
 
     @Override

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosNorth.java
@@ -1,15 +1,19 @@
 package edu.gemini.itc.gmos;
 
 import edu.gemini.itc.shared.GmosParameters;
+import edu.gemini.itc.shared.ImagingExp;
 import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.spModel.gemini.gmos.InstGmosNorth;
 import edu.gemini.spModel.gemini.gmos.GmosNorthType;
 
+import java.util.logging.Logger;
 
 /**
  * Gmos specification class
  */
 public final class GmosNorth extends Gmos {
+
+    private static final Logger Log = Logger.getLogger(GmosNorth.class.getName());
 
     // value taken from instrument's web documentation
     private static final double WellDepth = 105000;
@@ -47,7 +51,14 @@ public final class GmosNorth extends Gmos {
 
     @Override
     protected Gmos[] createCcdArray() {
-        return new Gmos[]{this, new GmosNorth(gp, odp, 1), new GmosNorth(gp, odp, 2)};
+        if (odp.calculationMethod() instanceof ImagingExp) {  // Only use the central CCD to speed up calculations
+            Log.fine("Returning CCD1 only");                  // This should return CCD2 only.
+            return new Gmos[]{this};                          // This line is not correct,
+            //return new Gmos[]{new GmosNorth(gp, odp, 1)};   // but this line does not work.
+        } else {
+            Log.fine("Returning array of all 3 CCDs");
+            return new Gmos[]{this, new GmosNorth(gp, odp, 1), new GmosNorth(gp, odp, 2)};
+        }
     }
 
     @Override

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -444,15 +444,19 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
         // Calculate the Fraction of source in the aperture
         final SourceFraction SFcalc = SourceFractionFactory.calculate(_sdParameters, _obsDetailParameters, instrument, im_qual);
 
-        // Calculate the Peak Pixel Flux
-        final double peak_pixel_count = PeakPixelFlux.calculate(instrument, _sdParameters, _obsDetailParameters, SFcalc, im_qual, sed_integral, sky_integral);
-
         // In this version we are bypassing morphology modules 3a-5a.
         // i.e. the output morphology is same as the input morphology.
         // Might implement these modules at a later time.
 
-        final ImagingS2NCalculatable IS2Ncalc = ImagingS2NCalculationFactory.getCalculationInstance(_obsDetailParameters, instrument, SFcalc, sed_integral, sky_integral);
+        final ImagingS2NCalculatable IS2Ncalc = ImagingS2NCalculationFactory.getCalculationInstance(_sdParameters, _obsDetailParameters, instrument, SFcalc, im_qual, sed_integral, sky_integral);
         IS2Ncalc.calculate();
+
+        // Calculate the Peak Pixel Flux
+        // if (_obsDetailParameters.calculationMethod() instanceof ImagingExp) {
+        double exposureTime = IS2Ncalc.getExposureTime();
+        final double peak_pixel_count = PeakPixelFlux.calculate(instrument, _sdParameters, exposureTime, SFcalc, im_qual, sed_integral, sky_integral);
+        // } else {
+        // peak_pixel_count = PeakPixelFlux.calculate(instrument, _sdParameters, _obsDetailParameters, SFcalc, im_qual, sed_integral, sky_integral); }
 
         return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc);
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -193,10 +193,10 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
             Log.fine(String.format("exposureTime = %d seconds", exposureTime));
             double timeToHalfMax = maxFlux / 2. / peakFlux * exposureTime;  // time to reach half of the maximum (our goal)
             Log.fine(String.format("timeToHalfMax = %.2f seconds", timeToHalfMax));
-            if (timeToHalfMax < 1.0) {
-                throw new RuntimeException(String.format("This target is too bright for this configuration.\n" +
-                        "The detector well is half filled in %.2f seconds.", timeToHalfMax));
-            }
+            if (timeToHalfMax < 1.0) throw new RuntimeException(String.format(
+                    "This target is too bright for this configuration.\n" +
+                    "The detector well is half filled in %.2f seconds.", timeToHalfMax));
+
             int maxExptime = Math.min(1200, (int) timeToHalfMax);     // 1200s is maximum due to cosmic rays
             Log.fine(String.format("maxExptime = %d seconds", maxExptime));
             double desiredSNR = ((SpectroscopyInt) calcMethod).sigma();

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gmos/GmosRecipe.java
@@ -25,6 +25,7 @@ import edu.gemini.itc.operation.SourceFractionFactory;
 import edu.gemini.itc.operation.SpecS2N;
 import edu.gemini.itc.operation.SpecS2NSlitVisitor;
 import edu.gemini.itc.shared.BackgroundData;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.ChartAxis;
 import edu.gemini.itc.shared.ChartAxisRange;
 import edu.gemini.itc.shared.FinalS2NData;
@@ -41,6 +42,8 @@ import edu.gemini.itc.shared.SignalChart;
 import edu.gemini.itc.shared.SignalData;
 import edu.gemini.itc.shared.SignalPixelChart;
 import edu.gemini.itc.shared.SingleS2NData;
+import edu.gemini.itc.shared.SpectroscopyInt;
+import edu.gemini.itc.shared.SpectroscopyS2N;
 import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.SpcChartData;
 import edu.gemini.itc.shared.SpcSeriesData;
@@ -67,6 +70,8 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
     private final ObservationDetails _obsDetailParameters;
     private final ObservingConditions _obsConditionParameters;
     private final TelescopeDetails _telescope;
+    private int exposureTime;
+    private int numberExposures;
 
     /**
      * Constructs a GmosRecipe given the parameters. Useful for testing.
@@ -111,9 +116,127 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
     public SpectroscopyResult[] calculateSpectroscopy() {
         final Gmos[] ccdArray = mainInstrument.getDetectorCcdInstruments();
         final SpectroscopyResult[] results = new SpectroscopyResult[ccdArray.length];
+        final CalculationMethod calcMethod = _obsDetailParameters.calculationMethod();
+        Log.fine("calcMethod = " + calcMethod);
+
+        int numberExposures;
+        if (calcMethod instanceof SpectroscopyS2N) {
+            numberExposures = ((SpectroscopyS2N) calcMethod).exposures();
+        } else if (calcMethod instanceof SpectroscopyInt) {
+            numberExposures = ((SpectroscopyInt) calcMethod).exposures();
+        } else {
+            throw new Error("Unsupported calculation method");
+        }
+
         for (int i = 0; i < ccdArray.length; i++) {
             final Gmos instrument = ccdArray[i];
-            results[i] = calculateSpectroscopy(mainInstrument, instrument, ccdArray.length);
+            results[i] = calculateSpectroscopy(mainInstrument, instrument, ccdArray.length,
+                    calcMethod.exposureTime(), numberExposures);
+        }
+
+        if (calcMethod instanceof SpectroscopyInt) {
+            // 1. Process all CCDs to get the peak flux and derive the maximum exposure time.
+            // 2. Figure out which CCD includes the wavelength of interest.
+            // 3. Iteratively determine exposureTime & numberExposures that will give the requested S/N at wavelength.
+            // 4. Process all the CCDs using the final exposureTime & numberExposures and return the result.
+
+            double wavelength = ((SpectroscopyInt) _obsDetailParameters.calculationMethod()).wavelength();
+            Log.fine(String.format("Wavelength = %.2f nm", wavelength));
+            final DetectorsTransmissionVisitor tv = mainInstrument.getDetectorTransmision();
+            double peakFlux = 0.0;
+            double snr = -1.0;
+            int ccd = -1;   // CCD index that includes the requested wavelength
+            int slit = -1;  // Slit index that includes the requested wavelength
+
+            for (int ccdIndex=0; ccdIndex < results.length; ccdIndex++) {
+                Log.fine("CCD index = " + ccdIndex);
+                final SpectroscopyResult result = results[ccdIndex];
+                final GmosSpecS2N specS2N = (GmosSpecS2N) result.specS2N()[0];  // Is GMOS always [0] ?
+                // specS2N.getFinalS2NSpectrum(0).accept(tv);  // this seems unnecessary?
+                Log.fine("Number of Slits = " + specS2N.getNumberOfSlits());
+                for (int slitIndex = 0; slitIndex < specS2N.getNumberOfSlits(); slitIndex++) {
+                    Log.fine("Slit index = " + slitIndex);
+                    peakFlux = Math.max(specS2N.getPeakPixelCount(slitIndex), peakFlux);
+                    final VisitableSampledSpectrum fins2n = specS2N.getFinalS2NSpectrum(slitIndex);
+                    double start = fins2n.getX(tv.getDetectorCcdStartIndex(ccdIndex));
+                    double end = fins2n.getX(tv.getDetectorCcdEndIndex(ccdIndex, ccdArray.length));
+                    Log.fine(String.format("ccd %d slit %d covers wavelengths %.2f - %.2f", ccdIndex, slitIndex, start, end));
+                    if (wavelength >= start && wavelength <= end) {
+                        Log.fine(String.format("S/N @ %.2f nm = %.2f", wavelength, fins2n.getY(wavelength)));
+                        if (snr == -1) {  // this is the first slit to include the measurement wavelength
+                            ccd = ccdIndex;
+                            slit = slitIndex;
+                            snr = fins2n.getY(wavelength);
+                        } else {  // the previous slit also covered this wavelength
+                            if (fins2n.getY(wavelength) > snr) {  // use the slit with the highest S/N
+                                Log.fine("Choosing this CCD & Slit as the one to optimize");
+                                ccd = ccdIndex;
+                                slit = slitIndex;
+                                snr = fins2n.getY(wavelength);
+                            } else {
+                                Log.fine("Ignoring this CCD & Slit since the S/N is lower than the other");
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (ccd == -1) throw new RuntimeException(
+                    "The wavelength where the S/N will be measured is not in the output.\n" +
+                    "Try changing the grating central wavelength or the wavelength at which to measure the S/N.");
+
+            Log.fine(String.format("Requested wavelength falls on CCD %d Slit %d", ccd, slit));
+            Log.fine("-> peakFlux over all CCDs = " + peakFlux);
+            double maxFlux = mainInstrument.maxFlux();  // maximum useful flux
+            Log.fine(String.format("maxFlux = %.0f electrons", maxFlux));
+            int exposureTime = (int) calcMethod.exposureTime();
+            Log.fine(String.format("exposureTime = %d seconds", exposureTime));
+            double timeToHalfMax = maxFlux / 2. / peakFlux * exposureTime;  // time to reach half of the maximum (our goal)
+            Log.fine(String.format("timeToHalfMax = %.2f seconds", timeToHalfMax));
+            if (timeToHalfMax < 1.0) {
+                throw new RuntimeException(String.format("This target is too bright for this configuration.\n" +
+                        "The detector well is half filled in %.2f seconds.", timeToHalfMax));
+            }
+            int maxExptime = Math.min(1200, (int) timeToHalfMax);     // 1200s is maximum due to cosmic rays
+            Log.fine(String.format("maxExptime = %d seconds", maxExptime));
+            double desiredSNR = ((SpectroscopyInt) calcMethod).sigma();
+            Log.fine(String.format("desiredSNR = %.2f", desiredSNR));
+
+            int oldNumberExposures = 0;
+            int oldExposureTime = 0;
+            int iterations = 0;
+            while ((numberExposures != oldNumberExposures) || (exposureTime != oldExposureTime)) {
+                iterations += 1;
+                Log.fine(String.format("--- ITERATION %d (%d != %d) or (%d != %d) ---",
+                        iterations, oldNumberExposures, numberExposures, oldExposureTime, exposureTime));
+                oldNumberExposures = numberExposures;
+                oldExposureTime = exposureTime;
+                // Estimate the time required to achieve the requested S/N assuming S/N scales as sqrt(t):
+                double totalTime = exposureTime * numberExposures * (desiredSNR / snr) * (desiredSNR / snr);
+                Log.fine(String.format("totalTime = %.2f", totalTime));
+                numberExposures = (int) Math.ceil(totalTime / maxExptime);
+                Log.fine(String.format("numberExposures = %d", numberExposures));
+                exposureTime = (int) Math.ceil(totalTime / numberExposures);
+                Log.fine(String.format("exposureTime = %d", exposureTime));
+
+                if ((numberExposures == oldNumberExposures) && (exposureTime == oldExposureTime)) {
+                    Log.fine("No change since the last iteration, so calculating final results for all CCDS...");
+                    this.exposureTime = exposureTime;
+                    this.numberExposures = numberExposures;
+                    for (int i = 0; i < ccdArray.length; i++) {
+                        final Gmos instrument = ccdArray[i];
+                        results[i] = calculateSpectroscopy(mainInstrument, instrument, ccdArray.length, exposureTime, numberExposures);
+                    }
+                } else { // Recalculate the S/N on the relevant CCD and see how we did
+                    final Gmos instrument = ccdArray[ccd];
+                    final SpectroscopyResult newresult = calculateSpectroscopy(mainInstrument, instrument, ccdArray.length, exposureTime, numberExposures);
+                    final GmosSpecS2N specS2N = (GmosSpecS2N) newresult.specS2N()[0];
+                    final VisitableSampledSpectrum fins2n = specS2N.getFinalS2NSpectrum(slit);
+                    snr = fins2n.getY(wavelength);
+                    Log.fine(String.format("Iteration %d: %d x %d sec -> S/N @ %.2f nm = %.2f",
+                            iterations, numberExposures, exposureTime, wavelength, snr));
+                }
+            }
         }
         return results;
     }
@@ -136,7 +259,12 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
     }
 
     // TODO: bring mainInstrument and instrument together
-    private SpectroscopyResult calculateSpectroscopy(final Gmos mainInstrument, final Gmos instrument, final int detectorCount) {
+    private SpectroscopyResult calculateSpectroscopy(
+            final Gmos mainInstrument,
+            final Gmos instrument,
+            final int detectorCount,
+            final double exposureTime,
+            final int numberExposures) {
 
         SpecS2NSlitVisitor specS2N;
         final SpecS2N[] specS2Narr;
@@ -254,7 +382,9 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
                             im_qual,
                             read_noise,
                             dark_current * instrument.getSpatialBinning() * instrument.getSpectralBinning(),
-                            _obsDetailParameters);
+                            _obsDetailParameters,
+                            exposureTime,
+                            numberExposures);
 
                     specS2N.setCcdPixelRange(firstCcdIndex, lastCcdIndex);
 
@@ -294,8 +424,9 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
                     im_qual,
                     read_noise,
                     dark_current * instrument.getSpatialBinning() * instrument.getSpectralBinning(),
-                    _obsDetailParameters);
-
+                    _obsDetailParameters,
+                    exposureTime,
+                    numberExposures);
 
             specS2N.setCcdPixelRange(firstCcdIndex, lastCcdIndex);
             specS2N.setSourceSpectrum(src[0].sed);
@@ -452,11 +583,8 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
         IS2Ncalc.calculate();
 
         // Calculate the Peak Pixel Flux
-        // if (_obsDetailParameters.calculationMethod() instanceof ImagingExp) {
         double exposureTime = IS2Ncalc.getExposureTime();
         final double peak_pixel_count = PeakPixelFlux.calculate(instrument, _sdParameters, exposureTime, SFcalc, im_qual, sed_integral, sky_integral);
-        // } else {
-        // peak_pixel_count = PeakPixelFlux.calculate(instrument, _sdParameters, _obsDetailParameters, SFcalc, im_qual, sed_integral, sky_integral); }
 
         return ImagingResult.apply(p, instrument, IQcalc, SFcalc, peak_pixel_count, IS2Ncalc);
 
@@ -758,4 +886,13 @@ public final class GmosRecipe implements ImagingArrayRecipe, SpectroscopyArrayRe
         data[1][0]                  = 0.0;
         data[1][data[1].length - 1] = 0.0;
     }
+
+    public int getExposureTime() {
+        return exposureTime;
+    }
+
+    public int getNumberExposures() {
+        return numberExposures;
+    }
+
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/Gnirs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/Gnirs.java
@@ -505,6 +505,10 @@ public final class Gnirs extends Instrument implements SpectroscopyInstrument {
         return 13.5;
     }
 
+    public double maxFlux() {
+        return _linearityLimit;
+    }
+
     @Override public List<WarningRule> warnings() {
         return new ArrayList<WarningRule>() {{
             add(new LinearityLimitRule(_linearityLimit, 0.80));

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/Gsaoi.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/Gsaoi.java
@@ -111,6 +111,10 @@ public final class Gsaoi extends Instrument {
         return 2.4;
     }
 
+    public double maxFlux() {
+        return LinearityLimit;
+    }
+
     @Override public List<WarningRule> warnings() {
         return new ArrayList<WarningRule>() {{
             add(new LinearityLimitRule(LinearityLimit, 0.80));

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/Michelle.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/michelle/Michelle.java
@@ -225,6 +225,10 @@ public final class Michelle extends Instrument implements SpectroscopyInstrument
         return 1.0;
     }
 
+    @Override public double maxFlux() {
+        return WELL_DEPTH;
+    }
+
     @Override public List<WarningRule> warnings() {
         return new ArrayList<WarningRule>() {{
             add(new SaturationLimitRule(WELL_DEPTH, 0.80));

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/Nifs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/Nifs.java
@@ -233,6 +233,10 @@ public final class Nifs extends Instrument implements SpectroscopyInstrument {
         return 2.8; // electrons / ADU
     }
 
+    public double maxFlux() {
+        return LinearityLimit;
+    }
+
     @Override public List<WarningRule> warnings() {
         return new ArrayList<WarningRule>() {{
             add(new LinearityLimitRule(LinearityLimit, 0.80));

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/Niri.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/Niri.java
@@ -255,6 +255,10 @@ public class Niri extends Instrument implements SpectroscopyInstrument {
         return 12.3;
     }
 
+    @Override public double maxFlux() {
+        return params.wellDepth().linearityLimit();
+    }
+
     @Override public List<WarningRule> warnings() {
         return new ArrayList<WarningRule>() {{
             add(new LinearityLimitRule(params.wellDepth().linearityLimit(), 0.80));

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingMethodExptime.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingMethodExptime.java
@@ -46,7 +46,6 @@ public final class ImagingMethodExptime extends ImagingS2NCalculation {
         // 3. Calculate the number of exposures, if more than one are required.
         // 4. Calculate the exposure time.
 
-        Log.fine(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         super.calculate();  // perform an initial S/N calculation using the default values from the HTML form
         double snr = totalSNRatio();
         Log.fine(String.format("Total S/N = %.2f from %d x %.2f second exposures", snr, numberExposures, exposure_time));
@@ -59,10 +58,10 @@ public final class ImagingMethodExptime extends ImagingS2NCalculation {
         double timeToHalfMax = maxFlux / 2. / peakFlux * exposure_time;  // time to reach half of the maximum (our goal)
         Log.fine(String.format("timeToHalfMax = %.2f seconds", timeToHalfMax));
 
-        if (timeToHalfMax < 1.0) {
-            throw new RuntimeException(String.format("This target is too bright for this configuration.\n" +
-                    "The detector well is half filled in %.2f seconds.", timeToHalfMax));
-        }
+        if (timeToHalfMax < 1.0) throw new RuntimeException(String.format(
+                "This target is too bright for this configuration.\n" +
+                "The detector well is half filled in %.2f seconds.", timeToHalfMax));
+
         int maxExptime = Math.min(1200, (int) timeToHalfMax);  // 1200s is the (GMOS) maximum due to cosmic rays
         Log.fine(String.format("maxExptime = %d seconds", maxExptime));
 
@@ -82,7 +81,6 @@ public final class ImagingMethodExptime extends ImagingS2NCalculation {
 
         super.calculate();
         Log.fine("totalSNRatio = " + totalSNRatio());
-        Log.fine("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
     }
 
     @Override public int numberSourceExposures() { return numberExposures; }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingMethodExptime.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingMethodExptime.java
@@ -1,0 +1,118 @@
+package edu.gemini.itc.operation;
+
+import edu.gemini.itc.base.Instrument;
+import edu.gemini.itc.operation.PeakPixelFlux;
+import edu.gemini.itc.shared.ImagingExp;
+import edu.gemini.itc.shared.ObservationDetails;
+import java.util.logging.Logger;
+
+public final class ImagingMethodExptime extends ImagingS2NCalculation {
+
+    private final double frac_with_source;
+    private final double req_s2n;
+    private int int_req_source_exposures;
+    private double req_number_exposures;
+    private double req_exptime;
+    private static final Logger Log = Logger.getLogger(ImagingMethodExptime.class.getName());
+
+    public ImagingMethodExptime(final ObservationDetails obs,
+                                final Instrument instrument,
+                                final SourceFraction srcFrac,
+                                final double sed_integral,
+                                final double sky_integral) {
+        super(obs, instrument, srcFrac, sed_integral, sky_integral);
+        this.frac_with_source = obs.sourceFraction();
+        this.exposure_time = obs.exposureTime();  // defined to be 60s in ITCgmos.html
+        this.coadds = 1;   // obs.calculationMethod().coaddsOrElse(1);
+        this.read_noise = instrument.getReadNoise();
+        this.pixel_size = instrument.getPixelSize();
+        this.req_s2n = ((ImagingExp) obs.calculationMethod()).sigma();
+    }
+
+    public void calculate() {
+
+        // ? Could we make it so that this calculation is ONLY done for the middle CCD ?
+
+        Log.fine("Calculating with initial guess for exptime...");
+        super.calculate();
+
+        Log.fine("singleSNRatio = " + singleSNRatio());
+
+        // Calculate the exposure time that should give the desired S/N
+
+        // In general, S/N ~ sqrt(t), so t ~ (S/N)^2
+        final double req_exptime = exposure_time * (req_s2n / singleSNRatio()) * (req_s2n / singleSNRatio());
+        Log.fine("Estimated exposure time = " + req_exptime);
+        // well, that didn't work very well...
+
+        Log.fine("frac_with_source = " + frac_with_source);  // fraction of images which include the source
+        Log.fine("source_fraction = " + source_fraction);  // fraction of source in aperture?
+
+        // Try again:
+        final double vs = sed_integral * source_fraction + secondary_integral * secondary_source_fraction;
+        final double vb = sky_integral * pixel_size * pixel_size * Npix;
+        final double vd = dark_current * Npix;
+        final double a = vs * vs;
+        final double b = -1.0 * req_s2n * req_s2n * (vs + vb + vd);
+        final double c = req_s2n * req_s2n * var_readout;
+        final double discriminant = b*b - 4.0 * a * c;
+        final double new_exptime_plus = (-1.0 * b + Math.sqrt(b*b - 4.0 * a * c)) / (2.0 * a);
+        final double new_exptime_minus = (-1.0 * b - Math.sqrt(b*b - 4.0 * a * c)) / (2.0 * a);
+        Log.fine("sed = " + sed_integral);
+        Log.fine("sky = " + sky_integral);
+        Log.fine("pixsize = " + pixel_size);
+        Log.fine("readnoise = " + read_noise);
+        Log.fine("Npix = " + Npix);
+        Log.fine("snr = " + req_s2n);
+        Log.fine("vs = " + vs);
+        Log.fine("vb = " + vb);
+        Log.fine("vd = " + vd);
+        Log.fine("vr = " + var_readout);
+        Log.fine("a = " + a);
+        Log.fine("b = " + b);
+        Log.fine("c = " + c);
+        Log.fine("discriminant = " + discriminant);
+        Log.fine("Calculated exposure time (+) = " + new_exptime_plus);
+        Log.fine("Calculated exposure time (-) = " + new_exptime_minus);
+        if (discriminant > 0) {
+            exposure_time = new_exptime_plus;
+        } else {
+            exposure_time = 1.0;
+        }
+
+
+        final double peak_flux = PeakPixelFlux.calculate(pixel_size, dark_current, _sdParameters, exposure_time, source_fraction, Npix, im_qual, sed_integral, sky_integral);
+        Log.fine("Peak Pixel Flux = " + peak_flux);
+
+
+        // final double req_source_exposures = (req_s2n / signal) * (req_s2n / signal) *
+        //        (signal + noiseFactor * sourceless_noise * sourceless_noise) / coadds;
+
+        // Calculate the exposure time that will give the max allowed counts (half-well?)
+
+        // Take the smaller of the two?
+
+        // The minimum exposure time is 1s for GMOS  (can I query the minimum for each instrument?)
+
+        // For instruments that can coadd - calculate the number of coadds required:
+        // numcoadds =
+        // if we need 90s
+        // and the longest allowed is 60s
+        // 90/60 = 1.5 -> take 2
+        // 90/2 = 45s each
+
+        Log.fine(String.format("Calculating S/N with Exptime = %.3f", exposure_time));
+        super.calculate();
+        Log.fine("singleSNRatio = " + singleSNRatio());
+
+    }
+
+    @Override public double numberSourceExposures() {
+        return 1;
+    }
+
+    public double exposureTime() {
+        return exposure_time;
+    }
+
+}

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingMethodExptime.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingMethodExptime.java
@@ -1,29 +1,21 @@
 package edu.gemini.itc.operation;
 
 import edu.gemini.itc.base.Instrument;
+import edu.gemini.itc.shared.CalculationMethod;
 import edu.gemini.itc.shared.ImagingExp;
 import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.SourceDefinition;
 import java.util.logging.Logger;
 
 public final class ImagingMethodExptime extends ImagingS2NCalculation {
-
+    private final CalculationMethod calcMethod;
     private final Instrument instrument;
     private final SourceDefinition _sdParameters;
     private final SourceFraction srcFrac;
-    private final double frac_with_source;
-    //private final double well_depth;
-    //private final double sat_limit;
-    //private final double gain;
-    private final double max_flux;
-    private final double req_s2n;
-    //private int int_req_source_exposures;
-    //private double req_number_exposures;
-    private final double im_qual;
-    //private final boolean is_uniform;
+    private final double maxFlux;
+    private final double imageQuality;
+    private int numberExposures;
     private static final Logger Log = Logger.getLogger(ImagingMethodExptime.class.getName());
-
-    //private ObservationDetails obs;
 
     public ImagingMethodExptime(ObservationDetails obs,
                                 final Instrument instrument,
@@ -31,108 +23,69 @@ public final class ImagingMethodExptime extends ImagingS2NCalculation {
                                 final double sed_integral,
                                 final double sky_integral,
                                 final SourceDefinition _sdParameters,
-                                final double im_qual) {
+                                final double imageQuality) {
         super(obs, instrument, srcFrac, sed_integral, sky_integral);
+
         this.instrument = instrument;
+        this.calcMethod = obs.calculationMethod();
         this._sdParameters = _sdParameters;
         this.srcFrac = srcFrac;
-        this.frac_with_source = obs.sourceFraction();
-        this.exposure_time = obs.exposureTime();  // defined to be 60s in ITCgmos.html
+        this.numberExposures = 1;
+        this.exposure_time = obs.exposureTime();  // 60s in ITCgmos.html
         this.coadds = 1;   // obs.calculationMethod().coaddsOrElse(1);
         this.read_noise = instrument.getReadNoise();
         this.pixel_size = instrument.getPixelSize();
-        //this.well_depth = instrument.wellDepth();
-        //this.sat_limit = (instrument instanceof BinningProvider) ?
-        //        well_depth * ((BinningProvider) instrument).getSpatialBinning() * ((BinningProvider) instrument).getSpectralBinning() :
-        //        well_depth;
-        this.max_flux = instrument.maxFlux();
-        //this.gain = instrument.gain();
-        this.req_s2n = ((ImagingExp) obs.calculationMethod()).sigma();
-        //this.is_uniform = _sdParameters.isUniform();
-        this.im_qual = im_qual;
-
+        this.maxFlux = instrument.maxFlux();
+        this.imageQuality = imageQuality;
     }
 
     public void calculate() {
 
-        Log.fine("Calculating with initial guess for exptime...");
-        super.calculate();
-        Log.fine("singleSNRatio = " + singleSNRatio());
+        // 1. Calculate the maximum exposure time
+        // 2. Calculate the total integration time required to achieve the requested S/N.
+        // 3. Calculate the number of exposures, if more than one are required.
+        // 4. Calculate the exposure time.
 
+        Log.fine(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+        super.calculate();  // perform an initial S/N calculation using the default values from the HTML form
+        double snr = totalSNRatio();
+        Log.fine(String.format("Total S/N = %.2f from %d x %.2f second exposures", snr, numberExposures, exposure_time));
 
-        // Calculate the exposure time that will give the max flux:
-        double peak_flux = PeakPixelFlux.calculate(instrument, _sdParameters, exposure_time, srcFrac, im_qual, sed_integral, sky_integral);
-        Log.fine(String.format("Peak Pixel Flux = %.0f e-", peak_flux));
-        Log.fine(String.format("Max acceptable flux = %.0f e-", max_flux));
-        double exposure_time_max_flux = max_flux / peak_flux * exposure_time;
-        Log.fine(String.format("Exposure time that would yield the max flux = %.2f seconds", exposure_time_max_flux));
+        double peakFlux = PeakPixelFlux.calculate(instrument, _sdParameters, exposure_time, srcFrac, imageQuality, sed_integral, sky_integral);
+        Log.fine(String.format("Peak Pixel Flux = %.0f e-", peakFlux));
 
+        Log.fine(String.format("Max acceptable flux = %.0f e-", maxFlux));
 
-        // Calculate the exposure time that should give the desired S/N
+        double timeToHalfMax = maxFlux / 2. / peakFlux * exposure_time;  // time to reach half of the maximum (our goal)
+        Log.fine(String.format("timeToHalfMax = %.2f seconds", timeToHalfMax));
 
-        // In general, S/N ~ sqrt(t), so t ~ (S/N)^2
-        //final double req_exptime = exposure_time * (req_s2n / singleSNRatio()) * (req_s2n / singleSNRatio());
-        //Log.fine("Estimated exposure time = " + req_exptime);
-        // well, that didn't work very well...
-
-        //Log.fine("frac_with_source = " + frac_with_source);  // fraction of images which include the source
-        //Log.fine("source_fraction = " + source_fraction);  // fraction of source in aperture?
-
-        // Try again:
-        final double vs = sed_integral * source_fraction + secondary_integral * secondary_source_fraction;
-        final double vb = sky_integral * pixel_size * pixel_size * Npix;
-        final double vd = dark_current * Npix;
-        final double a = vs * vs;
-        final double b = -1.0 * req_s2n * req_s2n * (vs + vb + vd);
-        final double c = req_s2n * req_s2n * var_readout;
-        final double discriminant = b*b - 4.0 * a * c;
-        final double new_exptime_plus = (-1.0 * b + Math.sqrt(b*b - 4.0 * a * c)) / (2.0 * a);
-        final double new_exptime_minus = (-1.0 * b - Math.sqrt(b*b - 4.0 * a * c)) / (2.0 * a);
-        Log.fine("sed = " + sed_integral);
-        Log.fine("sky = " + sky_integral);
-        Log.fine("pixsize = " + pixel_size);
-        Log.fine("readnoise = " + read_noise);
-        Log.fine("Npix = " + Npix);
-        Log.fine("snr = " + req_s2n);
-        Log.fine("vs = " + vs);
-        Log.fine("vb = " + vb);
-        Log.fine("vd = " + vd);
-        Log.fine("vr = " + var_readout);
-        Log.fine("a = " + a);
-        Log.fine("b = " + b);
-        Log.fine("c = " + c);
-        Log.fine("discriminant = " + discriminant);
-        Log.fine("Calculated exposure time (+) = " + new_exptime_plus);
-        Log.fine("Calculated exposure time (-) = " + new_exptime_minus);
-        if (discriminant > 0) {
-            exposure_time = new_exptime_plus;
-        } else {
-            exposure_time = 1.0;
+        if (timeToHalfMax < 1.0) {
+            throw new RuntimeException(String.format("This target is too bright for this configuration.\n" +
+                    "The detector well is half filled in %.2f seconds.", timeToHalfMax));
         }
+        int maxExptime = Math.min(1200, (int) timeToHalfMax);  // 1200s is the (GMOS) maximum due to cosmic rays
+        Log.fine(String.format("maxExptime = %d seconds", maxExptime));
 
-        //peak_flux = PeakPixelFlux.calculate(instrument, _sdParameters, exposure_time, srcFrac, im_qual, sed_integral, sky_integral);
-        //Log.fine("Peak Pixel Flux = " + peak_flux);
+        double desiredSNR = ((ImagingExp) calcMethod).sigma();
+        Log.fine(String.format("desiredSNR = %.2f", desiredSNR));
 
-        // Take the smaller of the two?
+        double totalTime = exposure_time * numberExposures * (desiredSNR / snr) * (desiredSNR / snr);
+        Log.fine(String.format("totalTime = %.2f", totalTime));
 
-        // The minimum exposure time is 1s for GMOS  (can I query the minimum for each instrument?)
+        numberExposures = (int) Math.ceil(totalTime / maxExptime);
+        Log.fine(String.format("numberExposures = %d", numberExposures));
 
-        // For instruments that can coadd - calculate the number of coadds required:
-        // numcoadds =
-        // if we need 90s
-        // and the longest allowed is 60s
-        // 90/60 = 1.5 -> take 2
-        // 90/2 = 45s each
+        exposure_time = Math.ceil(totalTime / numberExposures);
+        Log.fine(String.format("exposureTime = %.2f", exposure_time));
 
-        Log.fine(String.format("Calculating S/N with Exptime = %.3f", exposure_time));
+        // TODO: for instruments that can coadd - calculate the number of coadds
+
         super.calculate();
-        Log.fine("singleSNRatio = " + singleSNRatio());
-
+        Log.fine("totalSNRatio = " + totalSNRatio());
+        Log.fine("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
     }
 
-    @Override public double numberSourceExposures() {
-        return 1;
-    }
+    @Override public int numberSourceExposures() { return numberExposures; }
 
     @Override public double getExposureTime() { return exposure_time; }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingPointS2NMethodBCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingPointS2NMethodBCalculation.java
@@ -3,6 +3,7 @@ package edu.gemini.itc.operation;
 import edu.gemini.itc.base.Instrument;
 import edu.gemini.itc.shared.ImagingInt;
 import edu.gemini.itc.shared.ObservationDetails;
+import java.util.logging.Logger;
 
 public final class ImagingPointS2NMethodBCalculation extends ImagingS2NCalculation {
 
@@ -10,6 +11,7 @@ public final class ImagingPointS2NMethodBCalculation extends ImagingS2NCalculati
     private final double req_s2n;
     private int int_req_source_exposures;
     private double req_number_exposures;
+    private static final Logger Log = Logger.getLogger(ImagingPointS2NMethodBCalculation.class.getName());
 
     public ImagingPointS2NMethodBCalculation(final ObservationDetails obs,
                                              final Instrument instrument,
@@ -31,6 +33,7 @@ public final class ImagingPointS2NMethodBCalculation extends ImagingS2NCalculati
 
         final double req_source_exposures = (req_s2n / signal) * (req_s2n / signal) *
                 (signal + noiseFactor * sourceless_noise * sourceless_noise) / coadds;
+        Log.fine("Required on-source exposures = " + req_source_exposures);
 
         int_req_source_exposures =
                 new Double(Math.ceil(req_source_exposures)).intValue();

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingPointS2NMethodBCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingPointS2NMethodBCalculation.java
@@ -3,7 +3,6 @@ package edu.gemini.itc.operation;
 import edu.gemini.itc.base.Instrument;
 import edu.gemini.itc.shared.ImagingInt;
 import edu.gemini.itc.shared.ObservationDetails;
-import java.util.logging.Logger;
 
 public final class ImagingPointS2NMethodBCalculation extends ImagingS2NCalculation {
 
@@ -11,7 +10,6 @@ public final class ImagingPointS2NMethodBCalculation extends ImagingS2NCalculati
     private final double req_s2n;
     private int int_req_source_exposures;
     private double req_number_exposures;
-    private static final Logger Log = Logger.getLogger(ImagingPointS2NMethodBCalculation.class.getName());
 
     public ImagingPointS2NMethodBCalculation(final ObservationDetails obs,
                                              final Instrument instrument,
@@ -33,7 +31,6 @@ public final class ImagingPointS2NMethodBCalculation extends ImagingS2NCalculati
 
         final double req_source_exposures = (req_s2n / signal) * (req_s2n / signal) *
                 (signal + noiseFactor * sourceless_noise * sourceless_noise) / coadds;
-        Log.fine("Required on-source exposures = " + req_source_exposures);
 
         int_req_source_exposures =
                 new Double(Math.ceil(req_source_exposures)).intValue();
@@ -43,7 +40,7 @@ public final class ImagingPointS2NMethodBCalculation extends ImagingS2NCalculati
 
     }
 
-    @Override public double numberSourceExposures() {
+    @Override public int numberSourceExposures() {
         return int_req_source_exposures;
     }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculatable.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculatable.java
@@ -10,6 +10,7 @@ public interface ImagingS2NCalculatable extends Calculatable {
     double getVarBackground();
     double getVarDark();
     double getVarReadout();
+    double getExposureTime();
 
     double numberSourceExposures();
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculatable.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculatable.java
@@ -12,7 +12,7 @@ public interface ImagingS2NCalculatable extends Calculatable {
     double getVarReadout();
     double getExposureTime();
 
-    double numberSourceExposures();
+    int numberSourceExposures();
 
     double singleSNRatio();
     double totalSNRatio();

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculation.java
@@ -10,13 +10,13 @@ import edu.gemini.itc.trecs.TRecs;
 
 public abstract class ImagingS2NCalculation implements ImagingS2NCalculatable {
 
-    private final double Npix;
-    private final double source_fraction;
-    private final double dark_current;
-    private final double sed_integral;
-    private final double sky_integral;
-    private final double skyAper;
-    private final int    elfinParam;
+    protected final double Npix;
+    protected final double source_fraction;
+    protected final double dark_current;
+    protected final double sed_integral;
+    protected final double sky_integral;
+    protected final double skyAper;
+    protected final int elfinParam;
 
     protected double var_source;
     protected double var_background;
@@ -92,5 +92,7 @@ public abstract class ImagingS2NCalculation implements ImagingS2NCalculatable {
     public double singleSNRatio() {
         return Math.sqrt(coadds) * signal / noise;
     }
+
+    @Override public double getExposureTime() { return exposure_time; }
 
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculationFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NCalculationFactory.java
@@ -1,11 +1,16 @@
 package edu.gemini.itc.operation;
 
 import edu.gemini.itc.base.Instrument;
+import edu.gemini.itc.shared.ImagingExp;
+import edu.gemini.itc.shared.ImagingInt;
+import edu.gemini.itc.shared.ImagingS2N;
 import edu.gemini.itc.shared.ObservationDetails;
 import edu.gemini.itc.shared.S2NMethod;
+import edu.gemini.itc.shared.SourceDefinition;
+import java.util.logging.Logger;
 
 public final class ImagingS2NCalculationFactory {
-
+    private static final Logger Log = Logger.getLogger(ImagingS2NCalculationFactory.class.getName());
     private ImagingS2NCalculationFactory() {}
 
     public static ImagingS2NCalculatable getCalculationInstance(final ObservationDetails obs, final Instrument instrument, final SourceFraction srcFrac, final double sed_integral, final double sky_integral) {
@@ -15,8 +20,27 @@ public final class ImagingS2NCalculationFactory {
         } else {
             return new ImagingPointS2NMethodBCalculation(obs, instrument, srcFrac, sed_integral, sky_integral);
         }
+    }
 
+    public static ImagingS2NCalculatable getCalculationInstance(
+            final SourceDefinition _sdParameters,
+            ObservationDetails obs,
+            final Instrument instrument,
+            final SourceFraction srcFrac,
+            final double im_qual,
+            final double sed_integral,
+            final double sky_integral) {
+        Log.fine("calculationMethod = " + obs.calculationMethod().toString());
+
+        if (obs.calculationMethod() instanceof ImagingS2N) {
+            return new ImagingS2NMethodACalculation(obs, instrument, srcFrac, sed_integral, sky_integral);
+        } else if (obs.calculationMethod() instanceof ImagingInt) {
+            return new ImagingPointS2NMethodBCalculation(obs, instrument, srcFrac, sed_integral, sky_integral);
+        } else if (obs.calculationMethod() instanceof ImagingExp) {
+            return new ImagingMethodExptime(obs, instrument, srcFrac, sed_integral, sky_integral, _sdParameters, im_qual);
+        } else {
+            throw new Error("Invalid calculation method");
+        }
     }
 
 }
-

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NMethodACalculation.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingS2NMethodACalculation.java
@@ -42,8 +42,8 @@ public final class ImagingS2NMethodACalculation extends ImagingS2NCalculation {
 
     }
 
-    @Override public double numberSourceExposures() {
-        return number_exposures * frac_with_source * coadds;
+    @Override public int numberSourceExposures() {
+        return (int) (number_exposures * frac_with_source * coadds);
     }
 
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecs.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/trecs/TRecs.java
@@ -233,6 +233,10 @@ public final class TRecs extends Instrument implements SpectroscopyInstrument {
         return 1.0;
     }
 
+    @Override public double maxFlux() {
+        return WELL_DEPTH;
+    }
+
     @Override public List<WarningRule> warnings() {
         return new ArrayList<WarningRule>() {{
             add(new SaturationLimitRule(WELL_DEPTH, 0.80));

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/ghost/Ghost.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/ghost/Ghost.scala
@@ -9,7 +9,7 @@ import edu.gemini.spModel.core.Site
  * GHOST specification class
  */
 // TODO-GHOSTITC
-final class Ghost(gp: GhostParameters) extends Instrument(Site.GS, Bands.NEAR_IR, Ghost.instr_dir, Ghost.filename) with SpectroscopyInstrument{
+abstract final class Ghost(gp: GhostParameters) extends Instrument(Site.GS, Bands.NEAR_IR, Ghost.instr_dir, Ghost.filename) with SpectroscopyInstrument{
   /**
    * Returns the effective observing wavelength.
    * This is properly calculated as a flux-weighted averate of


### PR DESCRIPTION
This is primarily for Explore, however, I updated the web interface to facilitate testing.

This PR adds _GMOS_ support to the Integration Time Calculators to:

1. Calculate the optimal imaging exposure time and number of exposures to achieve the requested signal-to-noise ratio.

2. Calculate the optimal spectroscopic exposure time and number of exposures to achieve the requested signal-to-noise ratio at the specified wavelength.

