### PR TITLE
REL-4667: IGRINS-2 updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "ocs"
 organization in Global := "edu.gemini.ocs"
 
 // true indicates a test release, and false indicates a production release
-ocsVersion in ThisBuild := OcsVersion("2025A", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2025B", true, 1, 1, 1)
 
 pitVersion in ThisBuild := OcsVersion("2025B", false, 2, 1, 1)
 

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/igrins2/Igrins2Recipe.java
@@ -47,10 +47,10 @@ public final class Igrins2Recipe {
 
     private void validateInputParameters() {
         if (_calcMethod instanceof SpectroscopyS2N) {
-            if (_obsDetailParameters.exposureTime() < 1.63) {
-                throw new IllegalArgumentException("The minimum exposure time is 1.63 seconds.");
-            } else if (_obsDetailParameters.exposureTime() > 1800) {
-                throw new IllegalArgumentException("The maximum exposure time is 1800 seconds.");
+            if (_obsDetailParameters.exposureTime() < _mainInstrument[0].getMinExposureTime()) {
+                throw new IllegalArgumentException("The minimum exposure time is " + _mainInstrument[0].getMinExposureTime() + " seconds.");
+            } else if (_obsDetailParameters.exposureTime() > _mainInstrument[0].getMaxExposureTime()) {
+                throw new IllegalArgumentException("The maximum exposure time is " + _mainInstrument[0].getMaxExposureTime() + " seconds.");
             }
         }
         Validation.validate(_mainInstrument[0], _obsDetailParameters, _sdParameters);  // other general validations

--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/Igrins2Spec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/Igrins2Spec.scala
@@ -17,7 +17,7 @@ object Igrins2Spec extends RuleSpec {
     "not warn if instrument component exposure time is in range" in {
       expectNoneOf(Igrins2Rule.ExposureTimeRule.TooShort) {
         advancedSetup[Igrins2](Igrins2Mixin.SP_TYPE) { (_, _, g, _) =>
-          g.setExposureTime(2.0)
+          g.setExposureTime(4.0)
         }
       }
     }

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/igrins2/Igrins2.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/igrins2/Igrins2.scala
@@ -238,7 +238,7 @@ object Igrins2 {
   assert(AllowedFowlerSamples.forall(FowlerSamplesReadoutTime.contains))
 
   def fowlerSamples(expTime: Time): Int = {
-    val nFowler = ((expTime.toSeconds + 1.45479 - 0.168)/1.45479).toInt  // REL-4667
+    val nFowler = ((expTime.toSeconds - 1.45479 - 0.168)/1.45479).toInt  // REL-4667
     AllowedFowlerSamples.reverse.find(cur => nFowler >= cur).getOrElse(AllowedFowlerSamples.head)
   }
 

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/igrins2/Igrins2.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/gemini/igrins2/Igrins2.scala
@@ -33,7 +33,6 @@ import java.beans.PropertyDescriptor
 import java.time.Duration
 import scala.collection.immutable.TreeMap
 import scala.collection.JavaConverters._
-import scala.math.sqrt
 
 /*
  ** The Igrins2 instrument SP model.
@@ -224,7 +223,7 @@ object Igrins2 {
   val SetupTime: Time = 7.minutes // REL-4531
   val DefaultExposureTime: Time = 30.seconds // sec (by default settings)
 
-  val MinExposureTime: Time = 1.63.seconds
+  val MinExposureTime: Time = 3.08.seconds  // REL-4667
   val MaxExposureTime: Time = 600.seconds
 
   val WavelengthCoverageLowerBound: Wavelength = Wavelength.fromMicrons(1.49)
@@ -232,14 +231,14 @@ object Igrins2 {
 
   val AllowedFowlerSamples: List[Int] = List(1, 2, 4, 8, 16)
 
-  // REL-4531
+  // REL-4531 and updated in REL-4667
   val FowlerSamplesReadoutTime: Map[Int, Time] =
-    Map(1 -> 10.0.seconds, 2 -> 12.8.seconds, 4 -> 17.4.seconds, 8 -> 25.3.seconds, 16 -> 41.seconds)
+    Map(1 -> 8.5.seconds, 2 -> 11.3.seconds, 4 -> 16.0.seconds, 8 -> 24.0.seconds, 16 -> 39.5.seconds)
 
   assert(AllowedFowlerSamples.forall(FowlerSamplesReadoutTime.contains))
 
   def fowlerSamples(expTime: Time): Int = {
-    val nFowler = ((expTime.toSeconds - 0.168)/1.45479).toInt
+    val nFowler = ((expTime.toSeconds + 1.45479 - 0.168)/1.45479).toInt  // REL-4667
     AllowedFowlerSamples.reverse.find(cur => nFowler >= cur).getOrElse(AllowedFowlerSamples.head)
   }
 

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/igrins2/FowlerCalcTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/igrins2/FowlerCalcTest.scala
@@ -5,20 +5,18 @@ import org.junit.Test
 import squants.time.TimeConversions.TimeConversions
 
 /**
- * Test cases for the observing wavelength calculation.
+ * Test cases for the Fowler samples calculation.
  */
 class FowlerCalcTest {
 
   @Test def testCalculation(): Unit = {
-    assertEquals(1, Igrins2.fowlerSamples(0.seconds))
-    assertEquals(1, Igrins2.fowlerSamples(1.63.seconds))
-    assertEquals(2, Igrins2.fowlerSamples(5.seconds))
-    assertEquals(4, Igrins2.fowlerSamples(8.seconds))
-    assertEquals(4, Igrins2.fowlerSamples(10.seconds))
-    assertEquals(4, Igrins2.fowlerSamples(11.80631.seconds))
-    assertEquals(8, Igrins2.fowlerSamples(11.80632.seconds))
-    assertEquals(8, Igrins2.fowlerSamples(23.4446.seconds))
-    assertEquals(16, Igrins2.fowlerSamples(23.4447.seconds))
+    assertEquals(2, Igrins2.fowlerSamples(3.08.seconds))
+    assertEquals(2, Igrins2.fowlerSamples(4.53236.seconds))
+    assertEquals(4, Igrins2.fowlerSamples(4.53237.seconds))
+    assertEquals(4, Igrins2.fowlerSamples(10.35152.seconds))
+    assertEquals(8, Igrins2.fowlerSamples(10.35153.seconds))
+    assertEquals(8,  Igrins2.fowlerSamples(21.98984.seconds))
+    assertEquals(16, Igrins2.fowlerSamples(21.98985.seconds))
     assertEquals(16, Igrins2.fowlerSamples(1299.seconds))
   }
 }

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/igrins2/FowlerCalcTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/gemini/igrins2/FowlerCalcTest.scala
@@ -10,13 +10,15 @@ import squants.time.TimeConversions.TimeConversions
 class FowlerCalcTest {
 
   @Test def testCalculation(): Unit = {
-    assertEquals(2, Igrins2.fowlerSamples(3.08.seconds))
-    assertEquals(2, Igrins2.fowlerSamples(4.53236.seconds))
-    assertEquals(4, Igrins2.fowlerSamples(4.53237.seconds))
-    assertEquals(4, Igrins2.fowlerSamples(10.35152.seconds))
-    assertEquals(8, Igrins2.fowlerSamples(10.35153.seconds))
-    assertEquals(8,  Igrins2.fowlerSamples(21.98984.seconds))
-    assertEquals(16, Igrins2.fowlerSamples(21.98985.seconds))
+    assertEquals(1, Igrins2.fowlerSamples(3.08.seconds))
+    assertEquals(1, Igrins2.fowlerSamples(4.53236.seconds))
+    assertEquals(2, Igrins2.fowlerSamples(4.53237.seconds))
+    assertEquals(2, Igrins2.fowlerSamples(7.44194.seconds))
+    assertEquals(4, Igrins2.fowlerSamples(7.44195.seconds))
+    assertEquals(4, Igrins2.fowlerSamples(13.26110.seconds))
+    assertEquals(8, Igrins2.fowlerSamples(13.26111.seconds))
+    assertEquals(8,  Igrins2.fowlerSamples(24.89942.seconds))
+    assertEquals(16, Igrins2.fowlerSamples(24.89943.seconds))
     assertEquals(16, Igrins2.fowlerSamples(1299.seconds))
   }
 }


### PR DESCRIPTION
A few minor IGRINS-2 updates:
1. Update the minimum exposure time from 1.63 to 3.08.
2. Update the Fowler sampling equation to: N_Fowler = int((T_exp +1.45479 - 0.168)/1.45479)
3. Update overheads for Fowler Sampling [1, 2, 4, 8, 16] to {8.5, 11.3, 16.0, 24.0, 39.5}
