### PR TITLE
REL-4411: 24B default ObsClass for arcs

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/seqcomp/SeqRepeatFlatObs.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/seqcomp/SeqRepeatFlatObs.java
@@ -225,7 +225,10 @@ public class SeqRepeatFlatObs extends SeqRepeatCoaddExp
     }
 
     public ObsClass getDefaultObsClass() {
-        if (isArc()) return ObsClass.PROG_CAL;
+        // REL-4411: flats and arcs are now both PARTNER CAL.  Any already
+        // created manual flats will have recorded the PROG_CAL obs class,
+        // which is good since we don't want to change executed or existing
+        // observations.
         return ObsClass.PARTNER_CAL;
     }
 

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/seqcomp/SeqRepeatSmartGcalObsCB.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/seqcomp/SeqRepeatSmartGcalObsCB.java
@@ -243,7 +243,7 @@ public abstract class SeqRepeatSmartGcalObsCB implements IConfigBuilder, Cloneab
         } else if (this instanceof Flat) {
             autoObsClass = isBaselineNight ? ObsClass.PARTNER_CAL : ObsClass.PROG_CAL;
         } else if (this instanceof Arc) {
-            autoObsClass = isBaselineNight ? ObsClass.PARTNER_CAL : ObsClass.PROG_CAL;
+            autoObsClass = isBaselineNight ? ObsClass.PARTNER_CAL : DefaultArcObsClass.forNode(seqComponent);
         } else {
             throw new InternalError("unknown node type");
         }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/seqcomp/DefaultArcObsClass.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/seqcomp/DefaultArcObsClass.scala
@@ -1,0 +1,25 @@
+package edu.gemini.spModel.gemini.seqcomp
+
+import edu.gemini.pot.sp.ISPNode
+import edu.gemini.spModel.core.Semester
+import edu.gemini.spModel.obsclass.ObsClass
+import edu.gemini.spModel.rich.core._
+import edu.gemini.spModel.rich.pot.sp._
+
+// REL-4411: The default ObsClass for arcs changed in 24B.  Before it would
+// default to PARTNER_CAL but now should default to PROG_CAL.
+
+object DefaultArcObsClass {
+
+  private val Semester24B: Semester =
+    Semester.parseOptional("2024B").get
+
+  private def uses24BDefault(c: ISPNode): Boolean =
+    Option(c)
+      .flatMap(_.semesterOption)
+      .forall(_ >= Semester24B)
+
+  def forNode(c: ISPNode): ObsClass =
+    if (uses24BDefault(c)) ObsClass.PARTNER_CAL else ObsClass.PROG_CAL;
+
+}

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/RichNode.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/rich/pot/sp/RichNode.scala
@@ -1,7 +1,7 @@
 package edu.gemini.spModel.rich.pot.sp
 
 import edu.gemini.pot.sp.{SPNodeKey, ISPContainerNode, ISPNode}
-import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.core.{ProgramId, SPProgramID, Semester}
 import edu.gemini.spModel.data.ISPDataObject
 
 import scala.annotation.tailrec
