### PR TITLE
REL-4651: Fix ITC bug in calculation of minimum emission line width

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2025-Jan-30</footer>
+<footer>Last updated 2025-Feb-15</footer>
 </body>
 </html>


### PR DESCRIPTION
This fixes a typo (misplaced parenthesis on line 85) in the ITC calculation of the minimum emission line width.