### PR TITLE
REL-4509 Add P2 check for GMOS-N observations with E2V

### DIFF
--- a/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/GmosSpec.scala
+++ b/bundle/edu.gemini.p2checker/src/test/scala/edu/gemini/p2checker/rules/GmosSpec.scala
@@ -13,16 +13,16 @@ final class GmosSpec extends RuleSpec {
 
   val ruleSet = new GmosRule()
 
-  // === REL-2143: Don't allow E2V CCDs for GMOS-S programs after 2014A.
-  "No E2V for GMOS-S after 2014A rule" should {
+  // === REL-4509: Don't allow E2V CCDs.
+  "No E2V for GMOS" should {
 
     import GmosCommonType.DetectorManufacturer._
     import SPComponentType._
 
-    val E2VErrId = "GmosRule_POST_2014A_GMOS_S_WITH_E2V_RULE"
+    val E2VErrId = "GmosRule_POST_2014A_GMOS_WITH_E2V_RULE"
 
-    "give no error for unknown semester with E2V" in {
-      expectNoneOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH) { d =>
+    "give an error for unknown semester with E2V" in {
+      expectAllOf(E2VErrId) { setup[InstGmosSouth](INSTRUMENT_GMOSSOUTH) { d =>
         d.setDetectorManufacturer(E2V)
       }}
     }
@@ -69,8 +69,8 @@ final class GmosSpec extends RuleSpec {
       }}
     }
 
-    "not affect GMOS-N for semester 2015A with E2V" in {
-      expectNoneOf(E2VErrId) { setup[InstGmosNorth](INSTRUMENT_GMOS, "GN-2015A-Q-34") { d =>
+    "give an error for GMOS-N for semester 2015A with E2V" in {
+      expectAllOf(E2VErrId) { setup[InstGmosNorth](INSTRUMENT_GMOS, "GN-2015A-Q-34") { d =>
         d.setDetectorManufacturer(E2V)
       }}
     }

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/EdCompInstGMOS.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/gmos/EdCompInstGMOS.java
@@ -199,8 +199,11 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
         _w.ccdSlowHighButton.addActionListener(this);
         _w.ccdFastHighButton.addActionListener(this);
         _w.ccd3AmpButton.addActionListener(this);
+        _w.ccd3AmpButton.setEnabled(false);
         _w.ccd6AmpButton.addActionListener(this);
+        _w.ccd6AmpButton.setEnabled(false);
         _w.ccd12AmpButton.addActionListener(this);
+        _w.ccd12AmpButton.setEnabled(false);
         _w.transFollowXYButton.addActionListener(this);
         _w.transFollowXYZButton.addActionListener(this);
         _w.transFollowZButton.addActionListener(this);
@@ -453,6 +456,7 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
             _w.centralSpectrumButton.setText("Central Spectrum: spectroscopy of central 75\" FOV");
             _w.centralStampButton.setText("Central Stamp: 22\" x 22\" imaging FOV");
             _w.customButton.setText("Custom ROI");
+            _w.detectorManufacturerComboBox.setEnabled(true); // Only allow to ever change from E2V to Hammamatsu
         } else {// HAMAMATSU:
             if (OTOptions.isStaff(getProgram().getProgramID())) {
                 _w.ccd3AmpButton.setVisible(false);
@@ -463,6 +467,7 @@ public abstract class EdCompInstGMOS<T extends InstGmosCommon> extends EdCompIns
                 _w.ccd6AmpButton.setVisible(false);
                 _w.ccd12AmpButton.setVisible(false);
             }
+            _w.detectorManufacturerComboBox.setEnabled(false); // Only allow to ever change from E2V to Hammamatsu
             _w.noROIButton.setText("Full Frame Readout");
             _w.ccd2Button.setText("CCD2: 2.75' x 5.5' imaging FOV");
             _w.centralSpectrumButton.setText("Central Spectrum: spectroscopy of central 80\" FOV");


### PR DESCRIPTION
you can still copy paste an old program using gmos e2v

A phase 2 check will indicate that this is not allowed, and you should change it to Hammamatsu. 

The UI now only lets you ever change from E2V to Hammamatsu 