### PR TITLE
REL-4638: F2 ITC calculation of exposure time & number of exposures to achieve S/N

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2025-May-29</footer>
+<footer>Last updated 2025-Jun-01</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -147,8 +147,8 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
             // Calculate the S/N and verify that the answer is the same:
             Log.fine(String.format("Predicted S/N = %.3f e-", calculateSNR(signal, background, darkNoise, readNoise, skyAper, initialNumberExposures)));
 
-            // The maximum exposure time is that which gives 60% of the maximum allowed flux, up to a maximum of 600s:
-            double maxExposureTime = Math.min(600, 0.6 * maxFlux / peakFlux * initialExposureTime);
+            // The maximum exposure time is that which gives 60% of the maximum allowed flux, up to a maximum of 900s:
+            double maxExposureTime = Math.min(900, 0.6 * maxFlux / peakFlux * initialExposureTime);
             Log.fine(String.format("maxExposureTime = %.2f seconds", maxExposureTime));
 
             // If the maximum exposure time for this target + configuration is less than the minimum then throw an error:


### PR DESCRIPTION
This is a minor tweak to increase the F2 maximum spectroscopic exposure time to 900s when requesting S/N.  This change will only affect the web ITC (not the OT).