### PR TITLE
REL-4931: Add support for GNIRS S/N ETM (v2)

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2026-May-23</footer>
+<footer>Last updated 2026-May-26</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2026-May-16</footer>
+<footer>Last updated 2026-May-23</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCflamingos2.html
@@ -387,7 +387,7 @@
 
             <tr>
                 <td><input value="intTime" name="calcMethod" type="radio" /></td>
-                <td>Imaging integration time to achieve a S/N ratio of
+                <td><b>Imaging</b> integration time to achieve a S/N ratio of
                     <input name="sigmaC" size="3" value="5" type="text" /> using an exposure time for each exposure of
                     <input name="expTimeC" value="120" type="number" step="1" style="width: 5em" /> secs and with a fraction
                     <input name="fracOnSourceC" size="4" value="1.0" type="text" /> of exposures that observe the source </td>
@@ -395,7 +395,7 @@
 
             <tr>
                 <td><input value="expTime" name="calcMethod" type="radio" /></td>
-                <td>Imaging integration time to achieve a S/N ratio of
+                <td><b>Imaging</b> integration time to achieve a S/N ratio of
                     <input name="sigmaD" size="3" value="5" type="text" />
                     <input name="coaddsD" value="1" type="hidden"/>
                     <input name="fracOnSourceD" value="1" type="hidden"/>
@@ -404,7 +404,7 @@
 
             <tr>
                 <td><input value="intTimeSpec" name="calcMethod" type="radio" /></td>
-                <td>Spectroscopy integration time to achieve a S/N ratio of
+                <td><b>Spectroscopy</b> integration time to achieve a S/N ratio of
                     <input name="sigmaE" size="3" value="5" type="text" />
                     measured at <input name="wavelengthE" size="3" value="2200" type="text" /> nm.
                     <input name="coaddsE" value="1" type="hidden"/>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgmos.html
@@ -449,14 +449,14 @@
 			</tr>
 			<tr>
 				<td><input value="intTime" name="calcMethod" type="radio" /></td>
-				<td>Imaging integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
+				<td><b>Imaging</b> integration time to achieve a S/N ratio of <input name="sigmaC" size="3" value="5" type="text" />
 					using an exposure time for each exposure of<input name="expTimeC" size="5" value="900" type="text" />
 					secs and with a fraction <input name="fracOnSourceC" size="4" value="1.0" type="text" />
 					of exposures that observe the source </td>
 			</tr>
 			<tr>
 				<td><input value="expTime" name="calcMethod" type="radio" /></td>
-				<td>Imaging integration time to achieve a S/N ratio of
+				<td><b>Imaging</b> integration time to achieve a S/N ratio of
 					<input name="sigmaD" size="3" value="5" type="text" />
 					<input name="coaddsD" value="1" type="hidden"/>
 					<input name="fracOnSourceD" value="1" type="hidden"/>
@@ -464,7 +464,7 @@
 			</tr>
 			<tr>
 				<td><input value="intTimeSpec" name="calcMethod" type="radio" /></td>
-				<td>Spectroscopy integration time to achieve a S/N ratio of
+				<td><b>Spectroscopy</b> integration time to achieve a S/N ratio of
 					<input name="sigmaE" size="3" value="5" type="text" />
 					measured at <input name="wavelengthE" size="3" value="600" type="text" /> nm.
 					<input name="coaddsE" value="1" type="hidden"/>

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -470,7 +470,7 @@
 
 			<tr>
 				<td><input value="intTime" name="calcMethod" type="radio" /></td>
-				<td colspan="2">Total integration time to achieve S/N ratio of
+				<td colspan="2"><b>Imaging</b> integration time to achieve S/N ratio of
 					<input name="sigmaC" size="3" type="number" value="5" min="0" step="any" />
 					using an exposure time for each exposure of
 					<input name="expTimeC" size="5" type="number" value="120" min="0.2" step="any" /> secs
@@ -481,6 +481,15 @@
 			</tr>
 
 			<tr>
+				<td><input value="expTime" name="calcMethod" type="radio" /></td>
+				<td colspan="2"><b>Imaging</b> integration time to achieve S/N ratio of
+					<input name="sigmaD" size="3" type="number" value="5" min="0" step="any" />
+					<input name="coaddsD" value="1" type="hidden"/>
+					<input name="fracOnSourceD" value="1" type="hidden"/>
+				</td>
+			</tr>
+
+			<tr>
 				<td><input value="intTimeSpec" name="calcMethod" type="radio" /></td>
 				<td colspan="2"><b>Spectroscopy</b> integration time to achieve S/N ratio of
 					<input name="sigmaE" size="3" type="number" value="5" min="0" step="any" />
@@ -488,15 +497,6 @@
 					<input name="wavelengthE" size="5" type="number" value="2.14" min="0.6" max="7" step="any" /> &mu;m.
 					<input name="coaddsE" value="1" type="hidden"/>
 					<input name="fracOnSourceE" value="1" type="hidden"/>
-				</td>
-			</tr>
-
-			<tr>
-				<td><input value="expTime" name="calcMethod" type="radio" /></td>
-				<td colspan="2"><b>Imaging</b> integration time to achieve S/N ratio of
-					<input name="sigmaD" size="3" type="number" value="5" min="0" step="any" />
-					<input name="coaddsD" value="1" type="hidden"/>
-					<input name="fracOnSourceD" value="1" type="hidden"/>
 				</td>
 			</tr>
 

--- a/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/servlets/web/ITCgnirs.html
@@ -12,8 +12,12 @@
         input[type=number]::-webkit-inner-spin-button,
         input[type=number]::-webkit-outer-spin-button {
             -webkit-appearance: none;
+			margin: 0;
         }
