### PR TITLE
Make GHOST central wavelength a constant

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
@@ -140,9 +140,8 @@ object ConfigExtractor {
       binning       <- extract[GhostBinning]      (c, BinningKey)
       resolution    <- extract[ResolutionMode]    (c, InsResolution)
       nSkyMicrolens <- extract[Int]               (c, InsNskyMicrolens)
-      wavelen       <- extractObservingWavelength(c)
       camera         = GhostCameraParameters(readMode, binning)
-    } yield GhostParameters(wavelen, nSkyMicrolens, resolution, camera, camera)
+    } yield GhostParameters(nSkyMicrolens, resolution, camera, camera)
   }
 
   private def extractGmos(c: Config): String \/ GmosParameters = {

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/InstrumentDetails.scala
@@ -42,11 +42,13 @@ final case class GhostCameraParameters(
                      }
 
 final case class GhostParameters(
-                     centralWavelength: Wavelength,
                      nSkyMicrolens    : Int,
                      resolution       : ResolutionMode,
                      redCamera        : GhostCameraParameters,
-                     blueCamera       : GhostCameraParameters) extends InstrumentDetails
+                     blueCamera       : GhostCameraParameters) extends InstrumentDetails {
+                      val centralWavelength: Wavelength = Wavelength.fromNanometers(530)
+                     }
+    
 
 final case class GmosParameters(
                      filter:            GmosCommonType.Filter,

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCghost.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCghost.html
@@ -213,9 +213,6 @@
                     <input value="GhostStandard" name="instResolution" id="stdRes" type="radio" checked="checked"/> Standard Resolution
                     <input value="GhostHigh" name="instResolution" id="highRes" type="radio" /> High Resolution
                 </td>
-                <td colspan="1" style="visibility:hidden">Spectrum central wavelength:
-                    <input name="instrumentCentralWavelength" size="5" value="530" type="text" /> nm
-                </td>
 
             </tr>
             <tr>

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/ITCRequest.scala
@@ -200,7 +200,6 @@ object ITCRequest {
   def ghostParameters(r: ITCRequest): GhostParameters = {
 
     val binning       = r.enumParameter(classOf[GhostBinning],"binning")
-    val centralWl     = r.centralWavelengthInNanometers()
     val blueReadMode  = r.enumParameter(classOf[GhostReadNoiseGain], "BlueReadMode")
     val redReadMode   = r.enumParameter(classOf[GhostReadNoiseGain], "RedReadMode")
     val resolution    = r.enumParameter(classOf[ResolutionMode],"instResolution")
@@ -228,7 +227,7 @@ object ITCRequest {
     val blueCamera    = GhostCameraParameters(blueReadMode, binning, Some(blueCalcMethod))
     val redCamera     = GhostCameraParameters(redReadMode, binning, Some(redCalcMethod))
 
-    GhostParameters(centralWl, nSkyMicrolens, resolution, redCamera = redCamera, blueCamera = blueCamera)
+    GhostParameters(nSkyMicrolens, resolution, redCamera = redCamera, blueCamera = blueCamera)
   }
 
   def gmosParameters(r: ITCRequest): GmosParameters = {

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/json/InstrumentDetailsCodec.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/json/InstrumentDetailsCodec.scala
@@ -211,9 +211,8 @@ trait InstrumentDetailsCodec {
      )
 
   private implicit val GhostParametersCodec: CodecJson[GhostParameters] =
-    casecodec5(GhostParameters.apply, GhostParameters.unapply)(
-      "centralWavelength",
-      "nSkyMicroLens",
+    casecodec4(GhostParameters.apply, GhostParameters.unapply)(
+      "nSkyMicrolens",
       "resolution",
       "blueCamera",
       "redCamera"

--- a/bundle/edu.gemini.itc.web/src/test/scala/edu/gemini/itc/web/arb/ArbInstrumentDetails.scala
+++ b/bundle/edu.gemini.itc.web/src/test/scala/edu/gemini/itc/web/arb/ArbInstrumentDetails.scala
@@ -165,12 +165,11 @@ trait ArbInstrumentDetails {
 
   val genGhostParameters: Gen[GhostParameters] =
     for {
-      centralWavelength  <- arbitrary[Wavelength]
       nSkyMicroLens      <- arbitrary[Int]
       resolution         <- arbitrary[ResolutionMode]
       blueCamera         <- genGhostCameraParameters
       redCamera          <- genGhostCameraParameters
-    } yield GhostParameters(centralWavelength, nSkyMicroLens, resolution, blueCamera, redCamera)
+    } yield GhostParameters(nSkyMicroLens, resolution, blueCamera, redCamera)
 
   val genInstrumentDetails: Gen[InstrumentDetails] =
     Gen.oneOf(


### PR DESCRIPTION
It turns out the central wavelength for GHOST was hardcoded as a hidden parameter in the html file and treated as a variable in GhostParameters. Since the central wavelength for GHOST is a fixed value, I made it a constant in GhostParameters and removed it from the web page and the JSON interface.