### PR TITLE
REL 4277: IGRINS-2 ITC (v2)

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/Igrins2Printer.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/Igrins2Printer.java
@@ -51,9 +51,15 @@ public final class Igrins2Printer extends PrinterBase implements OverheadTablePr
         String str;
 
         _println("");
-        _println("Read noise: " +
-                results[0].instrument().getReadNoise() + " e- (" + ((Igrins2) results[0].instrument()).getWaveBand() + ") and " +
-                results[1].instrument().getReadNoise() + " e- (" + ((Igrins2) results[1].instrument()).getWaveBand() + ")");
+
+        _println(String.format("Read noise: %.2f e- in %s and %.2f e- in %s using %d Fowler samples.",
+                results[0].instrument().getReadNoise(), ((Igrins2) results[0].instrument()).getWaveBand(),
+                results[1].instrument().getReadNoise(), ((Igrins2) results[1].instrument()).getWaveBand(),
+                ((Igrins2) results[0].instrument()).getFowlerSamples()));
+
+        _println(String.format("Dark current: %.4f e-/s/pix in %s and %.4f e-/s/pix in %s.",
+                results[0].instrument().getDarkCurrent(), ((Igrins2) results[0].instrument()).getWaveBand(),
+                results[1].instrument().getDarkCurrent(), ((Igrins2) results[1].instrument()).getWaveBand()));
 
         if (result.aoSystem().isDefined()) { _println(HtmlPrinter.printSummary((Altair) result.aoSystem().get())); }
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2023-Jul-04</footer>
+<footer>Last updated 2023-Aug-02</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2.java
@@ -19,6 +19,7 @@ public class Igrins2 extends Instrument implements SpectroscopyInstrument {
     private final Igrins2GratingOptics _gratingOptics;
     private final Igrins2Arm _arm;
     private final double _readNoise;
+    private final int _fowlerSamples;
 
     public Igrins2(final Igrins2Parameters igp, final ObservationDetails odp, Igrins2Arm arm) {
         super(Site.GN, Bands.NEAR_IR, INSTR_DIR, FILENAME);
@@ -26,6 +27,9 @@ public class Igrins2 extends Instrument implements SpectroscopyInstrument {
 
         Log.fine("Calc method = " + odp.calculationMethod());
         Log.fine("Arm = " + arm.getName());
+
+        _fowlerSamples = Igrins2$.MODULE$.fowlerSamples(odp.exposureTime());
+        Log.fine("Fowler Samples = " + _fowlerSamples);
 
         _readNoise = Igrins2$.MODULE$.readNoise(odp.exposureTime(), arm.getMagnitudeBand());
         Log.fine("Read Noise = " + _readNoise + " e-");
@@ -61,7 +65,10 @@ public class Igrins2 extends Instrument implements SpectroscopyInstrument {
 
     public int getEffectiveWavelength() { return (int) _arm.getWavelengthCentral(); }  // (nanometers)
 
+    @Override
     public double getReadNoise() { return _readNoise; }  // (electrons)
+
+    public int getFowlerSamples() { return _fowlerSamples; }
 
     public String getDirectory() { return ITCConstants.LIB + "/" + INSTR_DIR; }  // the directory with the data files
 
@@ -84,6 +91,8 @@ public class Igrins2 extends Instrument implements SpectroscopyInstrument {
     @Override public double wellDepth() { return _arm.getWellDepth(); }  // Detector well-depth (electrons)
 
     @Override public double gain() { return _arm.getGain(); }  // Detector gain (electrons / ADU)
+
+    @Override public double getDarkCurrent() { return _arm.getDarkCurrent(); }  // Detector dark current (electrons / sec / pixel)
 
     @Override public double maxFlux() { return _arm.get_maxRecommendedFlux(); }  // Maximum recommended flux (electrons)
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2Arm.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2Arm.java
@@ -12,12 +12,12 @@ public enum Igrins2Arm {
             0.1,
             2048,
             2048,
-            2.05,
-            0.0147,
-            91000,
-            91000,
+            2.5,
+            0.0225,
+            100000,
             80000,
-            40000),
+            80000,
+            80000),
     K("K",
             MagnitudeBand.unsafeFromString("K"),
             1960.0,
@@ -27,12 +27,12 @@ public enum Igrins2Arm {
             0.1,
             2048,
             2048,
-            2.21,
-            0.0109,
-            101000,
-            101000,
-            90000,
-            45000);
+            1.7,
+            0.0238,
+            93600,
+            75000,
+            75000,
+            75000);
 
     private final String _name;
     private final MagnitudeBand _magnitudeBand;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2Recipe.java
@@ -46,8 +46,12 @@ public final class Igrins2Recipe {
     }
 
     private void validateInputParameters() {
-        if (_calcMethod instanceof SpectroscopyS2N && _obsDetailParameters.exposureTime() > 600) {
-            throw new IllegalArgumentException("The maximum exposure time is 600s.");
+        if (_calcMethod instanceof SpectroscopyS2N) {
+            if (_obsDetailParameters.exposureTime() < 1.63) {
+                throw new IllegalArgumentException("The minimum exposure time is 1.63 seconds.");
+            } else if (_obsDetailParameters.exposureTime() > 1800) {
+                throw new IllegalArgumentException("The maximum exposure time is 1800 seconds.");
+            }
         }
         Validation.validate(_mainInstrument[0], _obsDetailParameters, _sdParameters);  // other general validations
     }
@@ -126,7 +130,6 @@ public final class Igrins2Recipe {
             timeToHalfMax = Math.min(timeToHalfMax, maxFlux / 2. / peakFlux * exposureTime);
 
             if (((Igrins2) r.instrument()).getArm() == arm) {  // the requested wavelength is here
-                // det =
                 final VisitableSampledSpectrum fins2n = s.getFinalS2NSpectrum();
                 snr = fins2n.getY(wavelength);
                 Log.fine(String.format("S/N @ %.2f nm = %.2f", wavelength, snr));

--- a/bundle/edu.gemini.itc/src/main/resources/igrins2/igrins2.dat
+++ b/bundle/edu.gemini.itc/src/main/resources/igrins2/igrins2.dat
@@ -12,5 +12,5 @@ background.dat
 0.10
 # Read Noise (set in igrins2.java)
 0
-# Dark Current (e-/sec/pixel)
-0.01
+# Dark Current (set in igrins2.java)
+0

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/igrins2/Igrins2.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/igrins2/Igrins2.scala
@@ -228,6 +228,10 @@ object Igrins2 {
     AllowedFowlerSamples.reverse.find(cur => nFowler >= cur).getOrElse(AllowedFowlerSamples.head)
   }
 
+  def fowlerSamples(expTime: Double) : Int = {
+    fowlerSamples(expTime.seconds)
+  }
+
   def readoutTime(expTime: Time): Time = {
     val nFowler = fowlerSamples(expTime)
     1.45479.seconds * nFowler
@@ -235,14 +239,15 @@ object Igrins2 {
 
   def readNoise(expTime: Time): List[(MagnitudeBand, Double)] = {
     val fowlerSamples0 = fowlerSamples(expTime)
-    def rn(rnAt16: Double) = rnAt16 * sqrt(16) / sqrt(fowlerSamples0)
-    List((MagnitudeBand.H, rn(3.8)), (MagnitudeBand.K, rn(5.0)))
+    List(
+      (MagnitudeBand.H, 14.4 * math.pow(fowlerSamples0, -0.34977)),
+      (MagnitudeBand.K, 13.3 * math.pow(fowlerSamples0, -0.36533)))
   }
 
   def readNoise(expTime: Double, band: MagnitudeBand) : Double =
     band match {
-      case MagnitudeBand.H => 3.8 * sqrt(16) / sqrt(fowlerSamples(expTime.seconds))
-      case MagnitudeBand.K => 5.0 * sqrt(16) / sqrt(fowlerSamples(expTime.seconds))
+      case MagnitudeBand.H => 14.4 * math.pow(fowlerSamples(expTime.seconds), -0.34977)
+      case MagnitudeBand.K => 13.3 * math.pow(fowlerSamples(expTime.seconds), -0.36533)
   }
 
   private val query_no  = false


### PR DESCRIPTION
This pr makes a few minor updates to the IGRINS-2 ITC: detector dark current, read noise, well-depth, and exposure time limits.

This includes a modified relationship between the number of Fowler samples and read noise in Igrins2.scala, where there are 2 separate calculations of the readnoise which could probably be merged.