### PR TITLE
Reduce ITC Allocations

### DIFF
--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
@@ -55,7 +55,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
         for (int i = 0; i <= numIntervals; ++i) {
             data[i] = sp.getY(i * xInterval + xStart);
         }
-        reset(data, xStart, xInterval);
+        adopt(data, xStart, xInterval);
     }
 
     /**
@@ -84,7 +84,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
         for (int i = 0; i <= numIntervals; ++i) {
            data[i] = sp.getY(xStart + i * xInterval);
         }
-        reset(data, xStart, xInterval);
+        adopt(data, xStart, xInterval);
     }
 
     /**
@@ -93,7 +93,9 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
     @Override public Object clone() {
         double[] data = new double[getLength()];
         System.arraycopy(getValues(), 0, data, 0, getLength());
-        return new DefaultSampledSpectrum(data, getStart(), getSampling());
+        DefaultSampledSpectrum copy = new DefaultSampledSpectrum();
+        copy.adopt(data, getStart(), getSampling());
+        return copy;
     }
 
     @Override public void trim(double newStart, double newEnd) {
@@ -111,7 +113,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
         //System.out.println("startpos: " + new Double((newStart-getStart())/_xInterval).intValue() + "length: " + getLength() + " copylength: " + new Double((newEnd-newStart)/_xInterval).intValue());
 
         System.arraycopy(getValues(), new Double((newStart - getStart()) / _xInterval).intValue(), data, 0, new Double((newEnd - newStart) / _xInterval).intValue());
-        reset(data, newStart, _xInterval);
+        adopt(data, newStart, _xInterval);
     }
 
 
@@ -122,9 +124,20 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
      */
     @Override public void reset(double[] y, double xStart,
                       double xInterval) {
-        _y = new double[y.length];
         // need our own copy so client can't mess with it.
-        System.arraycopy(y, 0, _y, 0, y.length);
+        double[] copy = new double[y.length];
+        System.arraycopy(y, 0, copy, 0, y.length);
+        adopt(copy, xStart, xInterval);
+    }
+
+    // Uninitialised instance for internal use; callers must adopt() before returning it.
+    private DefaultSampledSpectrum() {
+    }
+
+    // Takes ownership of y without copying. Only for arrays freshly allocated in this class
+    // that nothing else references.
+    private void adopt(double[] y, double xStart, double xInterval) {
+        _y = y;
         _xStart = xStart;
         _xInterval = xInterval;
         _xEnd = _xStart + (_y.length - 1) * _xInterval;
@@ -264,7 +277,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
             x = (double) i * getSampling() + xStart;
             data[i] = getY(x / factor);
         }
-        reset(data, xStart, getSampling());
+        adopt(data, xStart, getSampling());
     }
 
     /**
@@ -284,7 +297,7 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
             x = (double) i * sampling + xStart;
             data[i] = getY(x / factor);
         }
-        reset(data, xStart, sampling);
+        adopt(data, xStart, sampling);
     }
 
     /**

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/DefaultSampledSpectrum.java
@@ -108,11 +108,10 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
         if (newEnd < getStart() || newStart > getEnd()) {
             return;
         }
-        double[] data = new double[new Double((newEnd - newStart) / _xInterval).intValue() + 4];
-        //System.out.println("os: " + getStart() + "ns: " + newStart + " oe: " + getEnd() + " ne: " + newEnd);
-        //System.out.println("startpos: " + new Double((newStart-getStart())/_xInterval).intValue() + "length: " + getLength() + " copylength: " + new Double((newEnd-newStart)/_xInterval).intValue());
-
-        System.arraycopy(getValues(), new Double((newStart - getStart()) / _xInterval).intValue(), data, 0, new Double((newEnd - newStart) / _xInterval).intValue());
+        int copyLength = (int) ((newEnd - newStart) / _xInterval);
+        int startPos = (int) ((newStart - getStart()) / _xInterval);
+        double[] data = new double[copyLength + 4];
+        System.arraycopy(getValues(), startPos, data, 0, copyLength);
         adopt(data, newStart, _xInterval);
     }
 
@@ -313,25 +312,21 @@ public class DefaultSampledSpectrum implements VisitableSampledSpectrum {
 
     @Override public void smoothY(int smoothing_element) {
         Log.fine(String.format("Smoothing Y by %d pix", smoothing_element));
-        double[] _y_temp;
-        _y_temp = new double[_y.length];
-        if (smoothing_element == 1.0) return;
+        if (smoothing_element == 1) return;
+        int half = smoothing_element / 2;
+        double[] _y_temp = new double[_y.length];
         for (int i = 0; i < getLength() - 1; ++i) {
             try {
-                if (i + smoothing_element / 2 >= getLength())
+                if (i + half >= getLength())
                     _y_temp[i] = getAverage(i, getLength() - 1);
-                else if (i - smoothing_element / 2 > 0 && smoothing_element % 2 != 0) { //if odd
-                    //System.out.println(" mod: " +smoothing_element%2);
-                    //double temp = _y[i-2]+_y[i-1]+_y[i]+_y[i+1]+_y[i+2];
-                    _y_temp[i] = getAverage(i - (new Double((smoothing_element) / 2).intValue()), i + (new Double((smoothing_element) / 2).intValue()));
-                    //_y[i]=temp/5;
-                } else if (i - smoothing_element / 2 > 0) //if even
-                    _y_temp[i] = getAverage(new Double(i - smoothing_element / 2).intValue() + 1, new Double(i + smoothing_element / 2).intValue());
+                else if (i - half > 0 && smoothing_element % 2 != 0) //if odd
+                    _y_temp[i] = getAverage(i - half, i + half);
+                else if (i - half > 0) //if even
+                    _y_temp[i] = getAverage(i - half + 1, i + half);
             } catch (Exception e) {
                 System.out.println("Smooth: " + e.toString());
             }
         }
-        //System.out.println("End"+ new Double(smoothing_element/2).intValue()+ "  " + getSampling());
         _y = _y_temp;
     }
 


### PR DESCRIPTION
Two follow-ups to the ITC allocation profiling (#2425, #2426). I was always suspect of the number of times arrays were copied in ITC and this confirm it. We Tremove roughly a third of the bytes allocated per `calculateExposureTime` call. 

**Avoid double array copy in `reset` internals.** The sampling constructors, `clone`, `trim`, `rescaleX` and `rescaleXwithFixedSampleSize` all build a fresh local array and hand it to `reset`, which copied it again. Those call sites now adopt the array directly.

The public constructor and public `reset` still copy, so no external contract changes.

**Tidy `smoothY` and `trim`.** `smoothY` allocated its scratch array before the early return, and both methods used `new Double(x).intValue()` as an int cast. `Double.intValue` is the same narrowing conversion as `(int)`, so results are identical.

This was verified on lucuma-itc comparing the results before and after.