### PR TITLE
REL-4297: add F2 preimaging flag

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -1416,6 +1416,7 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
         configInfo.add(new InstConfigInfo(READMODE_PROP));
         configInfo.add(new InstConfigInfo(LYOT_WHEEL_PROP));
         configInfo.add(new InstConfigInfo(FPU_PROP));
+        configInfo.add(new InstConfigInfo(MOS_PREIMAGING_PROP));
 
         return configInfo;
     }


### PR DESCRIPTION
Adds a "MOS PreImaging" flag to the OT "browser" Flamingos 2 options.