### PR TITLE
Logging Cleanup

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObsExecLog.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/pot/sp/memImpl/MemObsExecLog.java
@@ -50,12 +50,14 @@ public final class MemObsExecLog extends MemProgramNodeBase implements ISPObsExe
     @Override public PropagationId putClientData(String name, Object obj) {
         getProgramWriteLock();
 
+        final Level logLevel = Level.FINE;
+
         try {
             final Option<String>        oid = getObsId();
             final StringBuilder         buf = new StringBuilder();
             final List<ObsExecEvent> before = getVisitEvents(name, getDataObject());
             final List<ObsExecEvent>  after = getVisitEvents(name, obj);
-            final boolean         logEvents = !before.equals(after);
+            final boolean         logEvents = LOG.isLoggable(logLevel) && !before.equals(after);
 
             if (logEvents) {
                 buf.append(String.format("Updating ObsExecRecord for %s (%s)\n", oid.getOrElse("<unknown>"), getDocumentData().getLifespanId()));
@@ -69,7 +71,7 @@ public final class MemObsExecLog extends MemProgramNodeBase implements ISPObsExe
                 buf.append(String.format("After.....: %s\n", getDocumentData().versionVector(this.getNodeKey())));
                 buf.append(ObsExecLog.formatEvents(after));
 
-                LOG.log(Level.INFO, buf.toString(), new Throwable());
+                LOG.log(logLevel, buf.toString(), new Throwable());
             }
 
             return propid;

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisitList.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obsrecord/PrivateVisitList.java
@@ -90,7 +90,7 @@ final class PrivateVisitList implements Serializable {
 
     private void _rebuild(List<ObsExecEvent> eventList) {
         final String ids = eventList.stream().map(ObsExecEvent::getObsId).distinct().map(SPObservationID::stringValue).reduce((a, b) -> a + ", " + b).orElse("");
-        LOG.info("Rebuilding visit list for: " + ids);
+        LOG.fine("Rebuilding visit list for: " + ids);
 
         eventList.sort(ExecEvent.TIME_COMPARATOR);
         _visits.clear();


### PR DESCRIPTION
This PR would change the log level to `FINE` for some rather verbose log messages that were added specifically to track down a problem with synchronization.  That problem has been solved and the log messages are distracting from actual issues that might appear so it seems appropriate to tone them down a bit before the 2023B release.