### PR TITLE
REL-2501 "obsoleting" Y filter that was never purchased.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/flamingos2/Flamingos2.java
@@ -139,7 +139,11 @@ public final class Flamingos2 extends ParallacticAngleSupportInst
                 return true;
             }
         },
-        Y("Y (1.02 um)", "Y", new Some<>(1.02),                   Ictd.track("Y")),
+        Y("Y (1.02 um)", "Y", new Some<>(1.02),                   Ictd.unavailable()) {
+            @Override public boolean isObsolete() { //REL-2501 - This filter was never purchased....
+                return true;
+            }
+        },
         F1056("F1056 (1.056 um)", "F1056", new Some<>(1.056),     Ictd.unavailable()) {
             @Override public boolean isObsolete() {
                 return true;


### PR DESCRIPTION
Making the F2 Y filter obsolete. REL-2501 requested this `Y` filter and `F1056`  and `F1063` to be hidden - but the last two were taken care in REL-3561