### PR TITLE
REL-4252: remove fast high

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/GhostReadNoiseGain.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/ghost/GhostReadNoiseGain.java
@@ -4,13 +4,19 @@ import edu.gemini.shared.util.immutable.None;
 import edu.gemini.shared.util.immutable.Option;
 import edu.gemini.shared.util.immutable.Some;
 import edu.gemini.spModel.type.SpTypeUtil;
+import edu.gemini.spModel.type.ObsoletableSpType;
 import edu.gemini.spModel.type.StandardSpType;
 
-public enum GhostReadNoiseGain implements StandardSpType {
+public enum GhostReadNoiseGain implements StandardSpType, ObsoletableSpType {
     SLOW_LOW("Slow / Low", "Slow Read / Low Gain: Slow Readout", 10),
     MEDIUM_LOW("Medium / Low", "Medium Read / Low Gain: Medium Readout", 5),
     FAST_LOW("Fast / Low", "Fast Read / Low Gain: Rapid Readout", 2),
-    FAST_HIGH("Fast / High", "Fast Read / High Gain: Bright Targets", -1)
+    FAST_HIGH("Fast / High", "Fast Read / High Gain: Bright Targets", -1) {
+        @Override
+        public boolean isObsolete() {
+            return true;
+        }
+    }
     ;
 
     private final String displayValue;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -2,8 +2,8 @@ package jsky.app.ot.gemini.ghost
 
 import java.awt.Font
 import java.util.logging.Logger
-
 import com.jgoodies.forms.factories.DefaultComponentFactory
+
 import javax.swing.{DefaultComboBoxModel, JPanel, JSpinner}
 import edu.gemini.pot.sp.ISPObsComponent
 import edu.gemini.shared.gui.bean.{CheckboxPropertyCtrl, ComboPropertyCtrl, RadioPropertyCtrl, TextFieldPropertyCtrl}
@@ -29,6 +29,7 @@ import scala.swing.TabbedPane.Page
 import scala.swing.event.{ButtonClicked, SelectionChanged}
 import scalaz._
 import Scalaz._
+import edu.gemini.spModel.`type`.SpTypeUtil
 import edu.gemini.spModel.gemini.ghost.GhostAsterism.GuideFiberState.Enabled
 import jsky.app.ot.editor.SpinnerEditor
 
@@ -250,7 +251,12 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       }
       row += 1
 
-      val redReadNoiseGain: RadioPropertyCtrl[Ghost, GhostReadNoiseGain] = new RadioPropertyCtrl[Ghost, GhostReadNoiseGain](Ghost.RED_READ_NOISE_GAIN_PROP)
+      val redReadNoiseGain: RadioPropertyCtrl[Ghost, GhostReadNoiseGain] =
+        new RadioPropertyCtrl[Ghost, GhostReadNoiseGain](
+          Ghost.RED_READ_NOISE_GAIN_PROP,
+          true,
+          SpTypeUtil.getObsoleteItems(classOf[GhostReadNoiseGain])
+        )
       layout(Component.wrap(redReadNoiseGain.getComponent)) = new Constraints() {
         anchor = Anchor.NorthWest
         gridx = 0
@@ -349,7 +355,12 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
       }
       row += 1
 
-      val blueReadNoiseGain: RadioPropertyCtrl[Ghost, GhostReadNoiseGain] = new RadioPropertyCtrl[Ghost, GhostReadNoiseGain](Ghost.BLUE_READ_NOISE_GAIN_PROP)
+      val blueReadNoiseGain: RadioPropertyCtrl[Ghost, GhostReadNoiseGain] =
+        new RadioPropertyCtrl[Ghost, GhostReadNoiseGain](
+          Ghost.BLUE_READ_NOISE_GAIN_PROP,
+          true,
+          SpTypeUtil.getObsoleteItems(classOf[GhostReadNoiseGain])
+        )
       layout(Component.wrap(blueReadNoiseGain.getComponent)) = new Constraints() {
         anchor = Anchor.NorthWest
         gridx = 0


### PR DESCRIPTION
Removes the fast/high option in the OT.  The task did not state what to do with existing programs which have Fast/High already selected, but it seemed reasonable not to change them.

The option is now hidden in the OT unless it is already selected in which case it is visible but clearly marked as undesirable:

<img width="303" alt="Screen Shot 2023-04-03 at 10 48 06 AM" src="https://user-images.githubusercontent.com/4906023/229557165-5f91a201-e024-4e69-b768-2c51075eda35.png">

Once a non-obsolete choice is made (and the user revisits the editor), the option to select the obsolete choice is gone.