### PR TITLE
Improve performance of rounding itc series

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ItcService.scala
@@ -144,14 +144,18 @@ object SpcSeriesData {
   // Round the value to n significant figures, this to remove
   // the extra precision produced by ITC calculations using doubles
   // This will not work for extremely small numbers but we don't expect such
-  def roundToSignificantFigures(num: BigDecimal, n: Int): Double = {
+  //
+  // Takes a Double rather than a BigDecimal on purpose. Every caller passes a Double, and the
+  // implicit widening made `num == 0` route through BigDecimal.longValueExact, which throws and
+  // fills in a stack trace for every non-integral value.
+  def roundToSignificantFigures(num: Double, n: Int): Double = {
     if (num == 0) 0
     else {
-      val d     = ceil(log10(abs(num.toDouble)))
+      val d     = ceil(log10(abs(num)))
       val power = n - d.toInt
 
       val magnitude = pow(10, power)
-      val shifted   = round(num.toDouble * magnitude)
+      val shifted   = round(num * magnitude)
       shifted / magnitude
     }
   }


### PR DESCRIPTION
`SpcSeriesData.roundToSignificantFigures` took a `BigDecimal`, but its only caller (`ItcCalculation.roundToSix`) passes a `Double`.

The implicit widening made the first line `if (num == 0)` route through `java.math.BigDecimal.longValueExact`, which throws an `ArithmeticException` for every non-integral value.

It's caught and discarded inside`isValidLong`, but `fillInStackTrace` has already run — once per graph data point, inside the argonaut encoder.

Changing the parameter to `Double` (what every call site already had) removes it.

## Effect

`ItcCalculation.calculateCharts` on a GMOS-N longslit fixture:

| | before | after |
|---|---|---|
| wall time | 113.4 ms | 50.8 ms (-55%) |
| bytes allocated | 142.8 MB | 62.9 MB (-56%) |
