### PR TITLE
REL-3922: non-sidereal target lookup UI event loop issues

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/template/TemplateParametersEditor.scala
@@ -366,7 +366,7 @@ class TemplateParametersEditor(shells: java.util.List[ISPTemplateParameters]) ex
       val nonSiderealNameResolver: NonSiderealNameResolver =
         new NonSiderealNameResolver(
           nonSiderealNameField.peer,
-          (h, n) => HS2.delay(setHorizonsDesignation(h, n))
+          (h, n) => nonSiderealNameResolver.ui.onEDT(setHorizonsDesignation(h, n))
         )
 
       val nonSiderealQueryField = new BoundTextField[String](10)(

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/EphemerisUpdater.scala
@@ -7,7 +7,8 @@ import edu.gemini.pot.sp.{ISPObsComponent, ISPObservation}
 import edu.gemini.skycalc.ObservingNight
 
 import java.util.Date
-import javax.swing.{JRootPane, SwingUtilities}
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.{JOptionPane, JRootPane, SwingUtilities}
 
 import edu.gemini.horizons.server.backend.HorizonsService2._
 import edu.gemini.shared.gui.GlassLabel
@@ -47,6 +48,24 @@ object EphemerisUpdater {
 
     val hide: HS2[Unit] = onEDT {
       glass.foreach(_.hide())
+    }
+
+    def ask(parent: Component, message: String, selectionValues: Array[Object]): Option[Object] = {
+      val ref = new AtomicReference[Object]
+      Swing.onEDTWait {
+        ref.set(
+          JOptionPane.showInputDialog(
+            parent,
+            message,
+            "Horizons Search",
+            JOptionPane.QUESTION_MESSAGE,
+            null, // TODO: icon
+            selectionValues,
+            null
+          )
+        )
+      }
+      Option(ref.get())
     }
 
   }

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameResolver.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameResolver.scala
@@ -60,7 +60,9 @@ final class NonSiderealNameResolver(
     }
 
   val noResults: HS2[Unit] =
-    HS2.delay(DialogUtil.message(name, "No results found."))
+    ui.onEDT {
+      DialogUtil.message(name, "No results found.")
+    }
 
   def manyResults(rs: List[Row[_ <: HorizonsDesignation]]): HS2[Unit] =
     HS2.delay {

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameResolver.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/gemini/editor/targetComponent/details2/NonSiderealNameResolver.scala
@@ -10,7 +10,6 @@ import edu.gemini.spModel.core.{Target, HorizonsDesignation, NonSiderealTarget}
 import edu.gemini.spModel.target.SPTarget
 import jsky.app.ot.gemini.editor.EphemerisUpdater
 
-import javax.swing.JOptionPane
 import javax.swing.text.JTextComponent
 
 import jsky.util.gui.DialogUtil
@@ -41,16 +40,11 @@ final class NonSiderealNameResolver(
       case class Wrapper(unwrap: Search[_ <: HorizonsDesignation]) {
         override def toString = unwrap.productPrefix
       }
-      Option {
-        JOptionPane.showInputDialog(
-          name,
-          "Select the HORIZONS target type:",
-          "Horizons Search",
-          JOptionPane.QUESTION_MESSAGE,
-          null, // TODO: icon
-          List(Comet, Asteroid, MajorBody).map(f => Wrapper(f(name.getText))).toArray[Object],
-          null)
-      } .map(_.asInstanceOf[Wrapper].unwrap)
+      ui.ask(
+        name,
+        "Select the HORIZONS target type:",
+        List(Comet, Asteroid, MajorBody).map(f => Wrapper(f(name.getText))).toArray[Object]
+      ).map(_.asInstanceOf[Wrapper].unwrap)
     }
 
   val search: HS2[Unit] =
@@ -73,16 +67,11 @@ final class NonSiderealNameResolver(
       case class Wrapper(unwrap: Row[_ <: HorizonsDesignation]) {
         override def toString = unwrap.name + " - " + unwrap.a.des
       }
-      Option {
-        JOptionPane.showInputDialog(
-          name,
-          "Multiple results were found. Please disambiguate:",
-          "Horizons Search",
-          JOptionPane.QUESTION_MESSAGE,
-          null, // TODO: icon
-          rs.map(Wrapper).sortBy(_.toString).toArray[Object],
-          null)
-      } .map(_.asInstanceOf[Wrapper].unwrap)
+      ui.ask(
+        name,
+        "Multiple results were found. Please disambiguate:",
+        rs.map(Wrapper).sortBy(_.toString).toArray[Object]
+      ).map(_.asInstanceOf[Wrapper].unwrap)
     } >>= {
       case Some(r) => action(r.a, r.name)
       case None    => ().point[HS2]


### PR DESCRIPTION
Andy reports problems with non-sidereal name resolution hanging occasionally.  He's even had to kill the OT to resolve it.  It works for me, but makes me suspicious that we're mixing in UI updates from non-event loop threads.  We seem to be pretty meticulous about keeping UI updates in the event loop, but I did find one spot where we weren't doing it.  Perhaps this will fix the issue?  Is there a better way?