### PR TITLE
REL-4580 (expose obsolete configuration options)

### DIFF
--- a/app/spdb/build.sbt
+++ b/app/spdb/build.sbt
@@ -191,9 +191,9 @@ def rnorris(version: Version) = AppConfig(
   ),
   props = Map(
     "edu.gemini.auxfile.fits.host"               -> "gsconfig.gemini.edu",
-    "edu.gemini.auxfile.root"                    -> "/Users/rnorris/.auxfile",
+    "edu.gemini.auxfile.root"                    -> "/Users/rob.norris/.auxfile",
     "edu.gemini.dataman.gsa.summit.host"         -> "mkofits-lv1new.hi.gemini.edu",
-    "edu.gemini.spdb.dir"                        -> "/Users/rnorris/.spdb/",
+    "edu.gemini.spdb.dir"                        -> "/Users/rob.norris/.spdb/",
     "edu.gemini.util.trpc.name"                  -> "Rob's ODB (Test)",
     "edu.gemini.services.telescope.schedule.id.north"  -> "00h6i49qldh5qrteote4nfhldo@group.calendar.google.com",
     "edu.gemini.services.telescope.schedule.id.south"  -> "c4br8ehtv4i8741jfe4ef5saq8@group.calendar.google.com",

--- a/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Inst.java
+++ b/bundle/edu.gemini.qpt.shared/src/main/java/edu/gemini/qpt/shared/sp/Inst.java
@@ -214,7 +214,7 @@ public enum Inst {
         this.north = north;
         this.south = south;
         this.normallyAvailable = normallyAvailable;
-        this.options = filterNotObsolete(options);
+        this.options = options; // RNC: retain obsolete items to allow mid-semester changes
         this.normallyAvailableOptions = filterNotObsolete(normallyAvailableOptions);
         this.hiddenOptions = hiddenOptions;
         this.guideProbe = null;


### PR DESCRIPTION
This change exposes obsolete configuration options (this can be undone later if desired) so that both of the R400 gratings at GN will be visible in QPT. This will allow for mid-semester switchover without requiring a new QPT release.