### PR TITLE
REL-4638 v2: F2 ITC calculation of exposure time & number of exposures to achieve S/N

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2025-Feb-24</footer>
+<footer>Last updated 2025-May-29</footer>
 </body>
 </html>


### PR DESCRIPTION
This includes some minor updates:
- update the maximum allowed counts from 50% to 60% of the linearity limit
- increase the maximum exposure time from 300s to 600s
- limit the maximum number of exposures to 1000