### PR TITLE
REL-4931: Auto-select the GNIRS and F2 read mode for imaging S/N ETM

### DIFF
--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/GmosPrinter.java
@@ -293,7 +293,7 @@ public final class GmosPrinter extends PrinterBase implements OverheadTablePrint
     }
 
     @Override
-    public int getNumberExposures() { return numberExposures; }
+    public int getNumberExposures() { return recipe.getNumberExposures(); }
 
     public int getNumberCoadds() { return 1; }
 

--- a/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
+++ b/bundle/edu.gemini.itc.web/src/main/java/edu/gemini/itc/web/html/OverheadTablePrinter.java
@@ -102,6 +102,7 @@ public class OverheadTablePrinter {
             numOfExposures = ((SpectroscopyS2N) calcMethod).exposures();
         } else if (calcMethod instanceof ImagingIntegrationTime) {
             numOfExposures = printer.getNumberExposures();
+            coadds = printer.getNumberCoadds();
         } else if (calcMethod instanceof SpectroscopyIntegrationTime) {
             numOfExposures = printer.getNumberExposures();
             coadds = printer.getNumberCoadds();

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2026-May-26</footer>
+<footer>Last updated 2026-Jun-07</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc.web/src/main/resources/index.html
+++ b/bundle/edu.gemini.itc.web/src/main/resources/index.html
@@ -63,6 +63,6 @@ Source code documentation: <a href='../itcdocs/html/index.html'>../itcdocs/html/
 <br>
 Plots of data files: <a href='../itcdocs/plots/index.html'>../itcdocs/plots/</a>
 <hr>
-<footer>Last updated 2026-Jun-07</footer>
+<footer>Last updated 2026-Jun-11</footer>
 </body>
 </html>

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -74,6 +74,7 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
     }
 
     public SpectroscopyResult calculateSpectroscopy() {
+
         final CalculationMethod calcMethod = _obsDetailParameters.calculationMethod();
         Log.fine("calcMethod = " + calcMethod);
 
@@ -92,7 +93,6 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
 
         final double skyAper = 1.0;  // hard-coded in the F2 web form
         double readNoise;
-        double totalTime;
 
         if (calcMethod instanceof SpectroscopyIntegrationTime) {
             // Determine exposureTime & numberExposures that will give the requested S/N at wavelength.
@@ -157,49 +157,48 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
                     "This target is too bright for this configuration.\n" +
                             "The detector will reach %.0f e- in %.2f seconds.", maxFlux * safetyBuffer, maxExposureTime));
 