-        input[type=number] { -moz-appearance: textfield; }
+        input[type=number] {
+			-moz-appearance: textfield;
+			width: 7ch;
+		}
 		input[type=number]:invalid {
         	border: 2px solid red;
         	background-color: #ffe0e0;
@@ -141,7 +145,10 @@
 
 			<tr>
 				<td><input value="ELINE" name="Distribution" type="radio" /></td>
-				<td colspan="2">Single emission line at wavelength <input name="lineWavelength" size="5" value="2.2" type="text" /> micron with line flux <input name="lineFlux" size="8" value="5.0e-19" type="text" /> <select name="lineFluxUnits" size="1">
+				<td colspan="2">Single emission line at wavelength
+					<input name="lineWavelength" size="5" type="number" value="2.2" min="0" max="6" step="any"/> &mu;m
+					with line flux
+					<input name="lineFlux" size="8" value="5.0e-19" type="text" /> <select name="lineFluxUnits" size="1">
 				<option selected="selected" value="watts_flux">
 				W/m²</option>
 				<option value="ergs_flux">
@@ -457,32 +464,32 @@
 
 			<tr>
 				<td width="20"><input value="s2n" name="calcMethod" checked="checked" type="radio" /></td>
-				<td colspan="2">Total S/N ratio resulting from
+				<td colspan="2">S/N per pixel resulting from
 					<input name="numExpA" size="5" type="number" value="30" min="1" step="1" />
 					exposures each having
 					<input name="numCoaddsA" size="5" type="number" value="1" min="1" step="1" /> coadds
 					with exposure time of
-					<input name="expTimeA" size="5" type="number" value="120" min="0.2" step="any" /> secs,
+					<input name="expTimeA" size="5" type="number" value="120" min="0.2" step="any" /> seconds,
 					and with a fraction
 					<input name="fracOnSourceA" size="4" type="number" value="1.0" min="0" max="1.0" step="any" />
-					of exposures that observe the source </td>
+					of exposures that observe the source.</td>
 			</tr>
 
 			<tr>
 				<td><input value="intTime" name="calcMethod" type="radio" /></td>
-				<td colspan="2"><b>Imaging</b> integration time to achieve S/N ratio of
+				<td colspan="2"><b>Imaging</b> integration time to achieve S/N of
 					<input name="sigmaC" size="3" type="number" value="5" min="0" step="any" />
 					using an exposure time for each exposure of
-					<input name="expTimeC" size="5" type="number" value="120" min="0.2" step="any" /> secs
+					<input name="expTimeC" size="5" type="number" value="120" min="0.2" step="any" /> seconds
 					and <input name="numCoaddsC" size="5" type="number" value="1" min="1" step="1" /> coadds,
 					and with a fraction
 					<input name="fracOnSourceC" size="4" type="number" value="1.0" min="0" max="1" />
-					of exposures that observe the source</td>
+					of exposures that observe the source.</td>
 			</tr>
 
 			<tr>
 				<td><input value="expTime" name="calcMethod" type="radio" /></td>
-				<td colspan="2"><b>Imaging</b> integration time to achieve S/N ratio of
+				<td colspan="2"><b>Imaging</b> integration time to achieve S/N of
 					<input name="sigmaD" size="3" type="number" value="5" min="0" step="any" />
 					<input name="coaddsD" value="1" type="hidden"/>
 					<input name="fracOnSourceD" value="1" type="hidden"/>
@@ -491,7 +498,7 @@
 
 			<tr>
 				<td><input value="intTimeSpec" name="calcMethod" type="radio" /></td>
-				<td colspan="2"><b>Spectroscopy</b> integration time to achieve S/N ratio of
+				<td colspan="2"><b>Spectroscopy</b> integration time to achieve S/N per pixel of
 					<input name="sigmaE" size="3" type="number" value="5" min="0" step="any" />
 					measured at
 					<input name="wavelengthE" size="5" type="number" value="2.14" min="0.6" max="7" step="any" /> &mu;m.
@@ -587,7 +594,7 @@
 				<td><input value="USER" name="PlotLimits" type="radio" /></td>
 				<td colspan="2">Display the range
 					<input name="plotWavelengthL" size="6" type="number" value="2.10" min="0.9" max="5.6" step="any"/> to
-					<input name="plotWavelengthU" size="6" type="number" value="2.20" min="0.9"	max="5.6" step="any" /> microns</td>
+					<input name="plotWavelengthU" size="6" type="number" value="2.20" min="0.9"	max="5.6" step="any" /> &mu;m</td>
 			</tr>
 
 			<tr>

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -195,9 +195,9 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
             // Calculate the S/N and verify that the answer is the same:
             Log.fine(String.format("Predicted S/N = %.3f", calculateSNR(signal, background, darkNoise, readNoise, skyAper, initialNumberExposures)));
 
-            // Calculate the maximum exposure time, up to a maximum of 900s:
+            // Calculate the maximum exposure time, up to a maximum of 350s:
             double safetyBuffer = 0.6;  // Use a 60% safety buffer to avoid saturating in better conditions
-            double maxExposureTime = Math.min(900, maxFlux * safetyBuffer / peakFlux * initialExposureTime);
+            double maxExposureTime = Math.min(350, maxFlux * safetyBuffer / peakFlux * initialExposureTime);
             Log.fine(String.format("maxExposureTime = %.2f seconds", maxExposureTime));
 
             // If the maximum exposure time for this target + configuration is less than the minimum then throw an error:


### PR DESCRIPTION
This updates the GNIRS S/N ETM maximum exposure time (now 350s) and makes some cosmetic changes to the web forms to make it clearer which calculation modes are for imaging and which are for spectroscopy.