### PR TITLE
[itc] only return y-data and axis information for charts to GPP

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -122,11 +122,6 @@ final case class SpcSeriesData(dataType: SpcDataType, title: String, data: Array
     ssdCopy
   }
 
-  def withSignificantFigures(n: Int): SpcSeriesData = {
-    val roundedData = data.map(_.map(d => SpcSeriesData.roundToSignificantFigures(BigDecimal(d), n)))
-    this.copy(data = roundedData)
-  }
-
   override def equals(other: Any): Boolean =
     other match {
       case SpcSeriesData(`dataType`, `title`, arr, `color`) =>
@@ -228,11 +223,6 @@ final case class ItcSpectroscopyResult(ccds: List[ItcCcd], chartGroups: List[Spc
     * This method will fail if the result (chart/data) you're looking for does not exist.
     */
   def allSeries(ct: SpcChartType, dt: SpcDataType): List[SpcSeriesData] = chart(ct).allSeries(dt)
-
-  def withSignificantFigures(n: Int): ItcSpectroscopyResult = {
-    val reducedCharts = chartGroups.map(g => g.copy(charts = g.charts.map(c => c.copy(series = c.series.map(_.withSignificantFigures(n))))))
-    this.copy(chartGroups = reducedCharts)
-  }
 
 }
 

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/json/ItcResultCodec.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/json/ItcResultCodec.scala
@@ -3,15 +3,21 @@ package edu.gemini.itc.web.json
 import argonaut._, Argonaut._
 import edu.gemini.itc.shared._
 
-trait ItcResultCodec {
+// Extending ItcSpectroscopyResultCodec means:
+//   1. The default SpcSeriesDataCodec val is always available for callers that
+//      don't supply a custom one.
+//   2. ItcSpectroscopyResultCodec (the implicit def) is inherited, so the isr
+//      parameter below resolves automatically without extra imports by callers.
+trait ItcResultCodec extends ItcSpectroscopyResultCodec {
   import edu.gemini.json.coproduct._
   import itcimagingresult._
-  import itcspectroscopyresult._
 
-  implicit val ItcResultDecodeJson: CodecJson[ItcResult] =
+  // implicit def (not val) so that isr — and transitively sds — are resolved
+  // at the call site of asJson, not at object-initialisation time.
+  implicit def ItcResultDecodeJson(implicit isr: CodecJson[ItcSpectroscopyResult]): CodecJson[ItcResult] =
     CoproductCodec[ItcResult]
-      .withCase("ItcImagingResult",      ItcImagingResultCodec)      { case a: ItcImagingResult      => a }
-      .withCase("ItcSpectroscopyResult", ItcSpectroscopyResultCodec) { case a: ItcSpectroscopyResult => a }
+      .withCase("ItcImagingResult",      ItcImagingResultCodec) { case a: ItcImagingResult      => a }
+      .withCase("ItcSpectroscopyResult", isr)                   { case a: ItcSpectroscopyResult => a }
       .asCodecJson
 
 }

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/json/ItcSpectroscopyResultCodec.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/json/ItcSpectroscopyResultCodec.scala
@@ -13,6 +13,7 @@ trait ItcSpectroscopyResultCodec {
     CoproductCodec[SpcChartType]
       .withCase("SignalChart",      constCodec(SignalChart))      { case SignalChart      => SignalChart }
       .withCase("S2NChart",         constCodec(S2NChart))         { case S2NChart         => S2NChart }
+      .withCase("S2NChartPerRes",   constCodec(S2NChartPerRes))   { case S2NChartPerRes   => S2NChartPerRes }
       .withCase("SignalPixelChart", constCodec(SignalPixelChart)) { case SignalPixelChart => SignalPixelChart }
       .asCodecJson
 
@@ -29,17 +30,21 @@ trait ItcSpectroscopyResultCodec {
       "range"
     )
 
-  private implicit val SpcDataTypeCodec: CodecJson[SpcDataType] =
+  implicit val SpcDataTypeCodec: CodecJson[SpcDataType] =
     CoproductCodec[SpcDataType]
-      .withCase("SignalData", constCodec(SignalData)) { case SignalData => SignalData }
-      .withCase("BackgroundData", constCodec(BackgroundData)) { case BackgroundData => BackgroundData }
-      .withCase("SingleS2NData", constCodec(SingleS2NData)) { case SingleS2NData => SingleS2NData }
-      .withCase("FinalS2NData", constCodec(FinalS2NData)) { case FinalS2NData => FinalS2NData }
-      .withCase("PixSigData", constCodec(PixSigData)) { case PixSigData => PixSigData }
-      .withCase("PixBackData", constCodec(PixBackData)) { case PixBackData => PixBackData }
+      .withCase("SignalData",         constCodec(SignalData))         { case SignalData         => SignalData }
+      .withCase("BackgroundData",     constCodec(BackgroundData))     { case BackgroundData     => BackgroundData }
+      .withCase("SingleS2NData",      constCodec(SingleS2NData))      { case SingleS2NData      => SingleS2NData }
+      .withCase("FinalS2NData",       constCodec(FinalS2NData))       { case FinalS2NData       => FinalS2NData }
+      .withCase("PixSigData",         constCodec(PixSigData))         { case PixSigData         => PixSigData }
+      .withCase("PixBackData",        constCodec(PixBackData))        { case PixBackData        => PixBackData }
+      .withCase("FinalS2NPerResEle",  constCodec(FinalS2NPerResEle))  { case FinalS2NPerResEle  => FinalS2NPerResEle }
+      .withCase("SingleS2NPerResEle", constCodec(SingleS2NPerResEle)) { case SingleS2NPerResEle => SingleS2NPerResEle }
       .asCodecJson
 
-  private implicit val SpcSeriesDataCodec: CodecJson[SpcSeriesData] =
+  // Default used by the OT. Callers can shadow this with a local implicit
+  // to customise encoding (e.g. for GPP).
+  implicit val SpcSeriesDataCodec: CodecJson[SpcSeriesData] =
     casecodec4(SpcSeriesData.apply, SpcSeriesData.unapply)(
       "dataType",
       "title",
@@ -47,29 +52,34 @@ trait ItcSpectroscopyResultCodec {
       "color"
     )
 
-  private implicit val SpcChartDataCodec: CodecJson[SpcChartData] =
-    casecodec6(SpcChartData.apply, SpcChartData.unapply)(
-      "chartType",
-      "title",
-      "xAxis",
-      "yAxis",
-      "series",
-      "axes"
-    )
-
-  private implicit val SpcChartGroupCodec: CodecJson[SpcChartGroup] =
-    casecodec1(SpcChartGroup.apply, SpcChartGroup.unapply)(
-      "charts"
-    )
-
-
-  val ItcSpectroscopyResultCodec: CodecJson[ItcSpectroscopyResult] =
+  // implicit def so that the SpcSeriesData codec — and the entire chart-data chain —
+  // is resolved at the outermost call site rather than at object-init time.
+  //
+  // The parameter is deliberately named `SpcSeriesDataCodec` so it shadows the
+  // inherited val of the same name inside this method body. That way there is
+  // exactly one candidate for CodecJson[SpcSeriesData] in scope here (the param),
+  // and Argonaut's list-codec derivation has no ambiguity to resolve.
+  implicit def ItcSpectroscopyResultCodec(implicit SpcSeriesDataCodec: CodecJson[SpcSeriesData]): CodecJson[ItcSpectroscopyResult] = {
+    implicit val SpcChartDataCodec: CodecJson[SpcChartData] =
+      casecodec6(SpcChartData.apply, SpcChartData.unapply)(
+        "chartType",
+        "title",
+        "xAxis",
+        "yAxis",
+        "series",
+        "axes"
+      )
+    implicit val SpcChartGroupCodec: CodecJson[SpcChartGroup] =
+      casecodec1(SpcChartGroup.apply, SpcChartGroup.unapply)(
+        "charts"
+      )
     casecodec4(ItcSpectroscopyResult.apply, ItcSpectroscopyResult.unapply)(
       "ccds",
       "chartGroups",
       "times",
       "signalToNoiseAt"
-  )
+    )
+  }
 
 }
 

--- a/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/servlets/JsonServlet.scala
+++ b/bundle/edu.gemini.itc.web/src/main/scala/edu/gemini/itc/web/servlets/JsonServlet.scala
@@ -1,13 +1,16 @@
 package edu.gemini.itc.web.servlets
 
-import argonaut._, Argonaut._
-import edu.gemini.itc.shared.{ ItcParameters, ItcResult, ItcService }
+import argonaut._
+import Argonaut._
+import edu.gemini.itc.shared.{ItcParameters, ItcResult, ItcService, SpcSeriesData}
 import edu.gemini.itc.service.ItcServiceImpl
-import edu.gemini.itc.web.json.{ ItcParametersCodec, ItcResultCodec }
-import javax.servlet.http.{ HttpServlet, HttpServletRequest, HttpServletResponse }
-import javax.servlet.http.HttpServletResponse.{ SC_BAD_REQUEST, SC_OK }
+import edu.gemini.itc.web.json.{ItcParametersCodec, ItcResultCodec, ItcSpectroscopyResultCodec}
+
+import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
+import javax.servlet.http.HttpServletResponse.{SC_BAD_REQUEST, SC_OK}
 import scala.io.Source
-import scalaz._, Scalaz._
+import scalaz._
+import Scalaz._
 
 /**
  * This object is used to expose the itc core calculation as if it were the servlet
@@ -19,9 +22,45 @@ import scalaz._, Scalaz._
  *
  * This will be used by the scala-3 based itc graphql server for gpp
  */
-object ItcCalculation extends ItcParametersCodec with ItcResultCodec {
+object ItcCalculation extends ItcParametersCodec with ItcResultCodec with ItcSpectroscopyResultCodec {
+  import edu.gemini.json.array._
+
+  def roundToSix(d: Double): Double = SpcSeriesData.roundToSignificantFigures(d, 6)
+
+  case class ItcXAxis(start: Double, end: Double, count: Int)
+
+  object ItcXAxis {
+
+    // Calculate the values on the axis range
+    def calcAxis(data: Array[Double]): Option[ItcXAxis] =
+      if (data.nonEmpty) {
+        Some(ItcXAxis(roundToSix(data.head), roundToSix(data(data.length - 1)), data.length))
+      }
+      else None
+  }
+
+  implicit val AxisCodec: CodecJson[ItcXAxis] =
+    casecodec3(ItcXAxis.apply, ItcXAxis.unapply)(
+      "start",
+      "end",
+      "count"
+    )
+
   def calculateCharts(json: String): String = {
     val itc: ItcService = new ItcServiceImpl
+
+    // Shadow the default SpcSeriesDataCodec with a custom one for GPP that
+    // sends x-axis data and only the y data values to save encoding time and bandwidth.
+    implicit val SpcSeriesDataCodec: CodecJson[SpcSeriesData] =
+      CodecJson(
+        (s: SpcSeriesData) =>
+          ("dataType" :=  s.dataType) ->:
+          ("title"    :=  s.title)    ->:
+          ("dataY"    :=  s.data(1).map(roundToSix))  ->:
+          ("xAxis"    :=  ItcXAxis.calcAxis(s.data(0)))  ->:
+          jEmptyObject,
+        (c: HCursor) => ??? // the decoder is never used
+      )
 
     (for {
       itcReq <- Parse.decodeEither[ItcParameters](json)
@@ -107,7 +146,7 @@ class JsonChartServlet(versionToken: String = "") extends HttpServlet with ItcPa
     val itc: ItcService = new ItcServiceImpl
 
     // Read the body, which with some luck is a JSON string
-    val enc  = Option(req.getCharacterEncoding).getOrElse("UTF-8")
+    val enc  = Option.apply(req.getCharacterEncoding).getOrElse("UTF-8")
     val src  = Source.fromInputStream(req.getInputStream, enc)
     val json = try src.mkString finally src.close
 
@@ -120,9 +159,9 @@ class JsonChartServlet(versionToken: String = "") extends HttpServlet with ItcPa
 
     // Send our result back.
     result match {
-      case Left(err)     => res.sendError(SC_BAD_REQUEST, err)
+      case Left(err)     => res.sendError(HttpServletResponse.SC_BAD_REQUEST, err)
       case Right(itcRes) =>
-        res.setStatus(SC_OK)
+        res.setStatus(HttpServletResponse.SC_OK)
         res.setContentType("text/json; charset=UTF-8")
         val writer = res.getWriter
         val json: Json =

--- a/bundle/edu.gemini.itc.web/src/test/scala/edu/gemini/itc/web/arb/ArbItcSpectroscopyResult.scala
+++ b/bundle/edu.gemini.itc.web/src/test/scala/edu/gemini/itc/web/arb/ArbItcSpectroscopyResult.scala
@@ -14,6 +14,7 @@ trait ArbItcSpectroscopyResult {
     Gen.oneOf(
       SignalChart,
       S2NChart,
+      S2NChartPerRes,
       SignalPixelChart
     )
 
@@ -37,7 +38,9 @@ trait ArbItcSpectroscopyResult {
       SingleS2NData,
       FinalS2NData,
       PixSigData,
-      PixBackData
+      PixBackData,
+      FinalS2NPerResEle,
+      SingleS2NPerResEle
     )
 
   val genSpcSeriesData: Gen[SpcSeriesData] =

--- a/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
+++ b/bundle/edu.gemini.itc/src/main/scala/edu/gemini/itc/service/ItcServiceImpl.scala
@@ -110,20 +110,20 @@ class ItcServiceImpl extends ItcService {
   private def spectroscopyResult(recipe: SpectroscopyRecipe, excludeCharts: Boolean): Result = {
     val r = recipe.calculateSpectroscopy()
     val s = recipe.serviceResult(r, excludeCharts)
-    ItcResult.forResult(s.withSignificantFigures(6))
+    ItcResult.forResult(s)
   }
 
   private def spectroscopyResult(recipe: SpectroscopyArrayRecipe, excludeCharts: Boolean): Result = {
     val r = recipe.calculateSpectroscopy()
     val s = recipe.serviceResult(r, excludeCharts)
-    ItcResult.forResult(s.withSignificantFigures(6))
+    ItcResult.forResult(s)
   }
 
   private def ghostSpectroscopyResult(recipe: GHostRecipe, excludeCharts: Boolean): Result = {
     val r = recipe.calculateSpectroscopy()
     // we use a special method to not produce S2NChartPerRes charts or the combined charts.
     val s = recipe.serviceResult(r, excludeCharts, true)
-    ItcResult.forResult(s.copy(chartGroups = s.chartGroups.take(2)).withSignificantFigures(6))
+    ItcResult.forResult(s.copy(chartGroups = s.chartGroups.take(2)))
   }
 
   // The web page has the fields in microns and they are passed directly as doubles so the recipe expects micros


### PR DESCRIPTION
For the series data sent to GPP, only return the y data and enough information to reconstruct the x data (which is equally spaced wavelengths). 

Claude Sonnet wrote some of the code that altered implicit resolution so I could provide an alternate `CodecJson[SpcSeriesData]` for the GPP endpoints. I did have to pretty much tell it how to do it, but it did figure out how make it all work and deal with all the types for me.

Note: I have no idea why `jline-2.10.7` is suddenly failing to resolve in CI. I deleted the ivy cache for it locally and it resolved just fine. Maybe it will work tomorrow.