### PR TITLE
REL-4448 - Include correct acquisition overheads (Slit or MOS) in GMOS ITC

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
@@ -222,8 +222,13 @@ public final class GmosPrinter extends PrinterBase implements OverheadTablePrint
 
         s += String.format("Amp gain: %s, Amp read mode: %s\n",config.ampGain().displayValue() ,config.ampReadMode().displayValue());
 
-        if (!instrument.getFpMask().equals(GmosNorthType.FPUnitNorth.FPU_NONE) && !instrument.getFpMask().equals(GmosSouthType.FPUnitSouth.FPU_NONE))
-            s += "<LI> Focal Plane Mask: " + instrument.getFpMask().displayValue() + "\n";
+        if (!instrument.getFpMask().equals(GmosNorthType.FPUnitNorth.FPU_NONE) && !instrument.getFpMask().equals(GmosSouthType.FPUnitSouth.FPU_NONE)) {
+            s += "<LI> Focal Plane Mask: " + instrument.getFpMask().displayValue();
+            if (instrument.getFpMask().equals(GmosNorthType.FPUnitNorth.CUSTOM_MASK) ||
+                    instrument.getFpMask().equals(GmosSouthType.FPUnitSouth.CUSTOM_MASK))
+                s += " with " + config.customSlitWidth().get().displayValue() + " slits";
+            s += "\n";
+        }
         s += "\n";
         s += "Region of Interest: " + config.builtinROI().displayValue() + "\n";
         if (p.observation().calculationMethod() instanceof Spectroscopy)

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2024-Oct-06</footer>
+<footer>Last updated 2024-Oct-27</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -250,20 +250,31 @@
 				</td>
 
 				<td>Focal plane unit:
-				<select name="instrumentFPMask" size="1">
-				<option selected="selected" value="FPU_NONE">none</option>
-				<option value="IFU_1">IFU-2</option>
-				<option value="IFU_2">IFU Left Slit (blue)</option>
-				<option value="IFU_3">IFU Right Slit (red)</option>
-                <option value="LONGSLIT_1">0.25 arcsec slit(let)</option>
-                <option value="LONGSLIT_2">0.5 arcsec slit(let)</option>
-				<option value="LONGSLIT_3">0.75 arcsec slit(let)</option>
-				<option value="LONGSLIT_4">1.0 arcsec slit(let)</option>
-				<option value="LONGSLIT_5">1.5 arcsec slit(let)</option>
-				<option value="LONGSLIT_6">2.0 arcsec slit(let)</option>
-				<option value="LONGSLIT_7">5.0 arcsec slit(let)</option>
-				</select></td>
+					<select name="instrumentFPMask" size="1">
+						<option selected="selected" value="FPU_NONE">None (imaging)</option>
+						<option value="IFU_1">IFU-2</option>
+						<option value="IFU_2">IFU Left Slit (blue)</option>
+						<option value="IFU_3">IFU Right Slit (red)</option>
+						<option value="none" disabled></option>
+						<option value="LONGSLIT_1">Long Slit 0.25&Prime;</option>
+						<option value="LONGSLIT_2">Long Slit 0.50&Prime;</option>
+						<option value="LONGSLIT_3">Long Slit 0.75&Prime;</option>
+						<option value="LONGSLIT_4">Long Slit 1.0&Prime;</option>
+						<option value="LONGSLIT_5">Long Slit 1.5&Prime;</option>
+						<option value="LONGSLIT_6">Long Slit 2.0&Prime;</option>
+						<option value="LONGSLIT_7">Long Slit 5.0&Prime;</option>
+						<option value="none" disabled></option>
+						<option value="CUSTOM_WIDTH_0_25">MOS 0.25&Prime; slits</option>
+						<option value="CUSTOM_WIDTH_0_50">MOS 0.50&Prime; slits</option>
+						<option value="CUSTOM_WIDTH_0_75">MOS 0.75&Prime; slits</option>
+						<option value="CUSTOM_WIDTH_1_00">MOS 1.0&Prime; slits</option>
+						<option value="CUSTOM_WIDTH_1_50">MOS 1.5&Prime; slits</option>
+						<option value="CUSTOM_WIDTH_2_00">MOS 2.0&Prime; slits</option>
+						<option value="CUSTOM_WIDTH_5_00">MOS 5.0&Prime; slits</option>
+					</select>
+				</td>
 			</tr>