@@ -16,6 +16,15 @@ final class RichNode(val node: ISPNode) extends AnyVal {
 
   def pidOption: Option[SPProgramID] =
     Option(node.getProgramID)
+
+  /**
+   * Extracts the semester from the program, if it can be determined from
+   * the program id.
+   */
+  def semesterOption: Option[Semester] =
+    pidOption
+      .map(pid => ProgramId.parse(pid.stringValue))
+      .flatMap(_.semester)
 
   def dataObject: Option[ISPDataObject] = Option(node.getDataObject)
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/BaselineReorderTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/BaselineReorderTest.scala
@@ -3,12 +3,14 @@ package edu.gemini.spModel.gemini.seqcomp
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
 import edu.gemini.spModel.config2.ItemKey
+import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.gemini.calunit.CalUnitParams._
 import edu.gemini.spModel.gemini.flamingos2.Flamingos2
 import org.junit.Assert._
 import org.junit.{Before, Test}
 
 final class BaselineReorderTest extends GcalExecTest {
+  override val progId = SPProgramID.toProgramID("GS-3000A-Q-1")
 
   val observeTypeItem  = new ItemKey("observe:observeType")
 
@@ -23,8 +25,8 @@ final class BaselineReorderTest extends GcalExecTest {
     }
   }
 
-  val flat = CalImpl(Set(Lamp.IR_GREY_BODY_HIGH), Shutter.OPEN,   Filter.ND_20, Diffuser.IR, 1,  4.0, 1, arc = false)
-  val arc  = CalImpl(Set(Lamp.AR_ARC),            Shutter.CLOSED, Filter.NIR,   Diffuser.IR, 1, 15.0, 1, arc = true )
+  val flat = CalImpl(Set(Lamp.IR_GREY_BODY_HIGH), Shutter.OPEN,   Filter.ND_20, Diffuser.IR, 1,  4.0, 1, arc = false, basecalNight = true, basecalDay = true)
+  val arc  = CalImpl(Set(Lamp.AR_ARC),            Shutter.CLOSED, Filter.NIR,   Diffuser.IR, 1, 15.0, 1, arc = true,  basecalNight = true, basecalDay = true)
 
   @Test def testOrderChange(): Unit = {
     locking {

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/CalImpl.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/CalImpl.scala
@@ -16,14 +16,17 @@ final case class CalImpl(lamps: Set[Lamp],
                          observe: Int,
                          exposureTime: Double,
                          coadds: Int,
-                         arc: Boolean) extends Calibration {
+                         arc: Boolean,
+                         basecalNight: Boolean = false,
+                         basecalDay:   Boolean = false
+) extends Calibration {
 
   // Satisfy the Calibration interface
 
   def isFlat: JBoolean               = !isArc
   def isArc: JBoolean                = arc
-  def isBasecalNight: JBoolean       = true
-  def isBasecalDay: JBoolean         = true
+  def isBasecalNight: JBoolean       = basecalNight
+  def isBasecalDay: JBoolean         = basecalDay
 
   def getLamps: java.util.Set[Lamp] = lamps.asJava
   def getObserve: JInteger          = observe

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/GcalExecTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/GcalExecTest.scala
@@ -13,8 +13,9 @@ import java.util.concurrent.locks.ReentrantLock
 
 
 abstract class GcalExecTest extends SpModelTestBase {
-  val progId = SPProgramID.toProgramID("GS-3000A-Q-1")
-  val obsId  = new SPObservationID(progId, 1)
+  def progId: SPProgramID
+
+  def obsId  = new SPObservationID(progId, 1)
 
   def label(num: Int): DatasetLabel    = new DatasetLabel(obsId, num)
   def dataset(num: Int): Dataset       = new Dataset(label(num), "file%d".format(num), System.currentTimeMillis())

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/Post2024BArcTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/Post2024BArcTest.scala
@@ -1,0 +1,17 @@
+package edu.gemini.spModel.gemini.seqcomp
+
+import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.obsclass.ObsClass
+import org.junit.Test
+
+/**
+ * Tests that ARCs default to PARTNER_CAL post-24B.
+ */
+class Post2024BArcTest extends SmartGcalArcObsClassBase {
+  override val progId = SPProgramID.toProgramID("GS-2024B-Q-1")
+
+  @Test def testArcObsClassPost24B() {
+    expect(ObsClass.PARTNER_CAL)
+  }
+
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/Pre2024BArcTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/Pre2024BArcTest.scala
@@ -1,0 +1,25 @@
+package edu.gemini.spModel.gemini.seqcomp
+
+import edu.gemini.spModel.config.ConfigBridge
+import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
+import edu.gemini.spModel.config2.ItemKey
+import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.gemini.calunit.calibration.CalDictionary
+import edu.gemini.spModel.gemini.calunit.CalUnitParams._
+import edu.gemini.spModel.gemini.gnirs.InstGNIRS
+import edu.gemini.spModel.obsclass.ObsClass
+import org.junit.Assert._
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests that ARCs default to PROG_CAL pre-24B.
+ */
+class Pre2024BArcTest extends SmartGcalArcObsClassBase {
+  override val progId = SPProgramID.toProgramID("GS-2024A-Q-1")
+
+  @Test def testArcObsClassPre24B() {
+    expect(ObsClass.PROG_CAL)
+  }
+
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/SmartGcalArcObsClassBase.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/SmartGcalArcObsClassBase.scala
@@ -1,0 +1,45 @@
+package edu.gemini.spModel.gemini.seqcomp
+
+import edu.gemini.spModel.config.ConfigBridge
+import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
+import edu.gemini.spModel.config2.ItemKey
+import edu.gemini.spModel.core.SPProgramID
+import edu.gemini.spModel.gemini.calunit.CalUnitParams._
+import edu.gemini.spModel.gemini.gnirs.InstGNIRS
+import edu.gemini.spModel.obsclass.ObsClass
+import org.junit.Assert._
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Support for testing the obs class setting for arcs.
+ */
+abstract class SmartGcalArcObsClassBase extends GcalExecTest {
+
+  val obsClassItem = new ItemKey("observe:class")
+
+  @Before override def setUp() {
+    super.setUp(progId)
+
+    addObsComponent(InstGNIRS.SP_TYPE)
+    addSeqComponent(getObs.getSeqComponent, SeqRepeatSmartGcalObs.Arc.SP_TYPE)
+  }
+
+  val cal = CalImpl(Set(Lamp.arcLamps().get(0)), Shutter.OPEN, Filter.ND_10, Diffuser.IR, 1, 1.0, 1, arc = true)
+
+  protected def expect(c: ObsClass): Unit = {
+    locking {
+      setupGcal(cal)
+
+      // Generate the sequence.
+      val cs = ConfigBridge.extractSequence(getObs, null, IDENTITY_MAP)
+
+      assertEquals(1, cs.getAllSteps.size)
+
+      val step = cs.getStep(0)
+
+      assertEquals(c, ObsClass.parseType(step.getItemValue(obsClassItem).asInstanceOf[String]))
+    }
+  }
+
+}

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/SmartGcalExecutedStepTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/seqcomp/SmartGcalExecutedStepTest.scala
@@ -3,6 +3,7 @@ package edu.gemini.spModel.gemini.seqcomp
 import edu.gemini.spModel.config.ConfigBridge
 import edu.gemini.spModel.config.map.ConfigValMapInstances.IDENTITY_MAP
 import edu.gemini.spModel.config2.ItemKey
+import edu.gemini.spModel.core.SPProgramID
 import edu.gemini.spModel.gemini.calunit.CalUnitParams._
 import edu.gemini.spModel.gemini.gnirs.InstGNIRS
 import org.junit.Assert._
@@ -12,6 +13,8 @@ import org.junit.{Before, Test}
  * Tests that executed steps don't change even if the mapping changes.
  */
 class SmartGcalExecutedStepTest extends GcalExecTest {
+  override val progId = SPProgramID.toProgramID("GS-3000A-Q-1")
+
   val shutterItem  = new ItemKey("calibration:shutter")
   val diffuserItem = new ItemKey("calibration:diffuser")
 


### PR DESCRIPTION
An embarrassing hack to change the default `OcsClass` for arcs in 2024B and beyond.  It's important to maintain the old default for old programs since the value impacts time accounting, which isn't recorded anywhere but instead recalculated on demand.  So, this is a _wee bit_ sketchy.  To avoid checking when you're asking, we instead check the program id and strip the semester from it.  If the semester is defined and pre-2024B we keep the old default.  Otherwise we use the new default.