### PR TITLE
REL-4390: back off daily sync

### DIFF
--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/PollService.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/app/PollService.scala
@@ -157,7 +157,7 @@ object PollService {
 
   private val Log = Logger.getLogger(getClass.getName)
 
-  def apply(name: String, workerCount: Int)(poll: DmanId => Unit): PollService =
+  def apply(name: String, workerCount: Int, priority: Int)(poll: DmanId => Unit): PollService =
     new PollService {
       val queue = RequestQueue.empty()
 
@@ -190,7 +190,7 @@ object PollService {
       val workers = (0 until (workerCount max 1)).toList.map { n =>
         val threadName = s"$name PollService Worker $n"
         new Thread(new PollRunnable(threadName), threadName) {
-          setPriority(Thread.NORM_PRIORITY - 1)
+          setPriority(priority)
           setDaemon(true)
         }
       }

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/PollServiceSpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/PollServiceSpec.scala
@@ -139,7 +139,7 @@ object PollServiceSpec extends Specification with ScalaCheck with Arbitraries {
       val oids        = (1 to 20).map(i => Obs(new SPObservationID(Q1.pid, i))).toList
       val log         = List.newBuilder[(DmanId, String)]
 
-      val ps = PollService("Test", threadCount) { id =>
+      val ps = PollService("Test", threadCount, Thread.NORM_PRIORITY - 1) { id =>
         // We want to simulate work and give the other poll service thread an
         // opportunity to run.  This is probably a bit sketchy since there is
         // no guarantee that the other thread will actually run.


### PR DESCRIPTION
Reduces the insistency of the daily full database / archive sync, reducing the thread count from 10 to 2 and backing the thread priority down by one.  This was in response to a request from Paul to avoid hitting the FITS servers with too many simultaneous requests.

Because all of the polling was done by shared worker pools, I had to segregate the jobs and put the daily full sync in its own pool.  Because the work is done by a priority queue, with the program sync being the lowest, I then needed to lower the thread priority of the separate daily program sync.