### PR TITLE
Stop frequent checks for old diverged datasets

### DIFF
--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/Dataman.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/Dataman.scala
@@ -10,11 +10,12 @@ import edu.gemini.util.security.principal.StaffPrincipal
 import java.security.Principal
 import java.time.Duration
 import java.util.UUID
-import java.util.concurrent.{TimeUnit, ThreadFactory, Executors}
+import java.util.concurrent.{Executors, ThreadFactory, TimeUnit}
 import java.util.logging.Logger
-
 import scalaz._
 import Scalaz._
+
+import java.time.Instant
 
 
 /** Dataman ties together the various pieces of the application.  Once created
@@ -121,7 +122,8 @@ object Dataman {
       schedule(progArchiveSync, progSyncDelay, config.archivePoll.allPrograms.time)
       schedule(progSummitSync, progSyncDelay, config.summitPoll.allPrograms.time)
 
-      val orr = new ObsRefreshRunnable(odb, User, oids =>
+      // Note "now" is passed by value to be re-evaluated every time it is needed.
+      val orr = new ObsRefreshRunnable(odb, User, Instant.now(), oids =>
         pollServices.foreach(_.addAll(oids))
       )
       schedule(orr, obsRefreshDelay, config.obsRefreshPeriod.time)

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ObsRefreshRunnable.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/ObsRefreshRunnable.scala
@@ -4,30 +4,53 @@ import edu.gemini.dataman.DetailLevel
 import edu.gemini.dataman.core.DmanId
 import edu.gemini.dataman.core.DmanId.Obs
 import edu.gemini.pot.spdb.IDBDatabaseService
-import edu.gemini.spModel.dataset.DataflowStatus.{Diverged, SummitOnly, UpdateInProgress, SyncPending}
-import edu.gemini.spModel.dataset.{DatasetLabel, DataflowStatus, DatasetRecord}
+import edu.gemini.spModel.dataset.DataflowStatus.{Diverged, SummitOnly, SyncPending, UpdateInProgress}
+import edu.gemini.spModel.dataset.{DataflowStatus, DatasetLabel, DatasetRecord}
 
 import java.security.Principal
 import java.util.logging.{Level, Logger}
-
 import scalaz.Scalaz._
 import scalaz._
 
+import java.time.Duration
+import java.time.Instant
+import scala.util.Try
+
 /** A `Runnable` that scans the database looking for datasets for which updates
   * are expected and then asks the archive for a status update.
+  * @param now Timestamp in the ODB server when this functor runs.
   */
 final class ObsRefreshRunnable(
-              odb: IDBDatabaseService,
-              user: java.util.Set[Principal],
-              refresh: List[Obs] => Unit) extends Runnable {
+  odb:     IDBDatabaseService,
+  user:    java.util.Set[Principal],
+  now:     => Instant,
+  refresh: List[Obs] => Unit
+) extends Runnable {
 
   private val Log = Logger.getLogger(getClass.getName)
 
+  // How long we can still hope to see any update from the FITS storage service.
+  // After this time, we'll stop checking frequently but still pick up an
+  // update should it occur with one of the other normal poll periods.
+  private val HopeDuration: Duration =
+    Duration.ofDays(1L);
+
   override def run(): Unit = {
+
+    // "now" is the timestamp in the ODB server when this functor runs.  We'll
+    // be comparing this to the FITS server timestamp which is obviously
+    // problematic but at the scale we're interested in (days) any discrepancies
+    // should not matter if the clocks are at least somewhat accurate.
+    def timeSinceDatasetUpdateOnSummit(dr: DatasetRecord): Option[Duration] =
+      dr.exec.summit.gsaTimestampOption.flatMap { t =>
+        Try(Duration.between(t, now)).toOption
+      }
+
     def updateExpected(dr: DatasetRecord): Boolean =
       DataflowStatus.derive(dr) match {
-        case SyncPending | UpdateInProgress | SummitOnly | Diverged => true
-        case _                                                      => false
+        case SyncPending | UpdateInProgress => true
+        case SummitOnly  | Diverged         => timeSinceDatasetUpdateOnSummit(dr).exists(_.compareTo(HopeDuration) <= 0)
+        case _                              => false
       }
 
     def obsIds(labs: List[DatasetLabel]): List[DmanId.Obs] =

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsRefreshRunnableSpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsRefreshRunnableSpec.scala
@@ -2,14 +2,15 @@ package edu.gemini.dataman.app
 
 import edu.gemini.dataman.core.DmanId.Obs
 import edu.gemini.spModel.dataset.DataflowStatus
-import edu.gemini.spModel.dataset.DataflowStatus.{Diverged, SummitOnly, UpdateInProgress, SyncPending}
-
+import edu.gemini.spModel.dataset.DataflowStatus.{Diverged, SummitOnly, SyncPending, UpdateInProgress}
 import scalaz._
 import Scalaz._
 
+import java.time.Instant
+
 object ObsRefreshRunnableSpec extends TestSupport {
   "ObsRefreshRunnable" should {
-    "find all exepected updates" ! forAllPrograms { (odb, progs) =>
+    "find all expected updates" ! forAllPrograms { (odb, progs) =>
 
       val expected = allDatasets(progs).filter { ds =>
         DataflowStatus.derive(ds) match {
@@ -19,7 +20,7 @@ object ObsRefreshRunnableSpec extends TestSupport {
       }.map(_.label.getObservationId).distinct.map(Obs).toSet
 
       var actual = Set.empty[Obs]
-      val orr = new ObsRefreshRunnable(odb, User, oids => actual = oids.toSet)
+      val orr = new ObsRefreshRunnable(odb, User, Instant.MIN, oids => actual = oids.toSet)
       orr.run()
 
       expected == actual

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/dataset/SummitState.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/dataset/SummitState.scala
@@ -287,7 +287,7 @@ object SummitState {
         .withParam("retry", retryCount)
   }
 
-  /** Constructs a `MIssing` instance with static type `SummitState`, which is
+  /** Constructs a `Missing` instance with static type `SummitState`, which is
     * convenient for folds, etc.
     *
     * @group Constructors


### PR DESCRIPTION
This is a hack around for a problem in the FITS storage service wherein the dataset status as reported on the summit vs. the archive diverges.  This is a situation we currently expect to be remedied quickly as it should synchronize the two.  Accordingly we frequently (every 2 minutes) poll asking for updates on these datasets so that the status can be shown to the user in a timely manner.  Unfortunately though the synchronization doesn't always happen, or in some cases we don't _observe_ that it has happened because the modification timestamp has gone backward in time and we've ignored the updated status.  Over time the set of datasets in this category has grown to be considerably large (over 3,000 at GN).

The hack is to simply stop expecting a quick update (and stop asking the server for its current status) in these situations if the summit timestamp is more than a day ago.  We still poll for dataset status updates regardless, just at slower rates, so we'll eventually catch an update if the synchronization does in fact happen at some point.