### PR TITLE
Apply REL-4834 to ocs 2026B

### DIFF
--- a/app/qpt/build.sbt
+++ b/app/qpt/build.sbt
@@ -42,9 +42,11 @@ def common(version: Version) = AppConfig(
     "org.osgi.framework.storage.clean"                 -> "onFirstInit",
     "edu.gemini.spdb.mode"                             -> "api",
     "edu.gemini.qpt.ltts.services.south.url"           -> "http://gsltts.cl.gemini.edu:8080/ltts/services",
+    "edu.gemini.qpt.ltts.services.south.enabled"       -> "false",
     "org.osgi.framework.startlevel.beginning"          -> "100",
     "edu.gemini.util.security.auth.ui.showDatabaseTab" -> "true",
     "edu.gemini.qpt.ltts.services.north.url"           -> "http://gnltts.hi.gemini.edu:8080/ltts/services",
+    "edu.gemini.qpt.ltts.services.north.enabled"       -> "true",
     "org.osgi.framework.bootdelegation"                -> "*"
   ),
   log = Some("%a/log/qpt.%u.%g.log"),
@@ -143,5 +145,3 @@ def development(version: Version) = AppConfig(
     BundleSpec(99, "org.apache.felix.gogo.shell",   Version(0, 10, 0))
   )
 ) extending List(common(version), development_credentials(version))
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "ocs"
 organization in Global := "edu.gemini.ocs"
 
 // true indicates a test release, and false indicates a production release
-ocsVersion in ThisBuild := OcsVersion("2026B", true, 1, 1, 1)
+ocsVersion in ThisBuild := OcsVersion("2026B", false, 1, 1, 2)
 
 pitVersion in ThisBuild := OcsVersion("2026B", true, 1, 1, 1)
 

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/LttsServicesClient.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/core/util/LttsServicesClient.java
@@ -49,6 +49,9 @@ public class LttsServicesClient {
     public static String LTTS_SERVICES_NORTH_URL = "http://localhost:1973/ltts-services/test";
     public static String LTTS_SERVICES_SOUTH_URL = "http://localhost:1973/ltts-services/test";
 
+    public static boolean LTTS_SERVICES_NORTH_ENABLED = true;
+    public static boolean LTTS_SERVICES_SOUTH_ENABLED = true;
+
     private static LttsServicesClient instance;
 
     // Maps obs id to observation
@@ -85,6 +88,16 @@ public class LttsServicesClient {
     }
 
     LttsServicesClient(long start, Peer peer) {
+        observationMap = new HashMap<String, Observation>();
+
+        boolean enabled = (peer.site == Site.GN) ? LTTS_SERVICES_NORTH_ENABLED : LTTS_SERVICES_SOUTH_ENABLED;
+        // if disabled it is the same as an empty observationMap
+        if (!enabled) {
+            LOGGER.info("LTTS Service disabled for " + peer.site);
+            status = true;
+            return;
+        }
+
         Client client = Client.create();
         Date date = new Date(start);
         // See LCH-182: http://localhost:1973/ltts-services/nights?date=20130105&laserAltitudeLimit=40&full=true
@@ -96,8 +109,6 @@ public class LttsServicesClient {
                 + "&laserLimit=" + LimitsListener.MIN_ELEVATION_ERROR_LIMIT
                 + "&full=true";
         LOGGER.info("Accessing LCH web service at " + url);
-
-        observationMap = new HashMap<String, Observation>();
 
         try {
             WebResource webResource = client.resource(url);

--- a/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/osgi/Activator.java
+++ b/bundle/edu.gemini.qpt.client/src/main/java/edu/gemini/qpt/osgi/Activator.java
@@ -59,6 +59,12 @@ public final class Activator implements BundleActivator {
             LOGGER.warning("Missing bundle.properties value edu.gemini.qpt.ltts.services.south.url");
         }
 
+        String northEnabled = context.getProperty("edu.gemini.qpt.ltts.services.north.enabled");
+        LttsServicesClient.LTTS_SERVICES_NORTH_ENABLED = !"false".equalsIgnoreCase(northEnabled);
+
+        String southEnabled = context.getProperty("edu.gemini.qpt.ltts.services.south.enabled");
+        LttsServicesClient.LTTS_SERVICES_SOUTH_ENABLED = !"false".equalsIgnoreCase(southEnabled);
+
         this.context = context;
 
         // TODO: this is set to the application install dir where we can find


### PR DESCRIPTION
We (I) forgot to apply REL-4834 to the main branch and it didn't get applied to the ocs 2026B release

See https://github.com/gemini-hlsw/ocs/pull/2387