### PR TITLE
Fix ghost charts

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/ghost/GHostRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/ghost/GHostRecipe.java
@@ -43,67 +43,76 @@ public final class GHostRecipe implements SpectroscopyArrayRecipe {
     }
 
     public ItcSpectroscopyResult serviceResult(final SpectroscopyResult[] r, final boolean headless) {
+        return serviceResult(r, headless, false);
+    }
+        
+    public ItcSpectroscopyResult serviceResult(final SpectroscopyResult[] r, final boolean headless, final boolean forGPP) {
         final List<List<SpcChartData>> groups = new ArrayList<>();
-        final List<SpcChartData> combined = new ArrayList<SpcChartData>();
         List<VisitableSampledSpectrum> listPerResElement = new ArrayList<VisitableSampledSpectrum>();
         for (SpectroscopyResult r1 : r) {
             final List<SpcChartData> dataSets1 = new ArrayList<SpcChartData>();
             dataSets1.add(Recipe$.MODULE$.createSignalChart(r1, 0));
             dataSets1.add(Recipe$.MODULE$.createS2NChart(r1, "Single Exposure and Final S/N in aperture per pixel", 0));
-            VisitableSampledSpectrum finalS2N = (VisitableSampledSpectrum) r1.specS2N()[0].getFinalS2NSpectrum().clone();
-            Ghost inst = (Ghost) r1.instrument();
-            inst.transPerResolutionElement(finalS2N);
-            VisitableSampledSpectrum singleS2N = (VisitableSampledSpectrum) r1.specS2N()[0].getExpS2NSpectrum().clone();
-            inst.transPerResolutionElement(singleS2N);
-            dataSets1.add(Recipe$.MODULE$.createS2NChartPerRes(singleS2N, finalS2N,
+            if (!forGPP) {
+                VisitableSampledSpectrum finalS2N = (VisitableSampledSpectrum) r1.specS2N()[0].getFinalS2NSpectrum().clone();
+                Ghost inst = (Ghost) r1.instrument();
+                inst.transPerResolutionElement(finalS2N);
+                VisitableSampledSpectrum singleS2N = (VisitableSampledSpectrum) r1.specS2N()[0].getExpS2NSpectrum().clone();
+                inst.transPerResolutionElement(singleS2N);
+                dataSets1.add(Recipe$.MODULE$.createS2NChartPerRes(singleS2N, finalS2N,
+                        "Single Exposure and Final S/N in aperture per resolution Element",
+                        ITCChart.DarkGreen, ITCChart.DarkRed));
+                listPerResElement.add(singleS2N);
+                listPerResElement.add(finalS2N);
+            }
+            groups.add(dataSets1);
+        }
+
+        if (!forGPP) {
+            // This part creates a single graph to include the blue and red band.
+            // This last graph is the one shown as the final result in the Ghost Web result.
+            VisitableSampledSpectrum singleS2NCombPerRes = (VisitableSampledSpectrum) listPerResElement.get(2).clone();
+            VisitableSampledSpectrum finalS2NSpecCombPerRes = (VisitableSampledSpectrum) listPerResElement.get(3).clone();
+            VisitableSampledSpectrum sigSpectrumComb = (VisitableSampledSpectrum) r[1].specS2N()[0].getSignalSpectrum().clone();
+            VisitableSampledSpectrum backGroundSpectComb = (VisitableSampledSpectrum) r[1].specS2N()[0].getBackgroundSpectrum().clone();
+            VisitableSampledSpectrum expS2NComb = (VisitableSampledSpectrum) r[1].specS2N()[0].getExpS2NSpectrum().clone();
+            VisitableSampledSpectrum finalS2NSpecComb = (VisitableSampledSpectrum) r[1].specS2N()[0].getFinalS2NSpectrum().clone();
+            int indexWV = r[0].specS2N()[0].getSignalSpectrum().getLowerIndex(WAVELENGTH_BLUE_END);
+            for (int i = 0; i <= indexWV; ++i) {
+                sigSpectrumComb.setY(i, r[0].specS2N()[0].getSignalSpectrum().getY(i));
+                backGroundSpectComb.setY(i, r[0].specS2N()[0].getBackgroundSpectrum().getY(i));
+                expS2NComb.setY(i, r[0].specS2N()[0].getExpS2NSpectrum().getY(i));
+                finalS2NSpecComb.setY(i, r[0].specS2N()[0].getFinalS2NSpectrum().getY(i));
+                singleS2NCombPerRes.setY(i, listPerResElement.get(0).getY(i));
+                finalS2NSpecCombPerRes.setY(i, listPerResElement.get(1).getY(i));
+            }
+
+            final List<SpcChartData> combined = new ArrayList<SpcChartData>();
+            combined.add(Recipe$.MODULE$.createSignalChart(sigSpectrumComb, "Signal",
+                    backGroundSpectComb, "SQRT(Background)",
+                    "Signal & SQRT(Background) in one pixel"));
+
+            combined.add(Recipe$.MODULE$.createS2NChart(expS2NComb, finalS2NSpecComb,
+                    "Single Exp S/N", "Final S/N  ",
+                    "Signal / Noise per spectral pixel"
+                    ));
+
+            combined.add(Recipe$.MODULE$.createS2NChartPerRes(singleS2NCombPerRes, finalS2NSpecCombPerRes,
                     "Single Exposure and Final S/N in aperture per resolution Element",
                     ITCChart.DarkGreen, ITCChart.DarkRed));
-            groups.add(dataSets1);
-            listPerResElement.add(singleS2N);
-            listPerResElement.add(finalS2N);
+            groups.add(combined);
         }
-        // This part creates a single graph to include the blue and red band.
-        // This last graph is the one shown as the final result in the Ghost Web result.
-        VisitableSampledSpectrum singleS2NCombPerRes = (VisitableSampledSpectrum) listPerResElement.get(2).clone();
-        VisitableSampledSpectrum finalS2NSpecCombPerRes = (VisitableSampledSpectrum) listPerResElement.get(3).clone();
-        VisitableSampledSpectrum sigSpectrumComb = (VisitableSampledSpectrum) r[1].specS2N()[0].getSignalSpectrum().clone();
-        VisitableSampledSpectrum backGroundSpectComb = (VisitableSampledSpectrum) r[1].specS2N()[0].getBackgroundSpectrum().clone();
-        VisitableSampledSpectrum expS2NComb = (VisitableSampledSpectrum) r[1].specS2N()[0].getExpS2NSpectrum().clone();
-        VisitableSampledSpectrum finalS2NSpecComb = (VisitableSampledSpectrum) r[1].specS2N()[0].getFinalS2NSpectrum().clone();
-        int indexWV = r[0].specS2N()[0].getSignalSpectrum().getLowerIndex(WAVELENGTH_BLUE_END);
-        for (int i = 0; i <= indexWV; ++i) {
-            sigSpectrumComb.setY(i, r[0].specS2N()[0].getSignalSpectrum().getY(i));
-            backGroundSpectComb.setY(i, r[0].specS2N()[0].getBackgroundSpectrum().getY(i));
-            expS2NComb.setY(i, r[0].specS2N()[0].getExpS2NSpectrum().getY(i));
-            finalS2NSpecComb.setY(i, r[0].specS2N()[0].getFinalS2NSpectrum().getY(i));
-            singleS2NCombPerRes.setY(i, listPerResElement.get(0).getY(i));
-            finalS2NSpecCombPerRes.setY(i, listPerResElement.get(1).getY(i));
-        }
+    return Recipe$.MODULE$.serviceGroupedResult(r, groups, headless);
+}
 
-        combined.add(Recipe$.MODULE$.createSignalChart(sigSpectrumComb, "Signal",
-                backGroundSpectComb, "SQRT(Background)",
-                "Signal & SQRT(Background) in one pixel"));
+public SpectroscopyResult[] calculateSpectroscopy() {
+    int length = _mainInstrument.length;
 
-        combined.add(Recipe$.MODULE$.createS2NChart(expS2NComb, finalS2NSpecComb,
-                "Single Exp S/N", "Final S/N  ",
-                "Signal / Noise per spectral pixel"
-                ));
-
-        combined.add(Recipe$.MODULE$.createS2NChartPerRes(singleS2NCombPerRes, finalS2NSpecCombPerRes,
-                "Single Exposure and Final S/N in aperture per resolution Element",
-                ITCChart.DarkGreen, ITCChart.DarkRed));
-        groups.add(combined);
-        return Recipe$.MODULE$.serviceGroupedResult(r, groups, headless);
-    }
-
-    public SpectroscopyResult[] calculateSpectroscopy() {
-        int length = _mainInstrument.length;
-
-        // Need to build integration times list for for both cameras because the serviceResult methods
-        // discards all but the first one.
-        List<IntegrationTime> allCalculations = new ArrayList<>();
-        for (int i = 0; i < length; i++) {
-            final SpectroscopyS2N calcMethod = getSpectroscopyS2N(_mainInstrument[i].getCamera());
+    // Need to build integration times list for for both cameras because the serviceResult methods
+    // discards all but the first one.
+    List<IntegrationTime> allCalculations = new ArrayList<>();
+    for (int i = 0; i < length; i++) {
+        final SpectroscopyS2N calcMethod = getSpectroscopyS2N(_mainInstrument[i].getCamera());
             allCalculations.add(new IntegrationTime(calcMethod.exposureTime(), calcMethod.exposures()));
         }
         // Not sure what to use for this. IGRINS2 selects this based on wavelength.

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/base/Recipe.scala
@@ -139,20 +139,20 @@ object Recipe {
   // === Java helpers
 
   // One result (CCD) and a simple set of charts, this covers most cases.
-  def serviceResult(r: SpectroscopyResult, charts: JList[SpcChartData], includeCharts: Boolean): ItcSpectroscopyResult = {
+  def serviceResult(r: SpectroscopyResult, charts: JList[SpcChartData], excludeCharts: Boolean): ItcSpectroscopyResult = {
     ItcSpectroscopyResult(
       List(toCcdData(r, charts.toList)),
-      if (includeCharts) Nil else List(SpcChartGroup(charts.toList)),
+      if (excludeCharts) Nil else List(SpcChartGroup(charts.toList)),
       r.times,
       r.signalToNoiseAt
     )
   }
 
   // One result (CCD) and a set of groups of charts, this covers NIFS (1 CCD and separate groups for IFU cases).
-  def serviceGroupedResult(r: SpectroscopyResult, charts: JList[JList[SpcChartData]], includeCharts: Boolean): ItcSpectroscopyResult = {
+  def serviceGroupedResult(r: SpectroscopyResult, charts: JList[JList[SpcChartData]], excludeCharts: Boolean): ItcSpectroscopyResult = {
     ItcSpectroscopyResult(
       List(toCcdData(r, charts.toList.flatten)),
-      if (includeCharts) Nil else charts.toList.map(l => SpcChartGroup(l.toList)),
+      if (excludeCharts) Nil else charts.toList.map(l => SpcChartGroup(l.toList)),
       r.times,
       r.signalToNoiseAt
     )
@@ -160,14 +160,14 @@ object Recipe {
 
   // A set of results and a set of groups of charts, this covers GMOS (3 CCDs and potentially separate groups
   // for IFU cases, if IFU is activated).
-  def serviceGroupedResult(rs: Array[SpectroscopyResult], charts: JList[JList[SpcChartData]], includeCharts: Boolean): ItcSpectroscopyResult = {
+  def serviceGroupedResult(rs: Array[SpectroscopyResult], charts: JList[JList[SpcChartData]], excludeCharts: Boolean): ItcSpectroscopyResult = {
     val snAtArray = rs.flatMap(_.signalToNoiseAt)
     // if all the snAt ar empty it means we are out of range, so return none
     // else filter out the ones containing 0 and return the first. If none is over 0 just return the first.
     val snAt = snAtArray.find(_.finalSignalToNoise > 0).orElse(snAtArray.headOption)
     ItcSpectroscopyResult(
       rs.map(r => toCcdData(r, charts.toList.flatten)).toList,
-      if (includeCharts) Nil else charts.toList.map(l => SpcChartGroup(l.toList)),
+      if (excludeCharts) Nil else charts.toList.map(l => SpcChartGroup(l.toList)),
       rs.map(_.times).headOption.getOrElse(AllIntegrationTimes.empty),
       snAt
     )

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -66,7 +66,7 @@ class ItcServiceImpl extends ItcService {
     // execute ITC service call with updated parameters
     p.observation.calculationMethod match {
       case _: Imaging       => ItcResult.forMessage ("Imaging not implemented.")
-      case _: Spectroscopy  => calculateSpectroscopyCharts(p)
+      case _: Spectroscopy  => calculateSpectroscopy(p, excludeCharts = false)
     }
 
   } catch {
@@ -104,43 +104,36 @@ class ItcServiceImpl extends ItcService {
 
   // === Spectroscopy
 
-  private def calculateSpectroscopy(p: ItcParameters, includeCharts: Boolean): Result =
+  private def calculateSpectroscopy(p: ItcParameters, excludeCharts: Boolean): Result =
     p.instrument match {
-      case i: Flamingos2Parameters        => spectroscopyResult   (new Flamingos2Recipe(p, i),               includeCharts)
-      case i: GmosParameters              => spectroscopyResult   (new GmosRecipe(p, i),                     includeCharts)
-      case i: GnirsParameters             => spectroscopyResult   (new GnirsRecipe(p, i),                    includeCharts)
-      case i: NifsParameters              => spectroscopyResult   (new NifsRecipe(p, i),                     includeCharts)
-      case i: NiriParameters              => spectroscopyResult   (new NiriRecipe(p, i),                     includeCharts)
-      case i: Igrins2Parameters           => spectroscopyResult   (new Igrins2Recipe(paramsInMicrons(p), i), includeCharts)
-      case i: GhostParameters             => spectroscopyResult   (new GHostRecipe(p, i),                    includeCharts)
+      case i: Flamingos2Parameters        => spectroscopyResult   (new Flamingos2Recipe(p, i),               excludeCharts)
+      case i: GmosParameters              => spectroscopyResult   (new GmosRecipe(p, i),                     excludeCharts)
+      case i: GnirsParameters             => spectroscopyResult   (new GnirsRecipe(p, i),                    excludeCharts)
+      case i: NifsParameters              => spectroscopyResult   (new NifsRecipe(p, i),                     excludeCharts)
+      case i: NiriParameters              => spectroscopyResult   (new NiriRecipe(p, i),                     excludeCharts)
+      case i: Igrins2Parameters           => spectroscopyResult   (new Igrins2Recipe(paramsInMicrons(p), i), excludeCharts)
+      case i: GhostParameters             => ghostSpectroscopyResult(new GHostRecipe(p, i),                    excludeCharts)
       case _                              => ItcResult.forMessage (s"Spectroscopy with this instrument: ${p.instrument} is not supported by ITC.")
 
     }
 
-  // === Spectroscopy
-
-  private def calculateSpectroscopyCharts(p: ItcParameters): Result =
-    p.instrument match {
-      case i: GmosParameters              => spectroscopyResult(new GmosRecipe(p, i),                     includeCharts = false)
-      case i: Flamingos2Parameters        => spectroscopyResult(new Flamingos2Recipe(p, i),               includeCharts = false)
-      case i: GnirsParameters             => spectroscopyResult(new GnirsRecipe(p, i),                    includeCharts = false)
-      case i: NifsParameters              => spectroscopyResult(new NifsRecipe(p, i),                     includeCharts = false)
-      case i: NiriParameters              => spectroscopyResult(new NiriRecipe(p, i),                     includeCharts = false)
-      case i: Igrins2Parameters           => spectroscopyResult(new Igrins2Recipe(paramsInMicrons(p), i), includeCharts = false)
-      case i: GhostParameters             => spectroscopyResult(new GHostRecipe(p, i),                    includeCharts = false)
-      case _                              => ItcResult.forMessage (s"Spectroscopy with this instrument: ${p.instrument} is not supported by ITC.")
-
-    }
-  private def spectroscopyResult(recipe: SpectroscopyRecipe, includeCharts: Boolean): Result = {
+  private def spectroscopyResult(recipe: SpectroscopyRecipe, excludeCharts: Boolean): Result = {
     val r = recipe.calculateSpectroscopy()
-    val s = recipe.serviceResult(r, includeCharts)
+    val s = recipe.serviceResult(r, excludeCharts)
     ItcResult.forResult(s)
   }
 
-  private def spectroscopyResult(recipe: SpectroscopyArrayRecipe, includeCharts: Boolean): Result = {
+  private def spectroscopyResult(recipe: SpectroscopyArrayRecipe, excludeCharts: Boolean): Result = {
     val r = recipe.calculateSpectroscopy()
-    val s = recipe.serviceResult(r, includeCharts)
+    val s = recipe.serviceResult(r, excludeCharts)
     ItcResult.forResult(s)
+  }
+
+  private def ghostSpectroscopyResult(recipe: GHostRecipe, excludeCharts: Boolean): Result = {
+    val r = recipe.calculateSpectroscopy()
+    // we use a special method to not produce S2NChartPerRes charts or the combined charts.
+    val s = recipe.serviceResult(r, excludeCharts, true)
+    ItcResult.forResult(s.copy(chartGroups = s.chartGroups.take(2)))
   }
 
   // The web page has the fields in microns and they are passed directly as doubles so the recipe expects micros

--- a/bundle/edu.gemini.json/src/main/scala/edu/gemini/json/CoproductCodec.scala
+++ b/bundle/edu.gemini.json/src/main/scala/edu/gemini/json/CoproductCodec.scala
@@ -26,7 +26,7 @@ trait CoproductCodec {
   class CoproductCodec[A] private { prev =>
 
     def encode(a: A): Json =
-      sys.error("Can't encode. No case was provided for $a.")
+      sys.error(s"Can't encode. No case was provided for $a.")
 
     def decode(c: HCursor): DecodeResult[A] =
       DecodeResult.fail[A]("Invalid tagged type", c.history)


### PR DESCRIPTION
GHOST was returning some chart enums we didn't have encoders for. Since we don't need those in GPP I just don't generate those charts for GPP. This also goes one step of the way toward decreasing the size of the data we throw over the wall to GPP.

NOTE: I think ignoring whitespace changes will probably greatly reduce the size of the diff...