### PR TITLE
REL-4345: Apply Proper Motion Corrections in `GhostRule` Coordinate Checks

### DIFF
--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/GhostSpec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/GhostSpec.scala
@@ -5,15 +5,130 @@ package edu.gemini.p2checker.rules
 
 import edu.gemini.p2checker.api.IRule
 import edu.gemini.p2checker.rules.ghost.GhostRule
+import edu.gemini.p2checker.rules.ghost.GhostRule.CoordinatesOutOfFOVRule
+import edu.gemini.pot.sp.ISPObservation
 import edu.gemini.pot.sp.SPComponentType
+import edu.gemini.spModel.core.Angle
+import edu.gemini.spModel.core.AngularVelocity
+import edu.gemini.spModel.core.Coordinates
+import edu.gemini.spModel.core.Declination
+import edu.gemini.spModel.core.DeclinationAngularVelocity
+import edu.gemini.spModel.core.ProperMotion
+import edu.gemini.spModel.core.RightAscension
+import edu.gemini.spModel.core.RightAscensionAngularVelocity
+import edu.gemini.spModel.core.SiderealTarget
+import edu.gemini.spModel.core.Target
 import edu.gemini.spModel.data.config.DefaultParameter
+import edu.gemini.spModel.gemini.ghost.GhostAsterism
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.GhostTarget
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.GuideFiberState
+import edu.gemini.spModel.gemini.ghost.GhostAsterism.createEmptyAsterism
 import edu.gemini.spModel.gemini.ghost.{Ghost, GhostMixin, SeqConfigGhost}
+import edu.gemini.spModel.obs.SchedulingBlock
+import edu.gemini.spModel.obs.SPObservation
+import edu.gemini.spModel.rich.pot.sp._
+import edu.gemini.spModel.target.SPCoordinates
+import edu.gemini.spModel.target.SPTarget
+import edu.gemini.spModel.target.env.TargetEnvironment
+import edu.gemini.spModel.target.obsComp.TargetObsComp
 
+import java.time._
+import java.util.TimeZone
 
 object GhostSpec extends RuleSpec {
 
   val ruleSet: IRule =
     GhostRule
+
+  "CoordinatesOutOfRange rule" should {
+    val highPmBase: GhostTarget = {
+      val t = SiderealTarget(
+        name         = "Zero",
+        coordinates  = Coordinates.zero,
+        properMotion = Some(ProperMotion(
+          RightAscensionAngularVelocity(AngularVelocity(10000.0)),
+          DeclinationAngularVelocity(AngularVelocity(0.0))
+        )),
+        redshift     = None,
+        parallax     = None,
+        magnitudes   = Nil,
+        spectralDistribution = None,
+        spatialProfile       = None
+      )
+      GhostTarget(new SPTarget(t), GuideFiberState.Enabled)
+    }
+
+    val Jan1_2023: SchedulingBlock = {
+      val ldt  = LocalDateTime.of(2023, Month.JANUARY, 1, 0, 0, 0)
+      val when = ldt.atZone(ZoneId.of("UTC")).toInstant
+      new SchedulingBlock(when.toEpochMilli, SchedulingBlock.Duration.Explicit(1000))
+    }
+
+    def modTargetEnvironment(
+      o: ISPObservation
+    )(
+      f: TargetEnvironment => TargetEnvironment
+    ): Unit =
+      o.findObsComponentByType(TargetObsComp.SP_TYPE).foreach { oc =>
+        val toc = oc.getDataObject.asInstanceOf[TargetObsComp]
+        toc.setTargetEnvironment(f(toc.getTargetEnvironment))
+        oc.setDataObject(toc)
+      }
+
+    def modObs(
+      o: ISPObservation
+    )(
+      f: SPObservation => Unit
+    ): Unit = {
+      val obs = o.getDataObject.asInstanceOf[SPObservation]
+      f(obs)
+      o.setDataObject(obs)
+    }
+
+    "warn if the base position moves out of range of an IFU" in {
+      expectAllOf(CoordinatesOutOfFOVRule.id) {
+        advancedSetup[Ghost](GhostMixin.SP_TYPE) { (_, o, _, _) =>
+          modTargetEnvironment(o) { env =>
+            env.setAsterism(
+              // SFU2 is ~ 230" away from PM corrected base on Jan1_2023
+              GhostAsterism.TargetPlusSky(highPmBase, SPCoordinates.zero, None)
+            )
+          }
+          modObs(o)(_.setSchedulingBlockSome(Jan1_2023))
+        }
+      }
+    }
+
+    "warn if the separation between the IFU probes is not at least 102 arcsec" in {
+      expectAllOf(CoordinatesOutOfFOVRule.id) {
+        advancedSetup[Ghost](GhostMixin.SP_TYPE) { (_, o, _, _) =>
+          modTargetEnvironment(o) { env =>
+            // IFU1 / IFU2 separation just under 102" on Jan1_2023
+            val coords = Coordinates(RightAscension.fromAngle(Angle.fromArcsecs(127)), Declination.zero)
+            env.setAsterism(
+              GhostAsterism.TargetPlusSky(highPmBase, new SPCoordinates(coords), None)
+            )
+          }
+          modObs(o)(_.setSchedulingBlockSome(Jan1_2023))
+        }
+      }
+    }
+
+    "no warning if the separation between the IFU probes over 102 and both are in range of base" in {
+      expectNoneOf(CoordinatesOutOfFOVRule.id) {
+        advancedSetup[Ghost](GhostMixin.SP_TYPE) { (_, o, _, _) =>
+          modTargetEnvironment(o) { env =>
+            // IFU1 / IFU2 separation just under 128" on Jan1_2023
+            val coords = Coordinates(RightAscension.fromAngle(Angle.fromArcsecs(100)), Declination.zero)
+            env.setAsterism(
+              GhostAsterism.TargetPlusSky(highPmBase, new SPCoordinates(coords), None)
+            )
+          }
+          modObs(o)(_.setSchedulingBlockSome(Jan1_2023))
+        }
+      }
+    }
+  }
 
   val AtTheLimit: Double =
     GhostRule.CosmicRayExposureRule.limitSeconds.toDouble

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/obs/SPObservation.java
@@ -344,6 +344,10 @@ public class SPObservation extends AbstractDataObject implements ISPStaffOnlyFie
         }
     }
 
+    public void setSchedulingBlockSome(SchedulingBlock newValue) {
+        setSchedulingBlock(new Some(newValue));
+    }
+
     /**
      * Get the exec status override.
      */

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPCoordinates.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/target/SPCoordinates.scala
@@ -107,4 +107,12 @@ object SPCoordinates {
   val CoordinatesName   = "coordinates"
   val Name = "Sky"
   val Tag = Name
+
+  /**
+   * Makes a new `SPCoordinates` object at (0, 0).  Coordinates are mutable in
+   * SPCoordinates so this must be a `def`.
+   */
+  def zero: SPCoordinates =
+    new SPCoordinates(Coordinates.zero)
+
 }


### PR DESCRIPTION
Adds `pmCorrectedCoordinates` to `GhostTarget` and `pmCorrectedBasePosition` to `Asterism`.  These are unused except in the `GhostRule` as requested.  This is unfortunately confusing for multiple reasons:

* Asking for a target's coordinates takes a time parameter (`when`) which implies that it will be PM corrected.  It is not.  Only sidereal targets use the `when` parameter.
* Fixing the problem above might open Pandora's box, so now there are `pmCorrected` options that also take a time `when` but do in fact use it for sidereal targets.
* Applying proper motion to `GhostRule` coordinate checks will mean that it no longer matches what we plot in the position editor, generating angst. 
