### PR TITLE
Report signal-to-noise at wavelength for GNIRS IFU

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java
@@ -420,7 +420,16 @@ public final class GnirsRecipe implements ImagingRecipe, SpectroscopyRecipe {
                 specS2Narr[i++] = specS2N;
             }
 
-            return new SpectroscopyResult(p, instrument, IQcalc, specS2Narr, null, 0, altair, Option.empty(), AllIntegrationTimes.empty());
+            // Report the signal-to-noise at the requested wavelength, as the slit cases do.
+            // Every IFU element covers the same wavelength range (they differ spatially), so
+            // the first one is representative; for the summed method it is the only one.
+            // If no wavelength was requested it will fall outside the range and yield no value.
+            final scala.Option<SignalToNoiseAt> sn = specS2Narr.length == 0
+                    ? scala.Option.<SignalToNoiseAt>empty()
+                    : RecipeUtil.instance().signalToNoiseAt(
+                            wavelengthAt, specS2Narr[0].getExpS2NSpectrum(), specS2Narr[0].getFinalS2NSpectrum());
+
+            return new SpectroscopyResult(p, instrument, IQcalc, specS2Narr, null, 0, altair, sn, AllIntegrationTimes.empty());
 
         } else {  // === SLIT ===
 


### PR DESCRIPTION
The IFU branch of GnirsRecipe.calculateSpectroscopy hardcoded an empty signalToNoiseAt, while both slit branches (XD and non-XD) compute it via RecipeUtil.signalToNoiseAt. GNIRS IFU configurations therefore never reported a S/N at the requested wavelength.

Downstream this left the S/N column of the Explore spectroscopy modes table blank for GNIRS IFU rows whenever the exposure time mode was set to time-and-count (the only mode in which that column is shown). The exposure time and count were unaffected, and the ITC tile falls back to the peak S/N from the graph data, so nothing else looked wrong.

Every IFU element covers the same wavelength range (they differ spatially), so the first is representative; for the summed analysis method used by GPP it is the only one.


Claude-Session: https://claude.ai/code/session_01Q8HPfo5nknxUYmpQkYZVnb