### PR TITLE
REL-4637 Fix IGRINS-2 ITC reporting of Fowler Samples when requesting time to achive a S/N

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/Igrins2Printer.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/Igrins2Printer.java
@@ -48,14 +48,16 @@ public final class Igrins2Printer extends PrinterBase implements OverheadTablePr
         final CalculationMethod calcMethod = p.observation().calculationMethod();
         final SpectroscopyResult result = results[0];
         final double iqAtSource = result.iqCalc().getImageQuality();
+        double exposureTime = recipe.getExposureTime();
+        numberExposures = recipe.getNumberExposures();
         String str;
 
         _println("");
 
-        _println(String.format("Read noise: %.2f e- in %s and %.2f e- in %s using %d Fowler samples.",
-                results[0].instrument().getReadNoise(), ((Igrins2) results[0].instrument()).getWaveBand(),
-                results[1].instrument().getReadNoise(), ((Igrins2) results[1].instrument()).getWaveBand(),
-                ((Igrins2) results[0].instrument()).getFowlerSamples()));
+        _println(String.format("Read noise: %.2f e- in %s, and %.2f e- in %s, using %d Fowler samples.",
+                ((Igrins2) results[0].instrument()).getReadNoise(exposureTime), ((Igrins2) results[0].instrument()).getWaveBand(),
+                ((Igrins2) results[1].instrument()).getReadNoise(exposureTime), ((Igrins2) results[1].instrument()).getWaveBand(),
+                ((Igrins2) results[0].instrument()).getFowlerSamples(exposureTime)));
 
         _println(String.format("Dark current: %.4f e-/s/pix in %s and %.4f e-/s/pix in %s.",
                 results[0].instrument().getDarkCurrent(), ((Igrins2) results[0].instrument()).getWaveBand(),
@@ -64,14 +66,12 @@ public final class Igrins2Printer extends PrinterBase implements OverheadTablePr
         if (result.aoSystem().isDefined()) { _println(HtmlPrinter.printSummary((Altair) result.aoSystem().get())); }
 
         _printSoftwareAperture(result, 1 / mainInstrument.getSlitWidth());
-        _println(String.format("Derived image size(FWHM) for a point source = %.2f arcsec", iqAtSource));
+        _println(String.format("Derived image size (FWHM) for a point source = %.2f arcsec.", iqAtSource));
         _println("");
 
         if (calcMethod instanceof SpectroscopyInt) {
-            double exposureTime = recipe.getExposureTime();
-            numberExposures = recipe.getNumberExposures();
-            if (exposureTime < 5.0) {
-                str = "Total integration time = %.1f seconds (%d x %.1f s), of which %.1f seconds is on source.";
+            if (exposureTime < 10) {
+                str = "Total integration time = %.1f seconds (%d x %.2f s), of which %.1f seconds is on source.";
             } else {
                 str = "Total integration time = %.0f seconds (%d x %.0f s), of which %.0f seconds is on source.";
             }

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2025-Jan-24</footer>
+<footer>Last updated 2025-Jan-30</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2.java
@@ -2,7 +2,6 @@ package edu.gemini.itc.igrins2;
 
 import edu.gemini.itc.base.*;
 import edu.gemini.itc.shared.*;
-import edu.gemini.spModel.core.MagnitudeBand;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.gemini.igrins2.Igrins2$;
 import java.util.ArrayList;
@@ -73,7 +72,17 @@ public class Igrins2 extends Instrument implements SpectroscopyInstrument {
         return Igrins2$.MODULE$.readNoise(exposureTime, _arm.getMagnitudeBand());  // (electrons)
     }
 
+    public double getMinExposureTime() { return Igrins2$.MODULE$.MinExposureTime().toSeconds(); }
+
+    public double getMaxExposureTime() { return Igrins2$.MODULE$.MaxExposureTime().toSeconds(); }
+
+    public double getDefaultExposureTime() { return Igrins2$.MODULE$.DefaultExposureTime().toSeconds(); }
+
     public int getFowlerSamples() { return _fowlerSamples; }
+
+    public int getFowlerSamples(double exposureTime) {
+        return Igrins2$.MODULE$.fowlerSamples(exposureTime);
+    }
 
     public String getDirectory() { return ITCConstants.LIB + "/" + INSTR_DIR; }  // the directory with the data files
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2.java
@@ -2,6 +2,7 @@ package edu.gemini.itc.igrins2;
 
 import edu.gemini.itc.base.*;
 import edu.gemini.itc.shared.*;
+import edu.gemini.spModel.core.MagnitudeBand;
 import edu.gemini.spModel.core.Site;
 import edu.gemini.spModel.gemini.igrins2.Igrins2$;
 import java.util.ArrayList;
@@ -67,6 +68,10 @@ public class Igrins2 extends Instrument implements SpectroscopyInstrument {
 
     @Override
     public double getReadNoise() { return _readNoise; }  // (electrons)
+
+    public double getReadNoise(double exposureTime) {
+        return Igrins2$.MODULE$.readNoise(exposureTime, _arm.getMagnitudeBand());  // (electrons)
+    }
 
     public int getFowlerSamples() { return _fowlerSamples; }
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2Recipe.java
@@ -24,7 +24,7 @@ public final class Igrins2Recipe {
     private final CalculationMethod _calcMethod;
     private double exposureTime;
     private int numberExposures;
-    public static final double MIN_EXPTIME = 1.63;  // seconds
+    private double SnrWavelength;
 
     // Construct an Igrins2Recipe
     public Igrins2Recipe(final ItcParameters p, final Igrins2Parameters instr)
@@ -78,30 +78,24 @@ public final class Igrins2Recipe {
         double readNoise;
         double totalTime;
 
-            Log.fine("calcMethod = " + _calcMethod);
+        Log.fine("calcMethod = " + _calcMethod);
 
-        if (_calcMethod instanceof SpectroscopyS2N) {  // the user has specified exposure time and number of exposures
+        if (_calcMethod instanceof SpectroscopyS2N) {  // user has specified exposure time and number of exposures
             exposureTime = _obsDetailParameters.exposureTime();
             numberExposures = ((SpectroscopyS2N) _calcMethod).exposures();
 
-
-
-
-
         } else if (_calcMethod instanceof SpectroscopyInt) {  // determine the optimal exposure time and number of exposures
-            exposureTime = 600.0;  // these are arbitrary starting points
-            numberExposures = 4;
 
             double desiredSNR = ((SpectroscopyInt) _calcMethod).sigma();
             Log.fine(String.format("desiredSNR = %.2f", desiredSNR));
 
-            double wavelength = ((SpectroscopyInt) _obsDetailParameters.calculationMethod()).wavelength();
-            Log.fine(String.format("Wavelength = %.2f nm", wavelength));
+            SnrWavelength = ((SpectroscopyInt) _obsDetailParameters.calculationMethod()).wavelength() * 1000.;
+            Log.fine(String.format("Wavelength = %.2f nm", SnrWavelength));
 
-            if (Igrins2Arm.H.getWavelengthStart() <= wavelength && wavelength <= Igrins2Arm.H.getWavelengthEnd()) {
+            if (Igrins2Arm.H.getWavelengthStart() <= SnrWavelength && SnrWavelength <= Igrins2Arm.H.getWavelengthEnd()) {
                 instIndex = 0;
                 arm = Igrins2Arm.H;
-            } else if (Igrins2Arm.K.getWavelengthStart() <= wavelength && wavelength <= Igrins2Arm.K.getWavelengthEnd()) {
+            } else if (Igrins2Arm.K.getWavelengthStart() <= SnrWavelength && SnrWavelength <= Igrins2Arm.K.getWavelengthEnd()) {
                 instIndex = 1;
                 arm = Igrins2Arm.K;
             } else {
@@ -111,243 +105,104 @@ public final class Igrins2Recipe {
 
             Igrins2 instrument = _mainInstrument[instIndex];
 
-            double maxFlux = arm.get_maxRecommendedFlux();
-            Log.fine(String.format("maxFlux = %.0f e-", maxFlux));
+            exposureTime = instrument.getDefaultExposureTime();
+            double initialExposureTime = exposureTime;  // remember for when calculating the signal/s and background/s
+            numberExposures = 4;
+            Log.fine(String.format("exposureTime = %.2f sec", exposureTime));
+            Log.fine("numberExposures = " + numberExposures);
 
-            readNoise = instrument.getReadNoise(exposureTime);  // per pixel
-            Log.fine(String.format("Read Noise = %.2f e- (per pixel)", readNoise));
+            Log.fine("Performing an initial run of the ITC to get the signal and background for this target");
+            SpectroscopyResult[] initialResults = new SpectroscopyResult[_mainInstrument.length];
+            for (int i = 0; i < _mainInstrument.length; i++) {
+                initialResults[i] = calculateSpectroscopy(_mainInstrument[i], exposureTime, numberExposures);
+            }
 
-            // Perform an initial run of the ITC to get the signal and background for this target at this wavelength
+            // Find the peak flux in each arm to determine the maximum exposure time
+            double maxExposureTime = instrument.getMaxExposureTime();  // start with the longest allowed time
+            for (SpectroscopyResult r : initialResults) {  // reduce timeToHalfMax based on the peak flux in each arm
+                double maxFlux = r.instrument().maxFlux();
+                Log.fine(String.format("Max recommended flux for this arm = %.0f e-", maxFlux));
+                final SpecS2N s = r.specS2N()[0];
+                double peakFlux = s.getPeakPixelCount();
+                Log.fine(String.format("maxExposureTime for this arm = %.3f sec", maxFlux / 2. / peakFlux * exposureTime));
+                maxExposureTime = Math.min(maxExposureTime, maxFlux / 2. / peakFlux * exposureTime);
+            }
+            Log.fine(String.format("maxExposureTime = %.3f seconds", maxExposureTime));
 
-            double initialExposureTime = 600.;  // the initial input values are arbitrary
-            int initialNumberExposures = 4;
-            Log.fine(String.format("initialExposureTime = %.2f sec", initialExposureTime));
-            Log.fine("initialNumberExposures = " + initialNumberExposures);
+            if (maxExposureTime < instrument.getMinExposureTime()) throw new RuntimeException(String.format(
+                    "This target is too bright for this configuration.\n" +
+                            "The detector will reach half of the linearity limit in %.2f seconds.", maxExposureTime));
 
-            SpectroscopyResult result = calculateSpectroscopy(instrument, initialExposureTime, initialNumberExposures);
-            SpecS2N specS2N = result.specS2N()[0];
-
-            double peakFlux = specS2N.getPeakPixelCount();
-            Log.fine(String.format("peakFlux = %.0f e-", peakFlux));
+            SpecS2N specS2N = initialResults[instIndex].specS2N()[0];
 
             VisitableSampledSpectrum backgroundSpectrum = specS2N.getTotalBackgroundSpectrum();
-            double background = backgroundSpectrum.getY(wavelength);
-            Log.fine(String.format("Background @ %.1f nm = %.2f e- (summed over aperture)", wavelength, background));
+            double background = backgroundSpectrum.getY(SnrWavelength);
+            Log.fine(String.format("Background @ %.1f nm = %.2f e- (summed over aperture)", SnrWavelength, background));
 
             VisitableSampledSpectrum signalSpectrum = specS2N.getTotalSignalSpectrum();
-            double signal = signalSpectrum.getY(wavelength);
-            Log.fine(String.format("Signal @ %.1f nm = %.2f e- (summed over aperture)", wavelength, signal));
+            double signal = signalSpectrum.getY(SnrWavelength);
+            Log.fine(String.format("Signal @ %.1f nm = %.2f e- (summed over aperture)", SnrWavelength, signal));
 
             int numberPixels = specS2N.getSlitLengthPixels();
             Log.fine("Pixels in aperture = " + numberPixels);
-
-            Log.fine(String.format("Read Noise = %.2f e- (per pixel)", instrument.getReadNoise(initialExposureTime)));
-            readNoise = instrument.getReadNoise(initialExposureTime) * instrument.getReadNoise(exposureTime) * numberPixels;
-            Log.fine(String.format("Read Noise = %.2f e- (squared and summed over aperture)", readNoise));
-            //Log.fine(String.format("Read Noise = %.3f e- (from specS2N)", specS2N.getTotalReadNoise()));
 
             double darkNoise = specS2N.getTotalDarkNoise();
             Log.fine(String.format("Dark Current = %.2f e- (summed over aperture)", darkNoise));
 
             // Look up the S/N calculated by the ITC for comparison:
             VisitableSampledSpectrum finalS2NSpectrum = specS2N.getFinalS2NSpectrum();
-            Log.fine(String.format("S/N @ %.1f nm = %.3f e-", wavelength, finalS2NSpectrum.getY(wavelength)));
+            Log.fine(String.format("S/N @ %.1f nm = %.3f", SnrWavelength, finalS2NSpectrum.getY(SnrWavelength)));
 
             // Calculate the S/N and verify that the answer is the same:
-            Log.fine(String.format("Predicted S/N = %.3f e-", calculateSNR(signal, background, darkNoise, readNoise, skyAper, initialNumberExposures)));
+            readNoise = instrument.getReadNoise(exposureTime) * instrument.getReadNoise(exposureTime) * numberPixels;
+            Log.fine(String.format("Predicted S/N = %.3f", calculateSNR(signal, background, darkNoise, readNoise, skyAper, numberExposures)));
 
-            double timeToHalfMax = maxFlux / 2. / peakFlux * initialExposureTime;  // time to reach half the maximum flux
-            Log.fine(String.format("timeToHalfMax = %.2f seconds", timeToHalfMax));
-
-            if (timeToHalfMax < 1.0) throw new RuntimeException(String.format(
-                    "This target is too bright for this configuration.\n" +
-                            "The detector will reach %.0f ADU in %.2f seconds.", maxFlux/2., timeToHalfMax));
-
-            double maxExptime = Math.min(300, (int) timeToHalfMax);
-            Log.fine(String.format("maxExptime = %.2f seconds", maxExptime));
-
-            // Step through each of the read modes and see which works best.
-            List<ReadMode> readModes = Arrays.asList(ReadMode.FAINT_OBJECT_SPEC, ReadMode.MEDIUM_OBJECT_SPEC, ReadMode.BRIGHT_OBJECT_SPEC);
-            for (ReadMode rm : readModes) {
-                readMode = rm;
-                Log.fine("=== Checking " + readMode.toString() + " read mode ===");
-
-                readNoise = readMode.readNoise() * readMode.readNoise() * numberPixels;
-                Log.fine(String.format("Read Noise = %.2f e- (squared and summed)", readNoise));
-                Log.fine(String.format("S/N = %.3f", calculateSNR(signal, background, darkNoise, readNoise, skyAper, initialNumberExposures)));
-
-                exposureTime = calculateExposureTime(signal / initialExposureTime,
-                        background / initialExposureTime, darkNoise / initialExposureTime,
-                        readNoise, skyAper, desiredSNR / Math.sqrt(initialNumberExposures));
-                totalTime = exposureTime * initialNumberExposures;
-                Log.fine(String.format("totalTime = %.2f sec", totalTime));
-
-                // Calculate the optimal number of exposures:
-                numberExposures = (int) Math.ceil(totalTime / maxExptime);
-                if (numberExposures % 4 != 0) {
-                    numberExposures += 4 - numberExposures % 4;  // make a multiple of 4
-                }
-                Log.fine(String.format("numberExposures = %d", numberExposures));
-
-                // Calculate the new exposure time with this number of exposures:
+            int iterations = 0;
+            int oldNumberExposures = -1;
+            double oldExposureTime = -1;
+            while ( (exposureTime != oldExposureTime || numberExposures != oldNumberExposures) && iterations < 10) {
+                Log.fine("Iteration " + iterations + " ----------------");
+                oldNumberExposures = numberExposures;
+                oldExposureTime = exposureTime;
+                readNoise = instrument.getReadNoise(exposureTime) * instrument.getReadNoise(exposureTime) * numberPixels;
                 exposureTime = calculateExposureTime(signal / initialExposureTime,
                         background / initialExposureTime, darkNoise / initialExposureTime,
                         readNoise, skyAper, desiredSNR / Math.sqrt(numberExposures));
-
-                if (exposureTime < readMode.recomendedExpTimeSec()) {  // continue to the next read mode
-                    Log.fine(String.format("This is shorter than recommended (%.1f sec)", readMode.recomendedExpTimeSec()));
-                } else {  // Accept this read mode
-                    break;
-                }
+                totalTime = exposureTime * numberExposures;
+                numberExposures = (int) Math.ceil(totalTime / maxExposureTime);
+                if (numberExposures % 4 != 0) { numberExposures += 4 - numberExposures % 4;}  // make a multiple of 4
+                exposureTime = totalTime / numberExposures;
+                Log.fine(String.format("Iteration %d: -> %d x %.3f sec = %.3f sec (RN=%.2f e-)",
+                        iterations, numberExposures, exposureTime, totalTime, instrument.getReadNoise(exposureTime)));
+                iterations += 1;
             }
 
-            Log.fine("=== The read mode, exposure time, and number of exposures have been decided ===");
-            Log.fine("readMode = " + readMode.toString());
-            Log.fine(String.format("numberExposures = %d", numberExposures));
-            if (exposureTime < readMode.minimumExpTimeSec()) {
-                Log.fine("Reducing exposure time to the minimum allowed for the read mode");
-                exposureTime = readMode.minimumExpTimeSec();
+            Log.fine("Converged");
+            if (exposureTime > 10.) {
+                exposureTime = Math.ceil(exposureTime);  // round long times up to an integer
+            } else {
+                exposureTime = (Math.ceil(exposureTime * 10.0)) / 10.0;  // round short times up to 0.1 sec
             }
-            Log.fine(String.format("exposureTime = %.3f", exposureTime));
+            Log.fine(String.format("Rounded exposureTime = %.2f", exposureTime));
+
+            if (exposureTime < instrument.getMinExposureTime()) {
+                Log.fine("Setting the exposure time to the minimum allowed");
+                exposureTime = instrument.getMinExposureTime();
+            }
+        } else {
+            throw new Error("Unsupported calculation method");
         }
+        Log.fine(String.format("Exposure Time = %.2f", exposureTime));
+        Log.fine("Number of Exposures = " + numberExposures);
 
-        Log.fine("Exposure Time = " + exposureTime);
-        Log.fine("Number Exposures = " + numberExposures);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        // Run the ITC calculations for each arm
         final SpectroscopyResult[] results = new SpectroscopyResult[_mainInstrument.length];
         for (int i = 0; i < _mainInstrument.length; i++) {
+            Log.fine("----- Final run of " + _mainInstrument[i].getArm().getName());
             results[i] = calculateSpectroscopy(_mainInstrument[i], exposureTime, numberExposures);
         }
-
-       if (_calcMethod instanceof SpectroscopyS2N) {
-           return results;
-       } else if (_calcMethod instanceof SpectroscopyInt) {
-           return iterate(results);
-       } else {
-           throw new Error("Unsupported calculation method");
-       }
+        return results;
     }
-
-
-
-
-    private SpectroscopyResult[] iterate(final SpectroscopyResult[] initialResults) {
-
-        // 1. Process both arms to get the peak flux and derive the maximum exposure time.
-        // 2. Figure out which detector includes the wavelength of interest.
-        // 3. Iteratively determine exposureTime & numberExposures that will give the requested S/N at wavelength.
-        // 4. Process all the CCDs using the final exposureTime & numberExposures and return the result.
-
-        final double wavelength = ((SpectroscopyInt) _obsDetailParameters.calculationMethod()).wavelength() * 1000.0;  // where to measure S/N
-        int inst;   // instrument array index that includes the requested wavelength
-        Igrins2Arm arm;
-        if (Igrins2Arm.H.getWavelengthStart() <= wavelength && wavelength <= Igrins2Arm.H.getWavelengthEnd()) {
-            inst = 0;
-            arm = Igrins2Arm.H;
-        } else if (Igrins2Arm.K.getWavelengthStart() <= wavelength && wavelength <= Igrins2Arm.K.getWavelengthEnd()) {
-            inst = 1;
-            arm = Igrins2Arm.K;
-        } else {
-            throw new RuntimeException("The wavelength where the S/N is to be measured is not in the output.");
-        }
-        Log.fine(String.format("Wavelength = %.2f nm is on the %s arm", wavelength, arm.getName()));
-
-        Log.fine("Checking the initial results...");
-        double timeToHalfMax = 600.0;  // start with the longest allowed time
-        double snr = -1.0;
-
-        for (SpectroscopyResult r : initialResults) {  // reduce timeToHalfMax based on the peak flux in each arm
-            double maxFlux = r.instrument().maxFlux();
-            Log.fine("max recommended flux for this arm = " + maxFlux);
-            final SpecS2N s = r.specS2N()[0];
-            double peakFlux = s.getPeakPixelCount();
-            Log.fine("timeToHalfMax for this arm = " + maxFlux / 2. / peakFlux * exposureTime);
-            timeToHalfMax = Math.min(timeToHalfMax, maxFlux / 2. / peakFlux * exposureTime);
-
-            if (((Igrins2) r.instrument()).getArm() == arm) {  // the requested wavelength is here
-                final VisitableSampledSpectrum fins2n = s.getFinalS2NSpectrum();
-                snr = fins2n.getY(wavelength);
-                Log.fine(String.format("S/N @ %.2f nm = %.2f", wavelength, snr));
-            }
-        }
-        Log.fine(String.format("timeToHalfMax = %.2f seconds", timeToHalfMax));
-
-        if (timeToHalfMax < MIN_EXPTIME) throw new RuntimeException(String.format(
-                "This target is too bright for this configuration.\n" +
-                "The optimal exposure time is %.2f seconds which is less than the minimum %.2f.", timeToHalfMax, MIN_EXPTIME));
-
-        double desiredSNR = ((SpectroscopyInt) _calcMethod).sigma();
-        Log.fine(String.format("desiredSNR = %.2f", desiredSNR));
-
-        int iterations = 0;
-        double maxExptime = timeToHalfMax;
-        int oldNumberExposures = 0;
-        double oldExposureTime = 0.0;
-        final SpectroscopyResult[] finalResults = new SpectroscopyResult[_mainInstrument.length];
-
-        while ((numberExposures != oldNumberExposures || exposureTime != oldExposureTime) && iterations <= 5) {
-            iterations += 1;
-            Log.fine(String.format("--- ITERATION %d (%d != %d) or (%.3f != %.3f) ---",
-                    iterations, oldNumberExposures, numberExposures, oldExposureTime, exposureTime));
-            oldNumberExposures = numberExposures;
-            oldExposureTime = exposureTime;
-            // Estimate the time required to achieve the requested S/N assuming S/N scales as sqrt(t):
-            double totalTime = exposureTime * numberExposures * (desiredSNR / snr) * (desiredSNR / snr);
-            Log.fine(String.format("totalTime = %.2f", totalTime));
-            numberExposures = (int) Math.ceil(totalTime / maxExptime);
-            Log.fine(String.format("numberExposures = %d (raw)", numberExposures));
-
-            if (numberExposures % 4 != 0) { numberExposures += 4 - numberExposures % 4; }  // force multiple of 4 exposures
-            Log.fine(String.format("numberExposures = %d (as multiple of 4)", numberExposures));
-
-            if ((totalTime / numberExposures) > 5.0) {
-                exposureTime = Math.ceil(totalTime / numberExposures);  // round long exposure times up to an integer
-            } else {
-                exposureTime = (Math.ceil(totalTime / numberExposures * 10.0)) / 10.0; // round short times up to 0.1 sec
-            }
-            if (exposureTime < MIN_EXPTIME) { exposureTime = MIN_EXPTIME; }
-            Log.fine(String.format("exposureTime = %.3f", exposureTime));
-
-            if ((numberExposures != oldNumberExposures || exposureTime != oldExposureTime) && iterations <= 5) {
-                // Try one more iteration to see if we can get closer to the requested S/N
-
-                // only recalculate the arm with the wavelength where the S/N is being measured
-                final SpectroscopyResult newResult = calculateSpectroscopy(_mainInstrument[inst], exposureTime, numberExposures, snr);
-                final VisitableSampledSpectrum fins2n = newResult.specS2N()[0].getFinalS2NSpectrum();
-                snr = fins2n.getY(wavelength);
-                Log.fine(String.format("Iteration %d: %d x %.2f sec -> S/N @ %.2f nm = %.2f",
-                        iterations, numberExposures, exposureTime, wavelength, snr));
-
-            } else {
-                if (iterations > 5) {
-                    Log.fine("--- STOPPING and calculating the results for all detectors");
-                } else {
-                    Log.fine("--- NO CHANGE since the last iteration, so calculating final results");
-                }
-                for (int i = 0; i < _mainInstrument.length; i++) {
-                    finalResults[i] = calculateSpectroscopy(_mainInstrument[i], exposureTime, numberExposures, snr);
-                }
-            }
-        }
-        return finalResults;
-    }
-
 
     private SpectroscopyResult calculateSpectroscopy(
             Igrins2 instrument,
@@ -356,15 +211,6 @@ public final class Igrins2Recipe {
             {
 
         Log.fine("Calculating from " + instrument.getWavelengthStart() + " to " + instrument.getWavelengthEnd() + " nm");
-
-        double readNoise = instrument.getReadNoise(exposureTime);  // per pixel
-        Log.fine(String.format("Read Noise = %.2f e- (per pixel)", readNoise));
-
-        // Calculate the total ReadNoise in the aperture:
-
-        // How many pixels are in the aperture???
-
-
 
         // Module 1b
         // Define the source energy (as function of wavelength).
@@ -400,7 +246,6 @@ public final class Igrins2Recipe {
         final Slit slit = Slit$.MODULE$.apply(_sdParameters, _obsDetailParameters, instrument, instrument.getSlitWidth(), IQcalc.getImageQuality());
         final SlitThroughput throughput = new SlitThroughput(_sdParameters, slit, im_qual);
 
-
         Log.fine(String.format("Read Noise = %.2f e- (per pixel)", instrument.getReadNoise(exposureTime)));
 
         Log.fine("Creating specS2N...");
@@ -424,12 +269,45 @@ public final class Igrins2Recipe {
         calcSource.sed.accept(specS2N);
 
         final SpecS2N[] specS2Narr = new SpecS2N[]{specS2N};
+
+        VisitableSampledSpectrum finalS2NSpectrum = specS2N.getFinalS2NSpectrum();
+        double snr = finalS2NSpectrum.getY(SnrWavelength);
+        Log.fine(String.format("S/N @ %.1f nm = %.3f", SnrWavelength, snr));
+
         return new SpectroscopyResult(p, instrument, IQcalc, specS2Narr, slit, throughput.throughput(), altair,
-                //Option.apply(new ExposureCalculation(exposureTime, numberExposures, snr)
-                Option.empty());
+                Option.apply(new ExposureCalculation(exposureTime, numberExposures, snr)));
+    }
+
+    private double calculateSNR(double signal, double background, double darkNoise, double readNoise, double skyAper, int numberExposures) {
+        final double noiseFactor = 1. + (1. / skyAper);
+        return Math.sqrt(numberExposures) * signal / Math.sqrt(signal + noiseFactor * (background + darkNoise + readNoise));
+    }
+
+    /**
+     * Calculate the exposure time required to achieve a desired Signal-to-Noise on a single frame.
+     * @param signal The signal per second summed over the pixels in the aperture.
+     * @param background The background per second summed over the pixels in the aperture.
+     * @param darkNoise The dark current per second summed over the pixels in the aperture.
+     * @param readNoise The squared read noise summed over the pixels in the aperture.
+     * @param skyAper
+     * @param SNR The desired Signal-to-Noise Ratio.
+     * @return The exposure time in seconds.
+     */
+    private double calculateExposureTime(double signal, double background, double darkNoise, double readNoise, double skyAper, double SNR) {
+        final double f = 1. + (1. / skyAper);  // noise factor
+        // SNR = S / sqrt(S + f(B + D + R)) = st / sqrt(st + f(bt + dt + R)) = x
+        // This can be expressed as a quadratic equation:  (ss/xx)t^2 - (s + fb + fd)t - fR = 0
+        // and solved using the quadratic formula: t = (-b + sqrt(b^2 - 4ac)) / 2a
+        double a = signal * signal / (SNR * SNR);
+        double b = -(signal + f * background + f * darkNoise);
+        double c = -f * readNoise;
+        double exposureTime = (-b + Math.sqrt(b*b - 4.*a*c)) / (2.*a);
+        Log.fine(String.format("exposureTime = %.3f", exposureTime));
+        return exposureTime;
     }
 
     public double getExposureTime() { return exposureTime; }
+
     public int getNumberExposures() { return numberExposures; }
 
 }


### PR DESCRIPTION
This PR fixes a bug  where the number of Fowler samples and read noise was derived from the exposure time set in the web form even though the user had asked for the integration time to achieve a S/N.  This also optimizes the calculations so that only 2 iterations (per arm) are required.