### PR TITLE
REL-4602: Do not add recentering overheads in the IGRINS-2 ITC

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
@@ -156,6 +156,7 @@ public class OverheadTablePrinter {
                     numReacq = 0;
                 }
             }
+            if (instrumentName.equals(SPComponentType.INSTRUMENT_IGRINS2)) numReacq = 0;  // REL-4602
         }
         return numReacq;
     }

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
@@ -156,7 +156,9 @@ public class OverheadTablePrinter {
                     numReacq = 0;
                 }
             }
-            if (instrumentName.equals(SPComponentType.INSTRUMENT_IGRINS2)) numReacq = 0;  // REL-4602
+            if (instrumentName.equals(SPComponentType.INSTRUMENT_IGRINS2)) {
+                numReacq = 0;  // REL-4602: IGRINS-2 does not need re-acquisitions
+            }
         }
         return numReacq;
     }

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2024-Nov-09</footer>
+<footer>Last updated 2024-Nov-14</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/igrins2/Igrins2.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/igrins2/Igrins2.scala
@@ -179,7 +179,7 @@ final class Igrins2 extends ParallacticAngleSupportInst(Igrins2.SP_TYPE)
     Duration.ofSeconds(Igrins2.SetupTime.toSeconds.toLong)
 
   override def getReacquisitionTime(config: Config): Duration =
-    Duration.ofSeconds(Igrins2.SetupTime.toSeconds.toLong)
+    Duration.ofMinutes(5)
 
   override def calc(cur: Config, prev: immutable.Option[Config]): PlannedTime.CategorizedTimeGroup = {
     val times = new java.util.ArrayList[CategorizedTime]()


### PR DESCRIPTION
This is a trivial change to avoid adding re-centering overheads in the IGRINS-2 ITC.  Note that even though it is no longer used, I reset the IGRINS-2 re-acquisition time back to 5 minutes since that had been accidentally set to the acquisition time of 7 minutes.
