### PR TITLE
REL-4203: Hide guide fiber options

### DIFF
--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/ghost/GhostCB.scala
@@ -5,7 +5,6 @@ import java.util.{Map => JMap}
 import edu.gemini.pot.sp.ISPObsComponent
 import edu.gemini.pot.sp.ISPObservation
 import edu.gemini.spModel.config.AbstractObsComponentCB
-import edu.gemini.spModel.core.Magnitude
 import edu.gemini.spModel.core.MagnitudeBand
 import edu.gemini.spModel.data.config._
 import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostTarget
@@ -83,8 +82,10 @@ final class GhostCB(obsComp: ISPObsComponent) extends AbstractObsComponentCB(obs
       /**
        * Add the guiding information for an SRIFU or HRIFU pointing at a target.
        */
-      def guiding(name: String, t: GhostTarget): Unit =
-        config.putParameter(systemName, DefaultParameter.getInstance(name, t.guideFiberState))
+      def guiding(name: String, t: GhostTarget): Unit = {
+        // REL-4203: Removing from the sequence config for now at least.
+        //config.putParameter(systemName, DefaultParameter.getInstance(name, t.guideFiberState))
+      }
 
       /** Add the target information for the observation for GHOST to the
         * sequence.

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/ghost/GhostEditor.scala
@@ -482,7 +482,8 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
         row += 1
 
         /** OIWFS guide star. */
-        panel.layout(new Label("Enable Guide Fibers:")) = new panel.Constraints() {
+        val gfLabel: Label = new Label("Enable Guide Fibers:")
+        panel.layout(gfLabel) = new panel.Constraints() {
           anchor = Anchor.NorthEast
           gridx = 0
           gridy = row
@@ -495,6 +496,11 @@ final class GhostEditor extends ComponentEditor[ISPObsComponent, Ghost] {
           gridy = row
           insets = new Insets(3, 0, 0, 0)
         }
+
+        // REL-4203: hide the guide fiber option
+        gfLabel.visible               = false
+        ifuGuideFiberCheckBox.visible = false
+
         row += 1
         panel
       }


### PR DESCRIPTION
Hides the "Enable guide fibers" options in the OT and removes them from the sequence configuration.  I'm not committing to removing them altogether yet since it changes the asterism definition drastically (`GhostTarget` would go away altogether) and it seems like it could easily come back.