+
 			<tr>
 				<td colspan="2" height="50" valign="bottom"><b>Detector properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10273#detector','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no');return false"><span>more info</span></a><span>)</span></i></td>
 			</tr>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmosSouth.html
@@ -249,21 +249,33 @@
 
                     </select>
                 </td>
+
                 <td>Focal plane unit:
-                <select name="instrumentFPMask" size="1">
-                <option selected="selected" value="FPU_NONE">none</option>
-                <option value="IFU_1">IFU-2</option>
-                <option value="IFU_2">IFU Left Slit (blue)</option>
-                <option value="IFU_3">IFU Right Slit (red)</option>
-                <option value="LONGSLIT_1">0.25 arcsec slit(let)</option>
-                <option value="LONGSLIT_2">0.5 arcsec slit(let)</option>
-                <option value="LONGSLIT_3">0.75 arcsec slit(let)</option>
-                <option value="LONGSLIT_4">1.0 arcsec slit(let)</option>
-                <option value="LONGSLIT_5">1.5 arcsec slit(let)</option>
-                <option value="LONGSLIT_6">2.0 arcsec slit(let)</option>
-                <option value="LONGSLIT_7">5.0 arcsec slit(let)</option>
-                </select></td>
+                    <select name="instrumentFPMask" size="1">
+                        <option selected="selected" value="FPU_NONE">None (imaging)</option>
+                        <option value="IFU_1">IFU-2</option>
+                        <option value="IFU_2">IFU Left Slit (blue)</option>
+                        <option value="IFU_3">IFU Right Slit (red)</option>
+                        <option value="none" disabled></option>
+                        <option value="LONGSLIT_1">Long Slit 0.25&Prime;</option>
+                        <option value="LONGSLIT_2">Long Slit 0.50&Prime;</option>
+                        <option value="LONGSLIT_3">Long Slit 0.75&Prime;</option>
+                        <option value="LONGSLIT_4">Long Slit 1.0&Prime;</option>
+                        <option value="LONGSLIT_5">Long Slit 1.5&Prime;</option>
+                        <option value="LONGSLIT_6">Long Slit 2.0&Prime;</option>
+                        <option value="LONGSLIT_7">Long Slit 5.0&Prime;</option>
+                        <option value="none" disabled></option>
+                        <option value="CUSTOM_WIDTH_0_25">MOS 0.25&Prime; slits</option>
+                        <option value="CUSTOM_WIDTH_0_50">MOS 0.50&Prime; slits</option>
+                        <option value="CUSTOM_WIDTH_0_75">MOS 0.75&Prime; slits</option>
+                        <option value="CUSTOM_WIDTH_1_00">MOS 1.0&Prime; slits</option>
+                        <option value="CUSTOM_WIDTH_1_50">MOS 1.5&Prime; slits</option>
+                        <option value="CUSTOM_WIDTH_2_00">MOS 2.0&Prime; slits</option>
+                        <option value="CUSTOM_WIDTH_5_00">MOS 5.0&Prime; slits</option>
+                    </select>
+                </td>
             </tr>
