### PR TITLE
Fix offset calculation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "ocs"
 organization in Global := "edu.gemini.ocs"
 
 // true indicates a test release, and false indicates a production release
-ocsVersion in ThisBuild := OcsVersion("2023A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2023B", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2023B", false, 2, 2, 1)
 

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Coordinates.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Coordinates.scala
@@ -17,6 +17,9 @@ final case class Coordinates(ra: RightAscension, dec: Declination) {
     Coordinates(ra0, dec0)
   }
 
+  def offset(o: Offset): Coordinates =
+    angularOffset(o.bearing, o.distance)
+
   /**
    * Compute the offset require to transform this `Coordinates` to the given one, such that
    * c1 offset (c1 diff c2) == c2.

--- a/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Offset.scala
+++ b/bundle/edu.gemini.spModel.core/src/main/scala/edu/gemini/spModel/core/Offset.scala
@@ -12,6 +12,7 @@ import Scalaz._
  * base position and a second position.
  */
 case class Offset(p: OffsetP, q: OffsetQ) {
+
   /**
    * Calculates the absolute distance between this Offset position and the
    * given position
@@ -27,6 +28,15 @@ case class Offset(p: OffsetP, q: OffsetQ) {
     val d = sqrt(pd*pd + qd*qd)
 
     Angle.fromDegrees(d)
+  }
+
+  /**
+   * Calculates the bearing from 0,0 as an Angle clockwise from north 0º.
+   */
+  def bearing: Angle = {
+    val x = -p.toAngle.toSignedDegrees
+    val y =  q.toAngle.toSignedDegrees
+    Angle.fromRadians(atan2(x, y))
   }
 
   /**

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/CoordinatesSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/CoordinatesSpec.scala
@@ -63,6 +63,30 @@ object CoordinatesSpec extends Specification with ScalaCheck with Arbitraries wi
         c.angularDistance(newCoordinates) ~= distance
       }
 
+    "calculate offset in angular separation" ! {
+
+      val o = Offset(OffsetP(Angle.fromArcmin(2.0)), OffsetQ(Angle.zero))
+
+      val ra   = RightAscension.fromHours(12.0)
+      val d0   = Declination.fromDegrees(0).get
+      val d45  = Declination.fromDegrees(45).get
+      val dm45 = Declination.fromDegrees(-45).get
+
+      // At the equator there is no correction
+      val c0 = Coordinates(ra, d0)
+      val c1 = Coordinates(ra.offset(Angle.fromArcmin(2.0)), d0)
+      c0.offset(o) ~= c1
+
+      // Further away we correct by cos(dec)
+      val c2 = Coordinates(ra, d45)
+      val c3 = Coordinates(ra.offset(Angle.fromArcmin(2.0/Math.cos(45.0.toRadians))), d45)
+      c2.offset(o) ~= c3
+
+      // Further away we correct by cos(dec)
+      val c4 = Coordinates(ra, dm45)
+      val c5 = Coordinates(ra.offset(Angle.fromArcmin(2.0/Math.cos(-45.0.toRadians))), dm45)
+      c4.offset(o) ~= c5
+    }
   }
 
   "Coordinates Angular Separation" should {

--- a/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/OffsetSpec.scala
+++ b/bundle/edu.gemini.spModel.core/src/test/scala/edu/gemini/spModel/core/OffsetSpec.scala
@@ -68,5 +68,26 @@ class OffsetSpec extends Specification with ScalaCheck with Arbitraries {
         o1.distance(o2) ~= o2.distance(o1)
       }
     }
+
+    "calculate bearing" in {
+      val tests = List(
+        ( 0,  1,   0),
+        ( 1,  1, 315),
+        ( 1,  0, 270),
+        ( 1, -1, 225),
+        ( 0, -1, 180),
+        (-1, -1, 135),
+        (-1,  0,  90),
+        (-1,  1,  45)
+      )
+
+      tests.forall { case (p, q, b) =>
+        val p0 = p.arcsecs[OffsetP]
+        val q0 = q.arcsecs[OffsetQ]
+        val o  = Offset(p0, q0)
+        val e  = ~Angle.fromDMS(b, 0, 0)
+        o.bearing ~= e
+      }
+    }
   }
 }


### PR DESCRIPTION
When we instantiate GHOST templates we add a fake target (for Dual Target mode) or fake sky positions (for the + sky modes).  These are created such that they are separated by 2 arcmins from the known target position.  Unfortunately this was being done as a simple offset in RA when in reality it should be angular separation.
