### PR TITLE
REL-4619 Use the gemini id to identify grating changes

### DIFF
--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/IctdDatabase.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/IctdDatabase.scala
@@ -1,15 +1,13 @@
 package edu.gemini.ictd
 
 import edu.gemini.spModel.core.Site
-import edu.gemini.spModel.ictd.{ Availability, CustomMaskKey }
-
+import edu.gemini.spModel.ictd.{Availability, CustomMaskKey}
 import doobie.imports._
+import edu.gemini.ictd.service.osgi.IctdServiceImpl
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeMap
-
 import scalaz.effect.IO
-
 
 /** Entry point for clients. Two categories of availability information are
   * obtainable.  One is the availability of custom masks and the other is the
@@ -82,5 +80,13 @@ object IctdDatabase {
     ): java.util.Map[Enum[_], Availability] =
       feature.unsafeSelect(c).availabilityMap(s).asJava
 
+  }
+
+  def main(args: Array[String]): Unit = {
+    val testConf = Configuration.forTesting
+
+    // Uncomment to print GS masks
+    //mask.unsafeSelect(testConf, Site.GS).foreach(println)
+    feature.unsafeSelect(testConf).gmosNorth.dispersers.foreach(println)
   }
 }

--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/dao/FeatureTables.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/dao/FeatureTables.scala
@@ -1,6 +1,5 @@
 package edu.gemini.ictd.dao
 
-import edu.gemini.ictd._
 import shapeless.tag
 import shapeless.tag.@@
 

--- a/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/IctdServiceImpl.scala
+++ b/bundle/edu.gemini.ictd/src/main/scala/edu/gemini/ictd/service/osgi/IctdServiceImpl.scala
@@ -1,14 +1,13 @@
 package edu.gemini.ictd.service.osgi
 
 import java.security.{AccessControlException, Permission, Principal}
-
 import edu.gemini.ictd.IctdDatabase
+import edu.gemini.ictd.IctdDatabase.Configuration
 import edu.gemini.pot.spdb.IDBDatabaseService
 import edu.gemini.spModel.core.Site
 import edu.gemini.spModel.ictd.{IctdService, IctdSummary}
 import edu.gemini.util.security.permission.StaffPermission
 import edu.gemini.util.security.policy.ImplicitPolicy
-
 import scalaz.effect.IO
 
 /**

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosNorthType.java
@@ -71,20 +71,20 @@ public class GmosNorthType {
     public enum DisperserNorth implements GmosCommonType.Disperser, ObsoletableSpType, IctdType {
         // Mirror isn't tracked but is always installed.
         MIRROR(     "Mirror",     "mirror",    0, Ictd.installed()),
-        B1200_G5301("B1200_G5301", "B1200", 1200, Ictd.track("B1200")),
-        R831_G5302(  "R831_G5302",  "R831",  831, Ictd.track("R831")),
+        B1200_G5301("B1200", "B1200", "G5301", 1200),
+        R831_G5302(  "R831",  "R831", "G5302", 831),
         B600_G5303(  "B600_G5303",  "B600",  600, Ictd.unavailable()) {
             @Override public boolean isObsolete() { return true; }
         },
-        B600_G5307(  "B600_G5307",  "B600",  600, Ictd.track("B600")),
-        R600_G5304(  "R600_G5304",  "R600",  600, Ictd.track("R600")),
-        B480_G5309(  "B480_G5309",  "B480",  480, Ictd.track("B480")),
-        R400_G5305(  "R400_G5305",  "R400",  400, Ictd.track("R400")),
-        R400_G5310(  "R400_G5310",  "R400",  400, Ictd.track("R400")),
+        B600_G5307(  "B600",  "B600", "G5307",  600),
+        R600_G5304(  "R600",  "R600", "G5304", 600),
+        B480_G5309(  "B480",  "B480",  "G5309", 480),
+        R400_G5305(  "R400",  "R400", "G5305",  400),
+        R400_G5310(  "R400",  "R400", "G5310",  400),
         R150_G5306(  "R150_G5306",  "R150",  150, Ictd.unavailable()) {
             @Override public boolean isObsolete() { return true; }
         },
-        R150_G5308(  "R150_G5308",  "R150",  150, Ictd.track("R150")),
+        R150_G5308(  "R150", "R150", "G5308",  150),
         ;
 
         /** The default Disperser value **/