+
             <tr>
                 <td colspan="4" height="50" valign="bottom"><b>Detector properties:</b> <i><span>(</span><a href="#" onclick="window.open('http://www.gemini.edu/?q=node/10273#detector','mywindow','width=1000,height=700,toolbar=no,location=no,directories=no,sta tus=no,menubar=no,scrollbars=yes,copyhistory=no,resizable=no'); return false"><span>more info</span></a><span>)</span></i></td>
             </tr>

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -337,8 +337,8 @@ object ITCRequest {
     fpMask match {
       case fpMask if fpMask.startsWith("CUSTOM_WIDTH") =>
         site match {
-          case Site.GN => FPUnitNorth.CUSTOM_MASK
-          case Site.GS => FPUnitSouth.CUSTOM_MASK
+          case Site.GN => FPUnitNorth.CUSTOM_MASK.asInstanceOf[GmosCommonType.FPUnit]
+          case Site.GS => FPUnitSouth.CUSTOM_MASK.asInstanceOf[GmosCommonType.FPUnit]
         }
       case _ =>
         site match {

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -216,11 +216,12 @@ object ITCRequest {
     val specBinning                       = r.intParameter("specBinning")
     val ccdType                           = r.enumParameter(classOf[DetectorManufacturer])
     val centralWl                         = r.centralWavelengthInNanometers()
-    val fpMask: GmosCommonType.FPUnit     = if (site.equals(Site.GN)) r.enumParameter(classOf[FPUnitNorth],    "instrumentFPMask")   else r.enumParameter(classOf[FPUnitSouth],      "instrumentFPMask")
+    val fpMask                            = fpMaskParameters(r)
+    val customSlitWidth                   = customSlitWidthParameters(r)
     val ampGain                           = r.enumParameter(classOf[AmpGain])
     val ampReadMode                       = r.enumParameter(classOf[AmpReadMode])
     val builtinROI                        = r.enumParameter(classOf[GmosCommonType.BuiltinROI])
-    GmosParameters(filter, grating, centralWl, fpMask, ampGain, ampReadMode, None, spatBinning, specBinning, ccdType, builtinROI, site)
+    GmosParameters(filter, grating, centralWl, fpMask, ampGain, ampReadMode, customSlitWidth, spatBinning, specBinning, ccdType, builtinROI, site)
   }
 
   /**
@@ -328,6 +329,34 @@ object ITCRequest {
     val avgStrehl  = r.doubleParameter("avgStrehl") / 100.0
     val strehlBand = r.parameter("strehlBand")
     GemsParameters(avgStrehl, strehlBand)
+  }
+
+  def fpMaskParameters(r: ITCRequest): GmosCommonType.FPUnit = {
+    val site = r.enumParameter(classOf[Site])
+    val fpMask = r.parameter("instrumentFPMask")
+    fpMask match {
+      case fpMask if fpMask.startsWith("CUSTOM_WIDTH") =>
+        site match {
+          case Site.GN => FPUnitNorth.CUSTOM_MASK
+          case Site.GS => FPUnitSouth.CUSTOM_MASK
+        }
+      case _ =>
+        site match {
+          case Site.GN => r.enumParameter(classOf[FPUnitNorth], "instrumentFPMask")
+          case Site.GS => r.enumParameter(classOf[FPUnitSouth], "instrumentFPMask")
+        }
+    }
+  }
+
+  def customSlitWidthParameters(r: ITCRequest): Option[GmosCommonType.CustomSlitWidth] = {
+    val fpMask = r.parameter("instrumentFPMask")
+    fpMask match {
+      case fpMask if fpMask.startsWith("CUSTOM_WIDTH") =>
+        val slitwidth = r.enumParameter(classOf[GmosCommonType.CustomSlitWidth], "instrumentFPMask")
+        some(slitwidth)
+      case _ =>
+        None
+    }
   }
 
   sealed trait CoaddsType

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/InstGmosCommon.java
@@ -449,7 +449,7 @@ public abstract class InstGmosCommon<
         return Optional.ofNullable(conf.getItemValue(FPU_KEY))
                 .map(c -> (GmosCommonType.FPUnit) c)
                 .filter(f -> !f.isImaging())
-                .map(f -> f.isIFU() ? SETUP_TIME_IFU_MOS : SETUP_TIME_LS_SPECTROSCOPY)
+                .map(f -> f.isIFU() | f.isCustom() ? SETUP_TIME_IFU_MOS : SETUP_TIME_LS_SPECTROSCOPY)
                 .orElse(SETUP_TIME_IMAGING);
     }
 


### PR DESCRIPTION
This adds separate options in the GMOS ITC web form for either Long Slit or MOS so that the correct acquisition overhead is given.  The S/N calculations should be unchanged.