-            // Step through each of the read modes and see which works best.
+            // Step through read modes and see which is best.  This does NOT re-run the ITC calculations.
             List<ReadMode> readModes = Arrays.asList(ReadMode.FAINT_OBJECT_SPEC, ReadMode.MEDIUM_OBJECT_SPEC, ReadMode.BRIGHT_OBJECT_SPEC);
             for (ReadMode rm : readModes) {
+                Log.fine("============================ " + rm + " ============================");
                 readMode = rm;
-                Log.fine("=== Checking " + readMode.toString() + " read mode ===");
-
                 readNoise = readMode.readNoise() * readMode.readNoise() * numberPixels;
                 Log.fine(String.format("Read Noise = %.2f e- (squared and summed)", readNoise));
                 Log.fine(String.format("S/N = %.3f", calculateSNR(signal, background, darkNoise, readNoise, skyAper, initialNumberExposures)));
 
-                int iterations = 0;
-                int oldNumberExposures = -1;
-                double oldExposureTime = -1;
-                while ( (exposureTime != oldExposureTime || numberExposures != oldNumberExposures) && iterations < 10) {
-                    Log.fine("Iteration " + iterations + " ----------------");
-                    oldNumberExposures = numberExposures;
-                    oldExposureTime = exposureTime;
+                numberExposures = initialNumberExposures;
+                final int MAX_ITERATIONS = 10;
+                for (int iter = 0; iter < MAX_ITERATIONS; iter++) {
                     exposureTime = calculateExposureTime(signal / initialExposureTime,
                             background / initialExposureTime, darkNoise / initialExposureTime,
                             readNoise, skyAper, desiredSNR / Math.sqrt(numberExposures));
-                    totalTime = exposureTime * numberExposures;
-                    numberExposures = (int) Math.ceil(totalTime / maxExposureTime);
-                    if (numberExposures % 4 != 0) { numberExposures += 4 - numberExposures % 4;}  // make a multiple of 4
-                    exposureTime = totalTime / numberExposures;
-                    Log.fine(String.format("Iteration %d: -> %d x %.3f sec = %.3f sec (RN=%.2f e-)",
-                            iterations, numberExposures, exposureTime, totalTime, readMode.readNoise()));
-                    iterations += 1;
-                }
-                Log.fine("Converged");
+                    int n = (int) Math.ceil(numberExposures * exposureTime / maxExposureTime);
+                    if (n % 4 != 0) n += 4 - n % 4;  // make a multiple of 4
 
-                if (exposureTime < readMode.recomendedExpTimeSec()) {  // continue to the next read mode
-                    Log.fine(String.format("This is shorter than recommended (%.0f sec)", readMode.recomendedExpTimeSec()));
+                    if (n == numberExposures) {
+                        Log.fine("------------------------------------------------------------------------");
+                        break;  // converged
+                    }
+                    numberExposures = n;
+                }
+                Log.fine(String.format("Converged: %d x %.3f sec (RN=%.2f e-)",
+                        numberExposures, exposureTime, readMode.readNoise()));
+
+                if (exposureTime < readMode.recomendedExpTimeSec()) {
+                    Log.fine(String.format("Below recommended (%.0f sec), trying next read mode", readMode.recomendedExpTimeSec()));
                 } else {  // Accept this read mode
                     break;
                 }
             }
-
-            Log.fine("=== The read mode, exposure time, and number of exposures have been decided ===");
+            Log.fine("============================================================================");
+            Log.fine("The read mode, exposure time, and number of exposures have been decided.");
             Log.fine("readMode = " + readMode.toString());
             Log.fine(String.format("numberExposures = %d", numberExposures));
+
             if (numberExposures > 1000) {
                 throw new RuntimeException("Configuration would require " + numberExposures + " exposures");
             }
+
             if (exposureTime < readMode.minimumExpTimeSec()) {
                 Log.fine("Increasing exposure time to the minimum allowed for the read mode");
                 exposureTime = readMode.minimumExpTimeSec();

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/flamingos2/Flamingos2Recipe.java
@@ -303,6 +303,9 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
 
     public ImagingResult calculateImaging() {
 
+        final CalculationMethod calcMethod = _obsDetailParameters.calculationMethod();
+        Log.fine("calcMethod = " + calcMethod);
+
         // Start of morphology section of ITC
 
         // Module 1a
@@ -313,6 +316,7 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
         // Define the source morphology
         //
         // inputs: source morphology specification
+
         final SEDFactory.SourceResult src = SEDFactory.calculate(instrument, _sdParameters, _obsConditionParameters, _telescope);
 
         // Calculate image quality
@@ -334,10 +338,73 @@ public final class Flamingos2Recipe implements ImagingRecipe, SpectroscopyRecipe
         final double sky_integral = sky.getIntegral();
 
         // Calculate the Signal to Noise
-        final ImagingS2NCalculatable IS2Ncalc = ImagingS2NCalculationFactory.getCalculationInstance(_sdParameters, _obsDetailParameters, instrument, SFcalc, im_qual, sed_integral, sky_integral);
-        IS2Ncalc.calculate();
-        exposureTime = (int) IS2Ncalc.getExposureTime();
-        numberExposures = IS2Ncalc.numberSourceExposures();
+        final ImagingS2NCalculatable IS2Ncalc;
+
+        if (calcMethod instanceof ImagingIntegrationTime) {
+
+            // Iterate over read modes to find the one that yields the desired S/N in the least amount of time.
+            ImagingMethodExptime bestCalc = null;
+            double bestTotalTime = Double.MAX_VALUE;
+
+            final List<ReadMode> readModes = Arrays.asList(ReadMode.BRIGHT_OBJECT_SPEC, ReadMode.MEDIUM_OBJECT_SPEC, ReadMode.FAINT_OBJECT_SPEC);
+            for (ReadMode rm : readModes) {
+                Log.fine("============================ " + rm + " ============================");
+
+                final ImagingMethodExptime calc = new ImagingMethodExptime(
+                        _obsDetailParameters, instrument, SFcalc, sed_integral, sky_integral,
+                        _sdParameters, im_qual, rm.readNoise(), rm.minimumExpTimeSec());
+
+                try {
+                    calc.calculate();
+                } catch (RuntimeException e) {
+                    Log.fine(e.getMessage());
+                    if (e.getMessage().startsWith("This target is too bright")) {
+                        if (rm == ReadMode.BRIGHT_OBJECT_SPEC) throw e;  // if too bright for BRIGHT_OBJECT_SPEC then too bright.
+                        continue;
+                    } else if (e.getMessage().startsWith("This target is too faint")) {
+                        if (rm == ReadMode.FAINT_OBJECT_SPEC) throw e;   // if too faint for FAINT_OBJECT_SPEC then too faint.
+                        continue;
+                    }
+                    throw e;
+                }
+
+                // Calculate the total time = Nexp x (exptime + readout)
+                final double totalTime = calc.numberSourceExposures() * (calc.getExposureTime() + rm.minimumExpTimeSec());
+                Log.fine(String.format("Total time = %.3f sec", totalTime));
+                if (totalTime < bestTotalTime) {
+                    bestTotalTime = totalTime;
+                    bestCalc = calc;
+                    readMode = rm;
+                } else {
+                    Log.fine("Total time increasing, so stopping read mode search");
+                    break;
+                }
+            }
+            Log.fine("============================================================================");
+
+            // The loop can fall through for red filters when the source is too faint for VERY_BRIGHT
+            // and the background is too bright for VERY_FAINT.  Catch that here:
+            if (bestCalc == null) throw new RuntimeException("Could not find best read mode.");
+
+            Log.fine(String.format("The winner is: %s read mode with total time = %.2f sec", readMode, bestTotalTime));
+
+            IS2Ncalc = bestCalc;
+            exposureTime = IS2Ncalc.getExposureTime();
+            numberExposures = IS2Ncalc.numberSourceExposures();
+
+        } else if (calcMethod instanceof ImagingS2N || calcMethod instanceof ImagingExposureCount) {
+            IS2Ncalc = ImagingS2NCalculationFactory.getCalculationInstance(_sdParameters, _obsDetailParameters, instrument, SFcalc, im_qual, sed_integral, sky_integral);
+            IS2Ncalc.calculate();
+            exposureTime = (int) IS2Ncalc.getExposureTime();
+            numberExposures = IS2Ncalc.numberSourceExposures();
+
+        } else {
+            throw new Error("Unsupported calculation method");
+        }
+
+        Log.fine("exposureTime = " + exposureTime);
+        Log.fine("numberExposures = " + numberExposures);
+        Log.fine("readMode = " + readMode);
 
         // Calculate the Peak Pixel Flux
         final double peak_pixel_count = PeakPixelFlux.calculate(instrument, _sdParameters, exposureTime, SFcalc, im_qual, sed_integral, sky_integral);

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -208,52 +208,37 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
             // Check each read mode and see which would be best.  This does NOT re-run the ITC calculations.
             List<ReadMode> readModes = Arrays.asList(ReadMode.VERY_FAINT, ReadMode.FAINT, ReadMode.BRIGHT, ReadMode.VERY_BRIGHT);
             for (ReadMode rm : readModes) {
+                Log.fine("============================ " + rm + " ============================");
                 readMode = rm;
-                Log.fine("=== Checking " + readMode.toString() + " read mode ===");
-
                 readNoise = readMode.getReadNoise() * readMode.getReadNoise() * numberPixels;
                 Log.fine(String.format("Read Noise = %.2f e- (squared and summed)", readNoise));
                 Log.fine(String.format("S/N = %.3f", calculateSNR(signal, background, darkNoise, readNoise, skyAper, initialNumberExposures)));
-
-                int iterations = 0;
-                exposureTime = initialExposureTime;
                 numberExposures = initialNumberExposures;
-                int oldNumberExposures = -1;
-                double oldExposureTime = -1;
-                while ( (exposureTime != oldExposureTime || numberExposures != oldNumberExposures) && iterations < 10) {
-                    Log.fine("Iteration " + iterations + " ----------------");
-                    oldNumberExposures = numberExposures;
-                    oldExposureTime = exposureTime;
+                final int MAX_ITERATIONS = 10;
+                for (int iter = 0; iter < MAX_ITERATIONS; iter++) {
+                    Log.fine("-------------------------------- iter " + iter + " --------------------------------");
                     exposureTime = ExposureTimeCalculator.calculate(signal / initialExposureTime,
                             background / initialExposureTime, darkNoise / initialExposureTime,
                             readNoise, skyAper, desiredSNR / Math.sqrt(numberExposures));
-                    Log.fine("exposureTime = " + exposureTime);
-                    totalTime = exposureTime * numberExposures;
-                    numberExposures = (int) Math.ceil(totalTime / maxExposureTime);
-                    if (numberExposures % 4 != 0) { numberExposures += 4 - numberExposures % 4;}  // make a multiple of 4
-                    exposureTime = totalTime / numberExposures;
-                    Log.fine("totalTime = " + totalTime);
-                    Log.fine("numberExposures = " + numberExposures);
-                    Log.fine(String.format("Iteration %d: -> %d x %.3f sec = %.3f sec (RN=%.2f e-)",
-                            iterations, numberExposures, exposureTime, totalTime, readMode.getReadNoise()));
-                    iterations += 1;
+                    int n = (int) Math.ceil(numberExposures * exposureTime / maxExposureTime);
+                    if (n % 4 != 0) n += 4 - n % 4;
+                    if (n == numberExposures) {
+                        Log.fine("------------------------------------------------------------------------");
+                        break;
+                    }
+                    numberExposures = n;
                 }
-                Log.fine("Converged");
-
                 exposureTime = roundExposureTime(exposureTime);
-                Log.fine(String.format("Rounded exposureTime = %.2f sec", exposureTime));
+                Log.fine(String.format("Rounded exposureTime = %.5f sec", exposureTime));
 
-                // Undecided whether to use "recommended" time or "minimum" time:
-                //if (exposureTime < instrument.getMinRecommendedExpTime(readMode)) {  // continue to the next read mode
-                //    Log.fine(String.format("This is shorter than recommended (%.0f sec)", instrument.getMinRecommendedExpTime(readMode)));
                 if (exposureTime < readMode.getMinExp()) {  // continue to the next read mode
                     Log.fine(String.format("This is shorter than the minimum (%.2f sec)", readMode.getMinExp()));
                 } else {  // Accept this read mode
                     break;
                 }
             }
-
-            Log.fine("=== The read mode, exposure time, and number of exposures have been decided ===");
+            Log.fine("============================================================================");
+            Log.fine("The read mode, exposure time, and number of exposures have been decided.");
             Log.fine("readMode = " + readMode.toString());
             Log.fine(String.format("numberExposures = %d", numberExposures));
             if (numberExposures > 1000) {

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -224,7 +224,7 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
                     Log.fine("Iteration " + iterations + " ----------------");
                     oldNumberExposures = numberExposures;
                     oldExposureTime = exposureTime;
-                    exposureTime = calculateExposureTime(signal / initialExposureTime,
+                    exposureTime = ExposureTimeCalculator.calculate(signal / initialExposureTime,
                             background / initialExposureTime, darkNoise / initialExposureTime,
                             readNoise, skyAper, desiredSNR / Math.sqrt(numberExposures));
                     Log.fine("exposureTime = " + exposureTime);
@@ -265,7 +265,7 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
             }
 
             Log.fine(String.format("exposureTime = %.2f", exposureTime));
-            coadds = calculateCoadds(exposureTime, numberExposures);
+            coadds = calculateCoadds(exposureTime, numberExposures, 4);
             numberExposures /= coadds;
 
         } else {
@@ -772,10 +772,9 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
         final double sky_integral = calcSource.sky.getIntegral();
         final double halo_integral = altair.isDefined() ? calcSource.halo.get().getIntegral() : 0.0;
 
-        final ImagingS2NCalculatable IS2Ncalc = ImagingS2NCalculationFactory.getCalculationInstance(
-                _sdParameters, _obsDetailParameters, instrument, SFcalc, im_qual, sed_integral, sky_integral);
-
-        Log.fine("IS2Ncalc = " + IS2Ncalc);
+        // Compute Altair secondary source fraction once, before branching on calcMethod.
+        final double secondaryIntegral;
+        final double secondarySourceFraction;
         if (altair.isDefined()) {
             final SourceFraction SFcalcHalo;
             final double aoCorrImgQual = altair.get().getAOCorrectedFWHM();
@@ -784,26 +783,95 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
             } else {
                 SFcalcHalo = SourceFractionFactory.calculate(_sdParameters, _obsDetailParameters, instrument, IQcalc.getImageQuality());
             }
-            IS2Ncalc.setSecondaryIntegral(halo_integral);
-            IS2Ncalc.setSecondarySourceFraction(SFcalcHalo.getSourceFraction());
+            secondaryIntegral = halo_integral;
+            secondarySourceFraction = SFcalcHalo.getSourceFraction();
+        } else {
+            secondaryIntegral = 0.0;
+            secondarySourceFraction = 0.0;
         }
-        IS2Ncalc.calculate();
+
+        ImagingS2NCalculatable IS2Ncalc;
 
         if (calcMethod instanceof ImagingS2N) {
+            IS2Ncalc = ImagingS2NCalculationFactory.getCalculationInstance(
+                    _sdParameters, _obsDetailParameters, instrument, SFcalc, im_qual, sed_integral, sky_integral);
+            Log.fine("IS2Ncalc = " + IS2Ncalc);
+            if (altair.isDefined()) {
+                IS2Ncalc.setSecondaryIntegral(secondaryIntegral);
+                IS2Ncalc.setSecondarySourceFraction(secondarySourceFraction);
+            }
+            IS2Ncalc.calculate();
             ImagingS2N s2nMethod = (ImagingS2N) calcMethod;
             exposureTime = s2nMethod.exposureTime();
             numberExposures = s2nMethod.exposures() * coadds;
 
         } else if (calcMethod instanceof ImagingIntegrationTime) {
+
+            // Iterate over read modes to find the one that yields the desired S/N in the least amount of time.
+            ImagingMethodExptime bestCalc = null;
+            double bestTotalTime = Double.MAX_VALUE;
+
+            final List<ReadMode> readModes = Arrays.asList(ReadMode.VERY_BRIGHT, ReadMode.BRIGHT, ReadMode.FAINT, ReadMode.VERY_FAINT);
+            for (ReadMode rm : readModes) {
+                Log.fine("============================ " + rm + " ============================");
+
+                final ImagingMethodExptime calc = new ImagingMethodExptime(
+                        _obsDetailParameters, instrument, SFcalc, sed_integral, sky_integral,
+                        _sdParameters, im_qual, rm.getReadNoise(), rm.getMinExp());
+
+                if (altair.isDefined()) {
+                    calc.setSecondaryIntegral(secondaryIntegral);
+                    calc.setSecondarySourceFraction(secondarySourceFraction);
+                }
+
+                try {
+                    calc.calculate();
+                } catch (RuntimeException e) {
+                    Log.fine(e.getMessage());
+                    if (e.getMessage().startsWith("This target is too bright")) {
+                        if (rm == ReadMode.VERY_BRIGHT) throw e;  // if too bright for VERY_BRIGHT then too bright.
+                        continue;
+                    } else if (e.getMessage().startsWith("This target is too faint")) {
+                        if (rm == ReadMode.VERY_FAINT) throw e;  // if too faint for VERY_FAINT then too faint.
+                        continue;
+                    }
+                }
+
+                // Calculate the total time = Nexp x (exptime + readout)
+                double totalTime = calc.numberSourceExposures() * (calc.getExposureTime() + rm.getMinExp());
+                Log.fine(String.format("Total time = %.3f sec", totalTime));
+                if (totalTime < bestTotalTime) {
+                    bestTotalTime = totalTime;
+                    bestCalc = calc;
+                    readMode = rm;
+                } else {
+                    Log.fine("Total time increasing, so stopping read mode search");
+                    break;
+                }
+            }
+            Log.fine("============================================================================");
+
+            // The loop can fall through for red filters when the source is too faint for VERY_BRIGHT
+            // and the background is too bright for VERY_FAINT.  Catch that here:
+            if (bestCalc == null) throw new RuntimeException("Could not find best read mode.");
+
+            Log.fine(String.format("The winner is: %s read mode with total time = %.2f sec", readMode, bestTotalTime));
+
+            IS2Ncalc = bestCalc;
             exposureTime = IS2Ncalc.getExposureTime();
-            Log.fine(String.format("exposureTime = %.2f sec", exposureTime));
             numberExposures = IS2Ncalc.numberSourceExposures();
-            Log.fine("numberExposures (from IS2Ncalc) = " + numberExposures);
-            coadds = calculateCoadds(exposureTime, numberExposures);
-            Log.fine("coadds = " + coadds);
+            coadds = calculateCoadds(exposureTime, numberExposures, 1);
             numberExposures /= coadds;
 
         } else if (calcMethod instanceof ImagingExposureCount) {
+            IS2Ncalc = ImagingS2NCalculationFactory.getCalculationInstance(
+                    _sdParameters, _obsDetailParameters, instrument, SFcalc, im_qual, sed_integral, sky_integral);
+            Log.fine("IS2Ncalc = " + IS2Ncalc);
+            if (altair.isDefined()) {
+                IS2Ncalc.setSecondaryIntegral(secondaryIntegral);
+                IS2Ncalc.setSecondarySourceFraction(secondarySourceFraction);
+            }
+            IS2Ncalc.calculate();
             exposureTime = IS2Ncalc.getExposureTime();
             numberExposures = IS2Ncalc.numberSourceExposures(); // Already has coadds factored.
 
@@ -812,6 +880,7 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
         }
         Log.fine("exposureTime = " + exposureTime);
         Log.fine("numberExposures = " + numberExposures);
+        Log.fine("coadds = " + coadds);
 
         // Calculate peak pixel flux
         final double peak_pixel_count = altair.isDefined() ?
@@ -828,42 +897,21 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
     }
 
     /**
-     * Calculate the exposure time required to achieve a desired Signal-to-Noise on a single frame.
-     * @param signal The signal per second summed over the pixels in the aperture.
-     * @param background The background per second summed over the pixels in the aperture.
-     * @param darkNoise The dark current per second summed over the pixels in the aperture.
-     * @param readNoise The squared read noise summed over the pixels in the aperture.
-     * @param skyAper
-     * @param SNR The desired Signal-to-Noise Ratio.
-     * @return The exposure time in seconds.
-     */
-    private double calculateExposureTime(double signal, double background, double darkNoise, double readNoise, double skyAper, double SNR) {
-        final double f = 1. + (1. / skyAper);  // noise factor
-        // SNR = S / sqrt(S + f(B + D + R)) = st / sqrt(st + f(bt + dt + R)) = x
-        // This can be expressed as a quadratic equation:  (ss/xx)t^2 - (s + fb + fd)t - fR = 0
-        // and solved using the quadratic formula: t = (-b + sqrt(b^2 - 4ac)) / 2a
-        double a = signal * signal / (SNR * SNR);
-        double b = -(signal + f * background + f * darkNoise);
-        double c = -f * readNoise;
-        double exposureTime = (-b + Math.sqrt(b*b - 4.*a*c)) / (2.*a);
-        Log.fine(String.format("exposureTime = %.3f", exposureTime));
-        return exposureTime;
-    }
-
-    /**
      * Calculate the optimal number of coadds.
-     * Assumes that at least 4 exposures are required and
-     * the maximum coadded integration time is 30 seconds.
+     * Assumes that at least 4 exposures are required, and
+     * the maximum coadded integration time is 30 seconds, and
+     * that the resulting number of exposures is a multiple of `multipleOf`.
     */
-    private int calculateCoadds(double expTime, int numberExposures) {
+    private int calculateCoadds(double expTime, int numberExposures, int multipleOf) {
         if (expTime <= 15 && numberExposures > 4) {
             int maxCoadds = (int) Math.floor(30.0 / expTime);
+            Log.fine("maxCoadds = " + maxCoadds);
             for (int c = maxCoadds; c >= 1; c--) {  // search downward for largest possible coadds
                 if (numberExposures % c != 0) {     // exposures must divide evenly
                     continue;
                 }
                 int newExposures = numberExposures / c;
-                if (newExposures % 4 != 0) {        // exposures must be a multiple of 4
+                if (newExposures % multipleOf != 0) { // number of exposures must be a multiple
                     continue;
                 }
                 return c;

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -130,7 +130,6 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
 
             final double skyAper = 1.0;
             double readNoise;
-            double totalTime;
 
             double desiredSNR = ((SpectroscopyIntegrationTime) calcMethod).sigma();
             Log.fine(String.format("desired SNR = %.2f", desiredSNR));
@@ -139,13 +138,10 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
             Log.fine(String.format("Maximum flux = %.0f e-", maxFlux));
 
             // Perform an initial run of the ITC to get the signal and background for this target at this wavelength
-
             readMode = ReadMode.FAINT;           // arbitrary
             Log.fine("readMode = " + readMode.toString());
-
             double initialExposureTime = 300.;   // arbitrary
             Log.fine(String.format("initialExposureTime = %.2f sec", initialExposureTime));
-
             int initialNumberExposures = 4;      // arbitrary
             Log.fine("initialNumberExposures = " + initialNumberExposures);
 
@@ -205,7 +201,7 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
                     "This target is too bright for this configuration.\n" +
                     "The detector will reach %.0f e- in %.3f seconds.", maxFlux * safetyBuffer, maxExposureTime));
 
-            // Check each read mode and see which would be best.  This does NOT re-run the ITC calculations.
+            // Step through read modes and see which is best.  This does NOT re-run the ITC calculations.
             List<ReadMode> readModes = Arrays.asList(ReadMode.VERY_FAINT, ReadMode.FAINT, ReadMode.BRIGHT, ReadMode.VERY_BRIGHT);
             for (ReadMode rm : readModes) {
                 Log.fine("============================ " + rm + " ============================");
@@ -213,6 +209,7 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
                 readNoise = readMode.getReadNoise() * readMode.getReadNoise() * numberPixels;
                 Log.fine(String.format("Read Noise = %.2f e- (squared and summed)", readNoise));
                 Log.fine(String.format("S/N = %.3f", calculateSNR(signal, background, darkNoise, readNoise, skyAper, initialNumberExposures)));
+
                 numberExposures = initialNumberExposures;
                 final int MAX_ITERATIONS = 10;
                 for (int iter = 0; iter < MAX_ITERATIONS; iter++) {
@@ -221,10 +218,11 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
                             background / initialExposureTime, darkNoise / initialExposureTime,
                             readNoise, skyAper, desiredSNR / Math.sqrt(numberExposures));
                     int n = (int) Math.ceil(numberExposures * exposureTime / maxExposureTime);
-                    if (n % 4 != 0) n += 4 - n % 4;
+                    if (n % 4 != 0) n += 4 - n % 4;  // make a multiple of 4
+
                     if (n == numberExposures) {
                         Log.fine("------------------------------------------------------------------------");
-                        break;
+                        break;   // converged
                     }
                     numberExposures = n;
                 }
@@ -241,9 +239,11 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
             Log.fine("The read mode, exposure time, and number of exposures have been decided.");
             Log.fine("readMode = " + readMode.toString());
             Log.fine(String.format("numberExposures = %d", numberExposures));
+
             if (numberExposures > 1000) {
                 throw new RuntimeException("Configuration would require " + numberExposures + " exposures");
             }
+
             if (exposureTime < readMode.getMinExp()) {
                 Log.fine("Increasing exposure time to the minimum allowed for the read mode");
                 exposureTime = readMode.getMinExp();

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ExposureTimeCalculator.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ExposureTimeCalculator.java
@@ -1,0 +1,40 @@
+package edu.gemini.itc.operation;
+
+import java.util.logging.Logger;
+
+public final class ExposureTimeCalculator {
+
+    private static final Logger Log = Logger.getLogger(ExposureTimeCalculator.class.getName());
+
+    private ExposureTimeCalculator() {}  // prevent instantiation
+
+    /**
+     * Calculate the exposure time required to achieve a desired Signal-to-Noise on a single frame.
+     * @param signal     The signal per second summed over the pixels in the aperture.
+     * @param background The background per second summed over the pixels in the aperture.
+     * @param darkNoise  The dark current per second summed over the pixels in the aperture.
+     * @param readNoise  The squared read noise summed over the pixels in the aperture.
+     * @param skyAper
+     * @param SNR        The desired Signal-to-Noise Ratio.
+     * @return The exposure time in seconds.
+     */
+    public static double calculate(
+            double signal,
+            double background,
+            double darkNoise,
+            double readNoise,
+            double skyAper,
+            double SNR
+    ) {
+        final double f = 1. + (1. / skyAper);  // noise factor
+        // SNR = S / sqrt(S + f(B + D + R)) = st / sqrt(st + f(bt + dt + R)) = x
+        // This can be expressed as a quadratic equation:  (ss/xx)t^2 - (s + fb + fd)t - fR = 0
+        // and solved using the quadratic formula: t = (-b + sqrt(b^2 - 4ac)) / 2a
+        double a = signal * signal / (SNR * SNR);
+        double b = -(signal + f * background + f * darkNoise);
+        double c = -f * readNoise;
+        double exposureTime = (-b + Math.sqrt(b*b - 4.*a*c)) / (2.*a);
+        Log.fine(String.format("Exposure time must be %.3f s to achieve S/N = %.2f in 1 exposure", exposureTime, SNR));
+        return exposureTime;
+    }
+}

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ExposureTimeCalculator.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ExposureTimeCalculator.java
@@ -30,11 +30,12 @@ public final class ExposureTimeCalculator {
         // SNR = S / sqrt(S + f(B + D + R)) = st / sqrt(st + f(bt + dt + R)) = x
         // This can be expressed as a quadratic equation:  (ss/xx)t^2 - (s + fb + fd)t - fR = 0
         // and solved using the quadratic formula: t = (-b + sqrt(b^2 - 4ac)) / 2a
+        if (signal <= 0) throw new Error("Signal is <= 0");
         double a = signal * signal / (SNR * SNR);
         double b = -(signal + f * background + f * darkNoise);
         double c = -f * readNoise;
         double exposureTime = (-b + Math.sqrt(b*b - 4.*a*c)) / (2.*a);
-        Log.fine(String.format("Exposure time must be %.3f s to achieve S/N = %.2f in 1 exposure", exposureTime, SNR));
+        Log.fine(String.format("Exposure time must be %.5f sec to achieve S/N = %.2f in 1 exposure", exposureTime, SNR));
         return exposureTime;
     }
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingMethodExptime.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImagingMethodExptime.java
@@ -15,6 +15,7 @@ public final class ImagingMethodExptime extends ImagingS2NCalculation {
     private final double maxFlux;
     private final double imageQuality;
     private int numberExposures;
+    private final double minExpTime;
     private static final Logger Log = Logger.getLogger(ImagingMethodExptime.class.getName());
 
     public ImagingMethodExptime(ObservationDetails obs,
@@ -37,18 +38,40 @@ public final class ImagingMethodExptime extends ImagingS2NCalculation {
         this.pixel_size = instrument.getPixelSize();
         this.maxFlux = instrument.maxFlux();
         this.imageQuality = imageQuality;
+        this.minExpTime = instrument.getMinExposureTime();
+    }
+
+    // Constructor using a read mode different from specified in the web form
+    public ImagingMethodExptime(ObservationDetails obs,
+                                final Instrument instrument,
+                                final SourceFraction srcFrac,
+                                final double sed_integral,
+                                final double sky_integral,
+                                final SourceDefinition _sdParameters,
+                                final double imageQuality,
+                                final double read_noise,
+                                final double minExpTime) {
+        super(obs, instrument, srcFrac, sed_integral, sky_integral);
+
+        this.instrument = instrument;
+        this.calcMethod = obs.calculationMethod();
+        this._sdParameters = _sdParameters;
+        this.srcFrac = srcFrac;
+        this.numberExposures = 1;
+        this.exposure_time = 10. * minExpTime;
+        this.coadds = 1;
+        this.read_noise = read_noise;
+        this.pixel_size = instrument.getPixelSize();
+        this.maxFlux = instrument.maxFlux();
+        this.imageQuality = imageQuality;
+        this.minExpTime = minExpTime;
     }
 
     public void calculate() {
 
-        // 1. Calculate the maximum exposure time
-        // 2. Calculate the total integration time required to achieve the requested S/N.
-        // 3. Calculate the number of exposures, if more than one are required.
-        // 4. Calculate the exposure time.
-
         super.calculate();  // perform an initial S/N calculation using the default values from the HTML form
-        double snr = totalSNRatio();
-        Log.fine(String.format("Total S/N = %.2f from %d x %.2f second exposures", snr, numberExposures, exposure_time));
+
+        Log.fine(String.format("Initial S/N = %.2f from %d x %.2f second exposures", totalSNRatio(), numberExposures, exposure_time));
 
         double peakFlux = PeakPixelFlux.calculate(instrument, _sdParameters, exposure_time, srcFrac, imageQuality, sed_integral, sky_integral);
         Log.fine(String.format("Peak Pixel Flux = %.0f e-", peakFlux));
@@ -57,32 +80,58 @@ public final class ImagingMethodExptime extends ImagingS2NCalculation {
 
         double timeToHalfMax = maxFlux / 2. / peakFlux * exposure_time;  // time to reach half of the maximum (our goal)
         Log.fine(String.format("timeToHalfMax = %.3f seconds", timeToHalfMax));
-        Log.fine(String.format("minExpTime = %.3f seconds", instrument.getMinExposureTime()));
+        Log.fine(String.format("minExpTime = %.3f seconds", minExpTime));
 
-        if (timeToHalfMax < instrument.getMinExposureTime()) {
-            Log.fine("Minimum exposure time = " + instrument.getMinExposureTime());
-            throw new RuntimeException(String.format(
-                    "This target is too bright for this configuration.\n" +
-                            "The detector well is half filled in %.2f seconds.", timeToHalfMax));
+        if (timeToHalfMax < minExpTime) {
+            throw new RuntimeException(String.format("This target is too bright for this configuration.\n" +
+                    "The detector well is half filled in %.2f seconds.", timeToHalfMax));
         }
 
-        // This should be instrument-specific.  GMOS: 1200, F2: , GNIRS:
-        double maxExptime = Math.min(1200, timeToHalfMax);
+        double maxExposureTime;
+        switch (instrument.getName()) {
+            case "Flamingos2": maxExposureTime = 300.0; break;
+            case "GMOS-N":     maxExposureTime = 600.0; break;
+            case "GMOS-S":     maxExposureTime = 600.0; break;
+            case "GNIRS":      maxExposureTime = 300.0; break;
+            default:           maxExposureTime = 300.0; break;
+        }
+        double maxExptime = Math.min(maxExposureTime, timeToHalfMax);
         Log.fine(String.format("maxExptime = %.3f seconds", maxExptime));
 
         double desiredSNR = ((ImagingIntegrationTime) calcMethod).sigma();
         Log.fine(String.format("desiredSNR = %.2f", desiredSNR));
 
-        double totalTime = exposure_time * numberExposures * (desiredSNR / snr) * (desiredSNR / snr);
-        Log.fine(String.format("Required totalTime = %.5f seconds", totalTime));
+        // Calculate rates from the initial super.calculate() results
+        final double signalPerSec     = var_source / exposure_time;
+        final double backgroundPerSec = var_background / exposure_time;
+        final double darkPerSec       = var_dark / exposure_time;
 
-        numberExposures = (int) Math.ceil(totalTime / maxExptime);
+        // Iterate to find the number of exposures and exposure time that will give the requested S/N.
+        // exposure_time is calculated exactly then numberExposures is updated from the resulting total time.
+        numberExposures = 1;
+        final int MAX_ITERATIONS = 10;
+        for (int iter = 0; iter < MAX_ITERATIONS; iter++) {
+            Log.fine("-------------------------------- iter " + iter + " --------------------------------");
+            exposure_time = ExposureTimeCalculator.calculate(signalPerSec, backgroundPerSec, darkPerSec,
+                    var_readout, skyAper, desiredSNR / Math.sqrt(numberExposures));
+            Log.fine(String.format("Iteration %d: %d x %.3f sec", iter, numberExposures, exposure_time));
+            int n = (int) Math.ceil(exposure_time * numberExposures / maxExptime);
+            if (n == numberExposures) {
+                Log.fine("------------------------------------------------------------------------");
+                break;
+            }
+            numberExposures = n;
+        }
         Log.fine(String.format("numberExposures = %d", numberExposures));
 
-        exposure_time = totalTime / numberExposures;
-        if (exposure_time < instrument.getMinExposureTime()) {
+        if (numberExposures > 10000) {
+            throw new RuntimeException(String.format("This target is too faint for this configuration.\n" +
+                    "%d exposures would be required to achieve the requested S/N.", numberExposures));
+        }
+
+        if (exposure_time < minExpTime) {
             Log.fine("Increasing exposure time to the minimum allowed");
-            exposure_time = instrument.getMinExposureTime();
+            exposure_time = minExpTime;
         }
 
         // GMOS and F2 require integer exposure times, so round up:
@@ -91,12 +140,12 @@ public final class ImagingMethodExptime extends ImagingS2NCalculation {
         } else {
             exposure_time = roundExposureTime(exposure_time);
         }
-        Log.fine(String.format("Rounding exposureTime up to %.2f sec", exposure_time));
+        Log.fine(String.format("Rounding exposureTime up to %.3f sec", exposure_time));
 
         // TODO: for instruments that can coadd - calculate the number of coadds
 
         super.calculate();
-        Log.fine("totalSNRatio = " + totalSNRatio());
+        Log.fine(String.format("Final: S/N = %.4f from %d x %.3f sec", totalSNRatio(), numberExposures, exposure_time));
     }
 
     /**
@@ -121,7 +170,5 @@ public final class ImagingMethodExptime extends ImagingS2NCalculation {
     }
 
     @Override public int numberSourceExposures() { return numberExposures; }
-
-    @Override public double getExposureTime() { return exposure_time; }
 
 }


### PR DESCRIPTION
This updates the ITC to calculate the best read mode for GNIRS and F2 imaging when the user requests S/N.

Note that this does *not* use the exposure time guidelines (which are really designed for spectroscopy) but rather calculates the total time for each read mode and chooses the shortest one.  This seems to yield good results although it does take a bit longer to calculate.

Note that every case I tested with Flamingos2 resulted in "Bright Object Mode".  We could probably just hard-code the read mode and save a bit of calculation time, but it is not a huge overhead since the calculation breaks off as soon as the next mode takes longer than the previous.

This also includes a fix to the GMOS S/N imaging mode where the number of exposures was not being propagated through to the overheads table.