@@ -100,6 +100,13 @@ public class GmosNorthType {
             this.logValue      = logValue;
             this.rulingDensity = rulingDensity;     // [lines/mm]
             this.ictd          = ictd;
+        }
+
+        DisperserNorth(final String name, final String logValue, final String geminiID, final int rulingDensity) {
+            this.displayValue  = name + "_" + geminiID;
+            this.logValue      = logValue;
+            this.rulingDensity = rulingDensity;     // [lines/mm]
+            this.ictd          = Ictd.trackWithID(name, geminiID);
         }
 
         public String displayValue() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/gmos/GmosSouthType.java
@@ -72,13 +72,13 @@ public class GmosSouthType {
     public enum DisperserSouth implements GmosCommonType.Disperser, IctdType {
         // Mirror isn't tracked but is always installed.
         MIRROR(     "Mirror",     "mirror",    0, Ictd.installed()),
-        B1200_G5321("B1200_G5321", "B1200", 1200, Ictd.track("B1200")),
-        R831_G5322(  "R831_G5322",  "R831",  831, Ictd.track( "R831")),
-        B600_G5323(  "B600_G5323",  "B600",  600, Ictd.track( "B600")),
-        R600_G5324(  "R600_G5324",  "R600",  600, Ictd.track( "R600")),
-        B480_G5327(  "B480_G5327",  "B480",  480, Ictd.track( "B480")),
-        R400_G5325(  "R400_G5325",  "R400",  400, Ictd.track( "R400")),
-        R150_G5326(  "R150_G5326",  "R150",  150, Ictd.track( "R150")),
+        B1200_G5321("B1200", "B1200", "G5321", 1200),
+        R831_G5322(  "R831",  "R831", "G5322", 831),
+        B600_G5323(  "B600",  "B600", "G5323", 600),
+        R600_G5324(  "R600",  "R600", "G5324", 600),
+        B480_G5327(  "B480",  "B480", "G5327",  480),
+        R400_G5325(  "R400",  "R400", "G5325",  400),
+        R150_G5326(  "R150",  "R150", "G5326",  150),
         ;
 
         /** The default Disperser value **/
@@ -94,6 +94,13 @@ public class GmosSouthType {
             this.logValue      = logValue;
             this.rulingDensity = rulingDensity;
             this.ictd          = ictd;
+        }
+
+        DisperserSouth(final String name, final String logValue, final String geminiID, final int rulingDensity) {
+            this.displayValue  = name + "_" + geminiID;
+            this.logValue      = logValue;
+            this.rulingDensity = rulingDensity;     // [lines/mm]
+            this.ictd          = Ictd.trackWithID(name, geminiID);
         }
 
         public String displayValue() {

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/ictd/IctdType.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/ictd/IctdType.java
@@ -7,7 +7,7 @@ package edu.gemini.spModel.ictd;
 public interface IctdType {
 
     /**
-     * Describes how to termine the availability of the associated instrument
+     * Describes how to determine the availability of the associated instrument
      * feature.
      */
     IctdTracking ictdTracking();

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/Ictd.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/ictd/Ictd.scala
@@ -21,6 +21,9 @@ object Ictd {
   def track(name: String): IctdTracking =
     IctdTracking.track(name)
 
+  def trackWithID(name: String, id: String): IctdTracking =
+    IctdTracking.track(s"${name}_$id")
+
   @annotation.varargs
   def trackAll(name: String, names: String*): IctdTracking =
     IctdTracking.trackAll(name, names: _*)


### PR DESCRIPTION
With the introduction of a new R400 grating for gmos N, the code to query ICTD from the odb needs an adjustment

This is a proposal for a fix that will query grating using both the name and the gemini id.

For completeness other components should follow the same logic but not every component on ICTD has a gemini id,

This was tested with a local db instance and loading the list of available GmosN gratings.