### PR TITLE
REL-4366: publish to pachon first for GS

### DIFF
--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/PublishAction.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/ui/action/PublishAction.java
@@ -94,7 +94,7 @@ public class PublishAction extends AbstractAsyncAction implements PropertyChange
                 // Get the destination(s)
                 destinations =
                         sched.getSite() == Site.GS ?
-                                new Destination[]{INTERNAL, PACHON} :
+                                new Destination[]{PACHON, INTERNAL} :
                                 new Destination[]{INTERNAL};
 
                 // Show progress dialog


### PR DESCRIPTION
Since publishing to GN is currently unavailable, this update changes the publishing order at GS to `PACHON` and then `INTERNAL` (GN).  It will still time out when attempting to publish at GN, but the site-local publish will in theory have happened by that point.

One caveat: this is untested since it involves network connections that aren't available to me.