### PR TITLE
Round the ITC graph data returned from the JSONServlet to 6 sigfigs

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -122,6 +122,11 @@ final case class SpcSeriesData(dataType: SpcDataType, title: String, data: Array
     ssdCopy
   }
 
+  def withSignificantFigures(n: Int): SpcSeriesData = {
+    val roundedData = data.map(_.map(d => SpcSeriesData.roundToSignificantFigures(BigDecimal(d), n)))
+    this.copy(data = roundedData)
+  }
+
   override def equals(other: Any): Boolean =
     other match {
       case SpcSeriesData(`dataType`, `title`, arr, `color`) =>
@@ -137,6 +142,23 @@ object SpcSeriesData {
   def withVisibility(visibility: Boolean, dataType: SpcDataType, title: String, data: Array[Array[Double]], color: Option[Color] = None): SpcSeriesData = {
     val ssd = new SpcSeriesData(dataType, title, data, color)
     ssd.withLegendVisibility(visibility)
+  }
+
+  import scala.math._
+
+  // Round the value to n significant figures, this to remove
+  // the extra precision produced by ITC calculations using doubles
+  // This will not work for extremely small numbers but we don't expect such
+  def roundToSignificantFigures(num: BigDecimal, n: Int): Double = {
+    if (num == 0) 0
+    else {
+      val d     = ceil(log10(abs(num.toDouble)))
+      val power = n - d.toInt
+
+      val magnitude = pow(10, power)
+      val shifted   = round(num.toDouble * magnitude)
+      shifted / magnitude
+    }
   }
 }
 
@@ -206,6 +228,11 @@ final case class ItcSpectroscopyResult(ccds: List[ItcCcd], chartGroups: List[Spc
     * This method will fail if the result (chart/data) you're looking for does not exist.
     */
   def allSeries(ct: SpcChartType, dt: SpcDataType): List[SpcSeriesData] = chart(ct).allSeries(dt)
+
+  def withSignificantFigures(n: Int): ItcSpectroscopyResult = {
+    val reducedCharts = chartGroups.map(g => g.copy(charts = g.charts.map(c => c.copy(series = c.series.map(_.withSignificantFigures(n))))))
+    this.copy(chartGroups = reducedCharts)
+  }
 
 }
 

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -120,20 +120,20 @@ class ItcServiceImpl extends ItcService {
   private def spectroscopyResult(recipe: SpectroscopyRecipe, excludeCharts: Boolean): Result = {
     val r = recipe.calculateSpectroscopy()
     val s = recipe.serviceResult(r, excludeCharts)
-    ItcResult.forResult(s)
+    ItcResult.forResult(s.withSignificantFigures(6))
   }
 
   private def spectroscopyResult(recipe: SpectroscopyArrayRecipe, excludeCharts: Boolean): Result = {
     val r = recipe.calculateSpectroscopy()
     val s = recipe.serviceResult(r, excludeCharts)
-    ItcResult.forResult(s)
+    ItcResult.forResult(s.withSignificantFigures(6))
   }
 
   private def ghostSpectroscopyResult(recipe: GHostRecipe, excludeCharts: Boolean): Result = {
     val r = recipe.calculateSpectroscopy()
     // we use a special method to not produce S2NChartPerRes charts or the combined charts.
     val s = recipe.serviceResult(r, excludeCharts, true)
-    ItcResult.forResult(s.copy(chartGroups = s.chartGroups.take(2)))
+    ItcResult.forResult(s.copy(chartGroups = s.chartGroups.take(2)).withSignificantFigures(6))
   }
 
   // The web page has the fields in microns and they are passed directly as doubles so the recipe expects micros


### PR DESCRIPTION
There are timeout issues with the ghost charts because there is so much more data than for the other modes. This PR will greatly reduce the size of the serialized data and hopefully will reduce the time to serialize/deserialize a bit. How much is uncertain since the `number` of data points to serialize/deserialize remains the same. I'm hoping we can get away with this for now and can optimize further when we have that mythical more time.

I discussed with Andy and he said 6 significant figures is plenty for any instrument in both GPP and the OT.